### PR TITLE
Updates for week of aug14

### DIFF
--- a/tools/verify.py
+++ b/tools/verify.py
@@ -48,7 +48,8 @@ _MARKDOWN_BOOKMARK_PATTERN = re.compile(r"(?<![\\])\[[^\?=].+?\]\[.+?\]", re.IGN
 _PHRASES_THAT_MUST_BE_CAPITALIZED_PATTERN = re.compile(
     r"(?<!`)(MUST(\s+NOT)?|"
     # ignore the "required" in the jsonschema of the json-format.md
-    r'(?<![`"])REQUIRED(?!")|'
+	# and ignore .required cases (attribute name is "required")
+    r'(?<![.`"])REQUIRED(?!")|'
     r"(?<!mar)SHALL(\s+NOT)?|"  # ignore the word "marshall"
     r"(?<!`)SHOULD(\s+NOT)?|"
     r"(?<!`)RECOMMENDED|"


### PR DESCRIPTION
- "documentation" is a URL not a STRING
- make it clear that Resources are aliases for "latest", not default values
- must specify the entire "labels" set when serialized as http headers - it's not a Patch
- all extensions MUST be predefined in the model
  - unknown extensions generate errors
  - all labels names MUST be lower-case
  - "model" defines it's own schema-like format to define each extension or constraint on spec defined attribute
  - added the notion of `/model?schema=FORMAT[/VERSION` so server can return the schema of the registry in various formats. Removed the "schema" attribute from "model" - replaced it with "schemas"->list of schema formats
- added a section on how to encode http header values (stolen from CE)
- setting latest is now:
  - `POST /GROUPs/gID/RESOURCEs/rID?setLatestVersionId=vID`
  - or `?latet=vID` for other operations - e.g. `DELETE .../versions/vID`
- added the notion of a "hasDocument" flag on resources in the model
