### PR TITLE
Week of Sept 6th updates

### DIFF
--- a/schema/spec.md
+++ b/schema/spec.md
@@ -166,7 +166,7 @@ repeated in `schemaversion` for clarity, but MUST be identical.
 - Type: URI
 - Description: Reference to a schema document external to the registry.
 - Constraints:
-  - Mutually exclusive with `schemaurl`. One of the two MUST be present.
+  - Mutually exclusive with `schema`. One of the two MUST be present.
   - Cross-references to a schema document within the same registry MUST NOT be
     used.
 


### PR DESCRIPTION
- Allow for bulk create/update of Groups, Resources and Versions
  - Merged "update" and "create" into one section for each
  - Creating/Updating Versions just points to the Resources section
- cleanup/shorten the samples a bit
- remove the ?latest query parameter and made people use the `latest` attribute instead
- lots of typos and clean-up
- make bulk DELETE's response an array instead of a map
