### PR TITLE
message-metadata split

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -589,701 +589,6 @@
                       "type": [
                         {
                           "type": "record",
-                          "name": "FormatAmqp10Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatAmqp10MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatAmqp10PropertiesType",
-                                      "fields": [
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10MessageIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP message-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP message-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "MessageId",
-                                          "doc": "AMQP message-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10UserIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP user-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP user-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "UserId",
-                                          "doc": "AMQP user-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ToType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP to value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP to required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "To",
-                                          "doc": "AMQP to."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10SubjectType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP subject value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP subject required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "Subject",
-                                          "doc": "AMQP subject."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ReplyToType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP reply-to value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP reply-to required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ReplyTo",
-                                          "doc": "AMQP reply-to."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10CorrelationIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP correlation-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP correlation-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "CorrelationId",
-                                          "doc": "AMQP correlation-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ContentTypeType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP content-type value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP content-type required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ContentType",
-                                          "doc": "AMQP content-type."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ContentEncodingType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP content-encoding value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP content-encoding required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ContentEncoding",
-                                          "doc": "AMQP content-encoding."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10AbsoluteExpiryTimeType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP absolute-expiry-time value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP absolute-expiry-time required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "AbsoluteExpiryTime",
-                                          "doc": "AMQP absolute-expiry-time."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10GroupIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP group-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP group-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "GroupId",
-                                          "doc": "AMQP group-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10GroupSequenceType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP group-sequence value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP group-sequence required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "GroupSequence",
-                                          "doc": "AMQP group-sequence."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ReplyToGroupIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP reply-to-group-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP reply-to-group-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ReplyToGroupId",
-                                          "doc": "AMQP reply-to-group-id."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Properties"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10ApplicationPropertiesType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10ApplicationPropertiesItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The application property name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The application property value template."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "The application property required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The application property type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "ApplicationProperties"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10MessageAnnotationsType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10MessageAnnotationsItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The message annotation name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The message annotation value"
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "Whether the message annotation is required"
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The message annotation type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "MessageAnnotations"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10DeliveryAnnotationsType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10DeliveryAnnotationsItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The delivery annotation name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The delivery annotation value"
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "Whether the annotation is required"
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The annotation type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "DeliveryAnnotations"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10HeaderType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10HeaderItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "AMQP header name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "AMQP header value."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "AMQP header required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "AMQP header type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Header"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10FooterType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10FooterItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "AMQP footer name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "AMQP footer value."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "AMQP footer required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "AMQP footer type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Footer"
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "AMQP message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatMqtt311Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatMqtt311MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311QosType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT qos value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Qos",
-                                    "doc": "MQTT qos."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311RetainType",
-                                      "fields": [
-                                        {
-                                          "type": "boolean",
-                                          "name": "Value",
-                                          "doc": "MQTT retain value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Retain",
-                                    "doc": "MQTT retain."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311TopicNameType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT topic-name value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "TopicName",
-                                    "doc": "MQTT topic-name."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "MQTT message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatMqtt50Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatMqtt50MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50QosType",
-                                      "fields": [
-                                        {
-                                          "type": "int",
-                                          "name": "Value",
-                                          "doc": "MQTT qos value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Qos",
-                                    "doc": "MQTT qos."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50RetainType",
-                                      "fields": [
-                                        {
-                                          "type": "boolean",
-                                          "name": "Value",
-                                          "doc": "MQTT retain value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Retain",
-                                    "doc": "MQTT retain."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50TopicNameType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT topic-name value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "TopicName",
-                                    "doc": "MQTT topic-name."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50MessageExpiryIntervalType",
-                                      "fields": [
-                                        {
-                                          "type": "int",
-                                          "name": "Value",
-                                          "doc": "MQTT message-expiry-interval value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "MessageExpiryInterval",
-                                    "doc": "MQTT message-expiry-interval."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50ResponseTopicType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT response-topic value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "ResponseTopic",
-                                    "doc": "MQTT response-topic."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50CorrelationDataType",
-                                      "fields": [
-                                        {
-                                          "type": "bytes",
-                                          "name": "Value",
-                                          "doc": "MQTT correlation-data value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "CorrelationData",
-                                    "doc": "MQTT correlation-data."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50ContentTypeType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT content-type value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "ContentType",
-                                    "doc": "MQTT content-type."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "record",
-                                        "name": "FormatMqtt50UserPropertiesType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "MQTT user-property name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "MQTT user-property value."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "UserProperties",
-                                    "doc": "MQTT user-properties."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "MQTT message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatKafka011Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatKafka011MetadataType",
-                                "fields": [
-                                  {
-                                    "type": "string",
-                                    "name": "Topic",
-                                    "doc": "The Apache Kafka topic."
-                                  },
-                                  {
-                                    "type": "int",
-                                    "name": "Partition",
-                                    "doc": "The Apache Kafka partition."
-                                  },
-                                  {
-                                    "type": "bytes",
-                                    "name": "Key",
-                                    "doc": "The Apache Kafka key."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatKafka011HeadersType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatKafka011HeadersItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The Apache Kafka header name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The Apache Kafka header value."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Headers",
-                                    "doc": "The Apache Kafka headers."
-                                  },
-                                  {
-                                    "type": "int",
-                                    "name": "Timestamp",
-                                    "doc": "The Apache Kafka timestamp."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "The Apache Kafka message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
                           "name": "FormatCloudevents10Type",
                           "fields": [
                             {
@@ -1412,22 +717,698 @@
                               "doc": "CloudEvents metadata constraints."
                             }
                           ]
-                        },
+                        }
+                      ],
+                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
+                    },
+                    {
+                      "name": "Binding",
+                      "type": [
                         {
                           "type": "record",
-                          "name": "FormatHttp11Type",
+                          "name": "BindingAmqp10Type",
                           "fields": [
                             {
                               "type": {
                                 "type": "record",
-                                "name": "FormatHttp11MetadataType",
+                                "name": "BindingAmqp10MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingAmqp10PropertiesType",
+                                      "fields": [
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10MessageIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP message-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP message-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "MessageId",
+                                          "doc": "AMQP message-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10UserIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP user-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP user-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "UserId",
+                                          "doc": "AMQP user-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ToType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP to value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP to required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "To",
+                                          "doc": "AMQP to."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10SubjectType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP subject value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP subject required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "Subject",
+                                          "doc": "AMQP subject."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ReplyToType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP reply-to value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP reply-to required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ReplyTo",
+                                          "doc": "AMQP reply-to."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10CorrelationIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP correlation-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP correlation-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "CorrelationId",
+                                          "doc": "AMQP correlation-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ContentTypeType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP content-type value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP content-type required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ContentType",
+                                          "doc": "AMQP content-type."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ContentEncodingType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP content-encoding value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP content-encoding required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ContentEncoding",
+                                          "doc": "AMQP content-encoding."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10AbsoluteExpiryTimeType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP absolute-expiry-time value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP absolute-expiry-time required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "AbsoluteExpiryTime",
+                                          "doc": "AMQP absolute-expiry-time."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10GroupIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP group-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP group-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "GroupId",
+                                          "doc": "AMQP group-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10GroupSequenceType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP group-sequence value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP group-sequence required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "GroupSequence",
+                                          "doc": "AMQP group-sequence."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ReplyToGroupIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP reply-to-group-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP reply-to-group-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ReplyToGroupId",
+                                          "doc": "AMQP reply-to-group-id."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Properties"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10ApplicationPropertiesType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10ApplicationPropertiesItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The application property value template."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "The application property required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The application property type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "ApplicationProperties"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10MessageAnnotationsType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10MessageAnnotationsItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The message annotation value"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "Whether the message annotation is required"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The message annotation type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "MessageAnnotations"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10DeliveryAnnotationsType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10DeliveryAnnotationsItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The delivery annotation value"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "Whether the annotation is required"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The annotation type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "DeliveryAnnotations"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10HeaderType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10HeaderItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "AMQP header value."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "AMQP header required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "AMQP header type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Header"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10FooterType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10FooterItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "AMQP footer value."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "AMQP footer required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "AMQP footer type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Footer"
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "AMQP message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingMqtt311Type",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingMqtt311MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311QosType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT qos value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Qos",
+                                    "doc": "MQTT qos."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311RetainType",
+                                      "fields": [
+                                        {
+                                          "type": "boolean",
+                                          "name": "Value",
+                                          "doc": "MQTT retain value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Retain",
+                                    "doc": "MQTT retain."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311TopicNameType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT topic-name value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "TopicName",
+                                    "doc": "MQTT topic-name."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "MQTT message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingMqtt50Type",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingMqtt50MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50QosType",
+                                      "fields": [
+                                        {
+                                          "type": "int",
+                                          "name": "Value",
+                                          "doc": "MQTT qos value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Qos",
+                                    "doc": "MQTT qos."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50RetainType",
+                                      "fields": [
+                                        {
+                                          "type": "boolean",
+                                          "name": "Value",
+                                          "doc": "MQTT retain value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Retain",
+                                    "doc": "MQTT retain."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50TopicNameType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT topic-name value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "TopicName",
+                                    "doc": "MQTT topic-name."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50MessageExpiryIntervalType",
+                                      "fields": [
+                                        {
+                                          "type": "int",
+                                          "name": "Value",
+                                          "doc": "MQTT message-expiry-interval value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "MessageExpiryInterval",
+                                    "doc": "MQTT message-expiry-interval."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50ResponseTopicType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT response-topic value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "ResponseTopic",
+                                    "doc": "MQTT response-topic."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50CorrelationDataType",
+                                      "fields": [
+                                        {
+                                          "type": "bytes",
+                                          "name": "Value",
+                                          "doc": "MQTT correlation-data value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "CorrelationData",
+                                    "doc": "MQTT correlation-data."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50ContentTypeType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT content-type value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "ContentType",
+                                    "doc": "MQTT content-type."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "record",
+                                        "name": "BindingMqtt50UserPropertiesType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Name",
+                                            "doc": "MQTT user-property name."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "MQTT user-property value."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "UserProperties",
+                                    "doc": "MQTT user-properties."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "MQTT message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingKAFKAType",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingKAFKAMessageType",
+                                "fields": [
+                                  {
+                                    "type": "string",
+                                    "name": "Topic",
+                                    "doc": "The Apache Kafka topic."
+                                  },
+                                  {
+                                    "type": "int",
+                                    "name": "Partition",
+                                    "doc": "The Apache Kafka partition."
+                                  },
+                                  {
+                                    "type": "bytes",
+                                    "name": "Key",
+                                    "doc": "The Apache Kafka key."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingKAFKAHeadersType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingKAFKAHeadersItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Name",
+                                            "doc": "The Apache Kafka header name."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The Apache Kafka header value."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Headers",
+                                    "doc": "The Apache Kafka headers."
+                                  },
+                                  {
+                                    "type": "int",
+                                    "name": "Timestamp",
+                                    "doc": "The Apache Kafka timestamp."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "The Apache Kafka message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingHTTPType",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingHTTPMessageType",
                                 "fields": [
                                   {
                                     "type": {
                                       "type": "array",
                                       "items": {
                                         "type": "record",
-                                        "name": "FormatHttp11HeadersType",
+                                        "name": "BindingHTTPHeadersType",
                                         "fields": [
                                           {
                                             "type": "string",
@@ -1498,13 +1479,13 @@
                                   }
                                 ]
                               },
-                              "name": "Metadata",
+                              "name": "Message",
                               "doc": "The HTTP message metadata constraints."
                             }
                           ]
                         }
                       ],
-                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
+                      "doc": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
                     }
                   ]
                 }
@@ -1605,7 +1586,12 @@
             {
               "type": "string",
               "name": "Format",
-              "doc": "Message format identifier. All definitions in this group share this format. Mixed-format groups are not permitted."
+              "doc": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted."
+            },
+            {
+              "type": "string",
+              "name": "Binding",
+              "doc": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted."
             },
             {
               "name": "definitions",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -69,14 +69,14 @@
       "oneOf": [
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "AMQP/1.0"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "AMQP message metadata constraints.",
               "properties": {
@@ -257,10 +257,6 @@
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The application property name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The application property value template."
@@ -280,10 +276,6 @@
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The message annotation name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The message annotation value"
@@ -296,20 +288,13 @@
                         "type": "string",
                         "description": "The message annotation type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "delivery-annotations": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The delivery annotation name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The delivery annotation value"
@@ -322,20 +307,13 @@
                         "type": "string",
                         "description": "The annotation type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "header": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "AMQP header name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP header value."
@@ -348,20 +326,13 @@
                         "type": "string",
                         "description": "AMQP header type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "footer": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "AMQP footer name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP footer value."
@@ -374,29 +345,26 @@
                         "type": "string",
                         "description": "AMQP footer type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 }
               }
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "MQTT/3.1.1"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "MQTT message metadata constraints.",
               "properties": {
@@ -434,19 +402,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "MQTT/5.0"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "MQTT message metadata constraints.",
               "properties": {
@@ -541,19 +509,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
-                "KAFKA/0.11"
+                "KAFKA"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "The Apache Kafka message metadata constraints.",
               "properties": {
@@ -594,116 +562,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
-                "CloudEvents/1.0"
+                "HTTP"
               ]
             },
-            "metadata": {
-              "type": "object",
-              "description": "CloudEvents metadata constraints.",
-              "properties": {
-                "type": {
-                  "type": "object",
-                  "description": "CloudEvents type.",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents type value template."
-                    }
-                  }
-                },
-                "source": {
-                  "type": "object",
-                  "description": "CloudEvents source",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents source value template."
-                    }
-                  }
-                },
-                "subject": {
-                  "type": "object",
-                  "description": "CloudEvents subject",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents subject value template."
-                    },
-                    "required": {
-                      "type": "boolean",
-                      "description": "CloudEvents subject required."
-                    }
-                  }
-                },
-                "id": {
-                  "type": "object",
-                  "description": "CloudEvents id",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents id value template."
-                    }
-                  }
-                },
-                "time": {
-                  "type": "object",
-                  "description": "The timestamp of when the event happened.",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "The timestamp value template."
-                    },
-                    "required": {
-                      "type": "boolean",
-                      "description": "The timestamp required."
-                    }
-                  }
-                },
-                "dataschema": {
-                  "type": "string",
-                  "format": "uri-template",
-                  "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default."
-                }
-              },
-              "additionalProperties": {
-                "type": "object",
-                "description": "CloudEvent extension property",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "The value template."
-                  },
-                  "required": {
-                    "type": "boolean",
-                    "description": "Whether the extension is required"
-                  }
-                }
-              }
-            }
-          },
-          "required": [
-            "format"
-          ]
-        },
-        {
-          "properties": {
-            "format": {
-              "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
-              "enum": [
-                "HTTP/1.1"
-              ]
-            },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "The HTTP message metadata constraints.",
               "properties": {
@@ -739,7 +610,7 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         }
       ]
@@ -903,9 +774,6 @@
                       "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message."
                     }
                   },
-                  "required": [
-                    "node"
-                  ],
                   "additionalProperties": {
                     "type": "string",
                     "description": "Further options to configure the AMQP 1.0 client"
@@ -1063,10 +931,7 @@
                         ]
                       }
                     }
-                  },
-                  "required": [
-                    "method"
-                  ]
+                  }
                 }
               },
               "required": [
@@ -1206,7 +1071,7 @@
         },
         "format": {
           "type": "string",
-          "description": "Message format identifier. All definitions in this group share this format. Mixed-format groups are not permitted."
+          "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted."
         },
         "createdBy": {
           "type": "string"
@@ -1222,6 +1087,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "binding": {
+          "type": "string",
+          "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted."
+        },
         "definitions": {
           "type": "object",
           "additionalProperties": {
@@ -1230,8 +1099,7 @@
         }
       },
       "required": [
-        "id",
-        "format"
+        "id"
       ]
     },
     "schemaVersion": {

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -2522,16 +2522,113 @@
           }
         }
       },
-      "format_AMQP_1_0": {
+      "format_CloudEvents_1_0": {
         "properties": {
           "format": {
             "type": "string",
             "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
-              "AMQP/1.0"
+              "CloudEvents/1.0"
             ]
           },
           "metadata": {
+            "type": "object",
+            "description": "CloudEvents metadata constraints.",
+            "properties": {
+              "type": {
+                "type": "object",
+                "description": "CloudEvents type.",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents type value template."
+                  }
+                }
+              },
+              "source": {
+                "type": "object",
+                "description": "CloudEvents source",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents source value template."
+                  }
+                }
+              },
+              "subject": {
+                "type": "object",
+                "description": "CloudEvents subject",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents subject value template."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents subject required."
+                  }
+                }
+              },
+              "id": {
+                "type": "object",
+                "description": "CloudEvents id",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents id value template."
+                  }
+                }
+              },
+              "time": {
+                "type": "object",
+                "description": "The timestamp of when the event happened.",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "The timestamp value template."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "The timestamp required."
+                  }
+                }
+              },
+              "dataschema": {
+                "type": "string",
+                "format": "uri-template",
+                "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default."
+              }
+            },
+            "additionalProperties": {
+              "type": "object",
+              "description": "CloudEvent extension property",
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "description": "The value template."
+                },
+                "required": {
+                  "type": "boolean",
+                  "description": "Whether the extension is required"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "format"
+        ]
+      },
+      "binding_AMQP_1_0": {
+        "properties": {
+          "binding": {
+            "type": "string",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "enum": [
+              "AMQP/1.0"
+            ]
+          },
+          "message": {
             "type": "object",
             "description": "AMQP message metadata constraints.",
             "properties": {
@@ -2712,10 +2809,6 @@
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "The application property name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "The application property value template."
@@ -2735,10 +2828,6 @@
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "The message annotation name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "The message annotation value"
@@ -2751,20 +2840,13 @@
                       "type": "string",
                       "description": "The message annotation type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               },
               "delivery-annotations": {
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "The delivery annotation name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "The delivery annotation value"
@@ -2777,20 +2859,13 @@
                       "type": "string",
                       "description": "The annotation type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               },
               "header": {
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "AMQP header name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP header value."
@@ -2803,20 +2878,13 @@
                       "type": "string",
                       "description": "AMQP header type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               },
               "footer": {
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "AMQP footer name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP footer value."
@@ -2829,29 +2897,26 @@
                       "type": "string",
                       "description": "AMQP footer type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               }
             }
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_MQTT_3_1_1": {
+      "binding_MQTT_3_1_1": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
               "MQTT/3.1.1"
             ]
           },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "MQTT message metadata constraints.",
             "properties": {
@@ -2889,19 +2954,19 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_MQTT_5_0": {
+      "binding_MQTT_5_0": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
               "MQTT/5.0"
             ]
           },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "MQTT message metadata constraints.",
             "properties": {
@@ -2996,19 +3061,19 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_KAFKA_0_11": {
+      "binding_KAFKA": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
-              "KAFKA/0.11"
+              "KAFKA"
             ]
           },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "The Apache Kafka message metadata constraints.",
             "properties": {
@@ -3049,116 +3114,19 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_CloudEvents_1_0": {
+      "binding_HTTP": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
-              "CloudEvents/1.0"
+              "HTTP"
             ]
           },
-          "metadata": {
-            "type": "object",
-            "description": "CloudEvents metadata constraints.",
-            "properties": {
-              "type": {
-                "type": "object",
-                "description": "CloudEvents type.",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents type value template."
-                  }
-                }
-              },
-              "source": {
-                "type": "object",
-                "description": "CloudEvents source",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents source value template."
-                  }
-                }
-              },
-              "subject": {
-                "type": "object",
-                "description": "CloudEvents subject",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents subject value template."
-                  },
-                  "required": {
-                    "type": "boolean",
-                    "description": "CloudEvents subject required."
-                  }
-                }
-              },
-              "id": {
-                "type": "object",
-                "description": "CloudEvents id",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents id value template."
-                  }
-                }
-              },
-              "time": {
-                "type": "object",
-                "description": "The timestamp of when the event happened.",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "The timestamp value template."
-                  },
-                  "required": {
-                    "type": "boolean",
-                    "description": "The timestamp required."
-                  }
-                }
-              },
-              "dataschema": {
-                "type": "string",
-                "format": "uri-template",
-                "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default."
-              }
-            },
-            "additionalProperties": {
-              "type": "object",
-              "description": "CloudEvent extension property",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "The value template."
-                },
-                "required": {
-                  "type": "boolean",
-                  "description": "Whether the extension is required"
-                }
-              }
-            }
-          }
-        },
-        "required": [
-          "format"
-        ]
-      },
-      "format_HTTP_1_1": {
-        "properties": {
-          "format": {
-            "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
-            "enum": [
-              "HTTP/1.1"
-            ]
-          },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "The HTTP message metadata constraints.",
             "properties": {
@@ -3194,7 +3162,7 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
       "definition": {
@@ -3242,14 +3210,13 @@
           "id"
         ],
         "discriminator": {
-          "propertyName": "format",
+          "propertyName": "binding",
           "mapping": {
-            "AMQP/1.0": "#/components/schemas/format_AMQP_1_0",
-            "MQTT/3.1.1": "#/components/schemas/format_MQTT_3_1_1",
-            "MQTT/5.0": "#/components/schemas/format_MQTT_5_0",
-            "KAFKA/0.11": "#/components/schemas/format_KAFKA_0_11",
-            "CloudEvents/1.0": "#/components/schemas/format_CloudEvents_1_0",
-            "HTTP/1.1": "#/components/schemas/format_HTTP_1_1"
+            "AMQP/1.0": "#/components/schemas/binding_AMQP_1_0",
+            "MQTT/3.1.1": "#/components/schemas/binding_MQTT_3_1_1",
+            "MQTT/5.0": "#/components/schemas/binding_MQTT_5_0",
+            "KAFKA": "#/components/schemas/binding_KAFKA",
+            "HTTP": "#/components/schemas/binding_HTTP"
           }
         }
       },
@@ -3317,9 +3284,6 @@
                 "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message."
               }
             },
-            "required": [
-              "node"
-            ],
             "additionalProperties": {
               "type": "string",
               "description": "Further options to configure the AMQP 1.0 client"
@@ -3477,10 +3441,7 @@
                   ]
                 }
               }
-            },
-            "required": [
-              "method"
-            ]
+            }
           }
         },
         "required": [
@@ -3713,7 +3674,7 @@
           },
           "format": {
             "type": "string",
-            "description": "Message format identifier. All definitions in this group share this format. Mixed-format groups are not permitted."
+            "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted."
           },
           "createdBy": {
             "type": "string"
@@ -3729,6 +3690,10 @@
             "type": "string",
             "format": "date-time"
           },
+          "binding": {
+            "type": "string",
+            "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted."
+          },
           "definitions": {
             "type": "object",
             "additionalProperties": {
@@ -3737,8 +3702,7 @@
           }
         },
         "required": [
-          "id",
-          "format"
+          "id"
         ]
       },
       "schemaVersion": {

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -60,7 +60,7 @@
                                                 "node": {
                                                     "description": "The AMQP node name. Commonly the name of a queue or a topic.",
                                                     "type": "string",
-                                                    "required": true
+                                                    "required": false
                                                 },
                                                 "durable": {
                                                     "description": "The AMQP durable flag. Whether the node is durable or transient.",
@@ -210,7 +210,7 @@
                                                 "method": {
                                                     "description": "The HTTP method name",
                                                     "type": "string",
-                                                    "required": true
+                                                    "required": false
                                                 },
                                                 "headers": {
                                                     "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive.",

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -589,701 +589,6 @@
                       "type": [
                         {
                           "type": "record",
-                          "name": "FormatAmqp10Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatAmqp10MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatAmqp10PropertiesType",
-                                      "fields": [
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10MessageIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP message-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP message-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "MessageId",
-                                          "doc": "AMQP message-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10UserIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP user-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP user-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "UserId",
-                                          "doc": "AMQP user-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ToType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP to value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP to required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "To",
-                                          "doc": "AMQP to."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10SubjectType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP subject value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP subject required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "Subject",
-                                          "doc": "AMQP subject."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ReplyToType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP reply-to value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP reply-to required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ReplyTo",
-                                          "doc": "AMQP reply-to."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10CorrelationIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP correlation-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP correlation-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "CorrelationId",
-                                          "doc": "AMQP correlation-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ContentTypeType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP content-type value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP content-type required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ContentType",
-                                          "doc": "AMQP content-type."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ContentEncodingType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP content-encoding value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP content-encoding required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ContentEncoding",
-                                          "doc": "AMQP content-encoding."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10AbsoluteExpiryTimeType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP absolute-expiry-time value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP absolute-expiry-time required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "AbsoluteExpiryTime",
-                                          "doc": "AMQP absolute-expiry-time."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10GroupIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP group-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP group-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "GroupId",
-                                          "doc": "AMQP group-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10GroupSequenceType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP group-sequence value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP group-sequence required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "GroupSequence",
-                                          "doc": "AMQP group-sequence."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ReplyToGroupIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP reply-to-group-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP reply-to-group-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ReplyToGroupId",
-                                          "doc": "AMQP reply-to-group-id."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Properties"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10ApplicationPropertiesType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10ApplicationPropertiesItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The application property name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The application property value template."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "The application property required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The application property type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "ApplicationProperties"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10MessageAnnotationsType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10MessageAnnotationsItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The message annotation name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The message annotation value"
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "Whether the message annotation is required"
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The message annotation type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "MessageAnnotations"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10DeliveryAnnotationsType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10DeliveryAnnotationsItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The delivery annotation name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The delivery annotation value"
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "Whether the annotation is required"
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The annotation type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "DeliveryAnnotations"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10HeaderType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10HeaderItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "AMQP header name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "AMQP header value."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "AMQP header required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "AMQP header type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Header"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10FooterType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10FooterItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "AMQP footer name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "AMQP footer value."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "AMQP footer required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "AMQP footer type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Footer"
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "AMQP message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatMqtt311Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatMqtt311MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311QosType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT qos value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Qos",
-                                    "doc": "MQTT qos."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311RetainType",
-                                      "fields": [
-                                        {
-                                          "type": "boolean",
-                                          "name": "Value",
-                                          "doc": "MQTT retain value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Retain",
-                                    "doc": "MQTT retain."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311TopicNameType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT topic-name value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "TopicName",
-                                    "doc": "MQTT topic-name."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "MQTT message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatMqtt50Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatMqtt50MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50QosType",
-                                      "fields": [
-                                        {
-                                          "type": "int",
-                                          "name": "Value",
-                                          "doc": "MQTT qos value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Qos",
-                                    "doc": "MQTT qos."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50RetainType",
-                                      "fields": [
-                                        {
-                                          "type": "boolean",
-                                          "name": "Value",
-                                          "doc": "MQTT retain value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Retain",
-                                    "doc": "MQTT retain."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50TopicNameType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT topic-name value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "TopicName",
-                                    "doc": "MQTT topic-name."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50MessageExpiryIntervalType",
-                                      "fields": [
-                                        {
-                                          "type": "int",
-                                          "name": "Value",
-                                          "doc": "MQTT message-expiry-interval value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "MessageExpiryInterval",
-                                    "doc": "MQTT message-expiry-interval."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50ResponseTopicType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT response-topic value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "ResponseTopic",
-                                    "doc": "MQTT response-topic."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50CorrelationDataType",
-                                      "fields": [
-                                        {
-                                          "type": "bytes",
-                                          "name": "Value",
-                                          "doc": "MQTT correlation-data value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "CorrelationData",
-                                    "doc": "MQTT correlation-data."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50ContentTypeType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT content-type value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "ContentType",
-                                    "doc": "MQTT content-type."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "record",
-                                        "name": "FormatMqtt50UserPropertiesType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "MQTT user-property name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "MQTT user-property value."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "UserProperties",
-                                    "doc": "MQTT user-properties."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "MQTT message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatKafka011Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatKafka011MetadataType",
-                                "fields": [
-                                  {
-                                    "type": "string",
-                                    "name": "Topic",
-                                    "doc": "The Apache Kafka topic."
-                                  },
-                                  {
-                                    "type": "int",
-                                    "name": "Partition",
-                                    "doc": "The Apache Kafka partition."
-                                  },
-                                  {
-                                    "type": "bytes",
-                                    "name": "Key",
-                                    "doc": "The Apache Kafka key."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatKafka011HeadersType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatKafka011HeadersItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The Apache Kafka header name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The Apache Kafka header value."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Headers",
-                                    "doc": "The Apache Kafka headers."
-                                  },
-                                  {
-                                    "type": "int",
-                                    "name": "Timestamp",
-                                    "doc": "The Apache Kafka timestamp."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "The Apache Kafka message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
                           "name": "FormatCloudevents10Type",
                           "fields": [
                             {
@@ -1412,22 +717,698 @@
                               "doc": "CloudEvents metadata constraints."
                             }
                           ]
-                        },
+                        }
+                      ],
+                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
+                    },
+                    {
+                      "name": "Binding",
+                      "type": [
                         {
                           "type": "record",
-                          "name": "FormatHttp11Type",
+                          "name": "BindingAmqp10Type",
                           "fields": [
                             {
                               "type": {
                                 "type": "record",
-                                "name": "FormatHttp11MetadataType",
+                                "name": "BindingAmqp10MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingAmqp10PropertiesType",
+                                      "fields": [
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10MessageIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP message-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP message-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "MessageId",
+                                          "doc": "AMQP message-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10UserIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP user-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP user-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "UserId",
+                                          "doc": "AMQP user-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ToType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP to value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP to required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "To",
+                                          "doc": "AMQP to."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10SubjectType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP subject value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP subject required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "Subject",
+                                          "doc": "AMQP subject."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ReplyToType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP reply-to value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP reply-to required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ReplyTo",
+                                          "doc": "AMQP reply-to."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10CorrelationIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP correlation-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP correlation-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "CorrelationId",
+                                          "doc": "AMQP correlation-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ContentTypeType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP content-type value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP content-type required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ContentType",
+                                          "doc": "AMQP content-type."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ContentEncodingType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP content-encoding value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP content-encoding required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ContentEncoding",
+                                          "doc": "AMQP content-encoding."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10AbsoluteExpiryTimeType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP absolute-expiry-time value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP absolute-expiry-time required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "AbsoluteExpiryTime",
+                                          "doc": "AMQP absolute-expiry-time."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10GroupIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP group-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP group-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "GroupId",
+                                          "doc": "AMQP group-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10GroupSequenceType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP group-sequence value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP group-sequence required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "GroupSequence",
+                                          "doc": "AMQP group-sequence."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ReplyToGroupIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP reply-to-group-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP reply-to-group-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ReplyToGroupId",
+                                          "doc": "AMQP reply-to-group-id."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Properties"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10ApplicationPropertiesType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10ApplicationPropertiesItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The application property value template."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "The application property required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The application property type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "ApplicationProperties"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10MessageAnnotationsType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10MessageAnnotationsItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The message annotation value"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "Whether the message annotation is required"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The message annotation type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "MessageAnnotations"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10DeliveryAnnotationsType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10DeliveryAnnotationsItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The delivery annotation value"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "Whether the annotation is required"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The annotation type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "DeliveryAnnotations"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10HeaderType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10HeaderItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "AMQP header value."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "AMQP header required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "AMQP header type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Header"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10FooterType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10FooterItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "AMQP footer value."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "AMQP footer required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "AMQP footer type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Footer"
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "AMQP message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingMqtt311Type",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingMqtt311MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311QosType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT qos value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Qos",
+                                    "doc": "MQTT qos."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311RetainType",
+                                      "fields": [
+                                        {
+                                          "type": "boolean",
+                                          "name": "Value",
+                                          "doc": "MQTT retain value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Retain",
+                                    "doc": "MQTT retain."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311TopicNameType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT topic-name value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "TopicName",
+                                    "doc": "MQTT topic-name."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "MQTT message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingMqtt50Type",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingMqtt50MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50QosType",
+                                      "fields": [
+                                        {
+                                          "type": "int",
+                                          "name": "Value",
+                                          "doc": "MQTT qos value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Qos",
+                                    "doc": "MQTT qos."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50RetainType",
+                                      "fields": [
+                                        {
+                                          "type": "boolean",
+                                          "name": "Value",
+                                          "doc": "MQTT retain value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Retain",
+                                    "doc": "MQTT retain."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50TopicNameType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT topic-name value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "TopicName",
+                                    "doc": "MQTT topic-name."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50MessageExpiryIntervalType",
+                                      "fields": [
+                                        {
+                                          "type": "int",
+                                          "name": "Value",
+                                          "doc": "MQTT message-expiry-interval value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "MessageExpiryInterval",
+                                    "doc": "MQTT message-expiry-interval."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50ResponseTopicType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT response-topic value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "ResponseTopic",
+                                    "doc": "MQTT response-topic."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50CorrelationDataType",
+                                      "fields": [
+                                        {
+                                          "type": "bytes",
+                                          "name": "Value",
+                                          "doc": "MQTT correlation-data value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "CorrelationData",
+                                    "doc": "MQTT correlation-data."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50ContentTypeType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT content-type value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "ContentType",
+                                    "doc": "MQTT content-type."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "record",
+                                        "name": "BindingMqtt50UserPropertiesType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Name",
+                                            "doc": "MQTT user-property name."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "MQTT user-property value."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "UserProperties",
+                                    "doc": "MQTT user-properties."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "MQTT message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingKAFKAType",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingKAFKAMessageType",
+                                "fields": [
+                                  {
+                                    "type": "string",
+                                    "name": "Topic",
+                                    "doc": "The Apache Kafka topic."
+                                  },
+                                  {
+                                    "type": "int",
+                                    "name": "Partition",
+                                    "doc": "The Apache Kafka partition."
+                                  },
+                                  {
+                                    "type": "bytes",
+                                    "name": "Key",
+                                    "doc": "The Apache Kafka key."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingKAFKAHeadersType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingKAFKAHeadersItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Name",
+                                            "doc": "The Apache Kafka header name."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The Apache Kafka header value."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Headers",
+                                    "doc": "The Apache Kafka headers."
+                                  },
+                                  {
+                                    "type": "int",
+                                    "name": "Timestamp",
+                                    "doc": "The Apache Kafka timestamp."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "The Apache Kafka message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingHTTPType",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingHTTPMessageType",
                                 "fields": [
                                   {
                                     "type": {
                                       "type": "array",
                                       "items": {
                                         "type": "record",
-                                        "name": "FormatHttp11HeadersType",
+                                        "name": "BindingHTTPHeadersType",
                                         "fields": [
                                           {
                                             "type": "string",
@@ -1498,13 +1479,13 @@
                                   }
                                 ]
                               },
-                              "name": "Metadata",
+                              "name": "Message",
                               "doc": "The HTTP message metadata constraints."
                             }
                           ]
                         }
                       ],
-                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
+                      "doc": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
                     }
                   ]
                 }

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -57,14 +57,14 @@
       "oneOf": [
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "AMQP/1.0"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "AMQP message metadata constraints.",
               "properties": {
@@ -245,10 +245,6 @@
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The application property name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The application property value template."
@@ -268,10 +264,6 @@
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The message annotation name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The message annotation value"
@@ -284,20 +276,13 @@
                         "type": "string",
                         "description": "The message annotation type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "delivery-annotations": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The delivery annotation name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The delivery annotation value"
@@ -310,20 +295,13 @@
                         "type": "string",
                         "description": "The annotation type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "header": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "AMQP header name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP header value."
@@ -336,20 +314,13 @@
                         "type": "string",
                         "description": "AMQP header type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "footer": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "AMQP footer name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP footer value."
@@ -362,29 +333,26 @@
                         "type": "string",
                         "description": "AMQP footer type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 }
               }
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "MQTT/3.1.1"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "MQTT message metadata constraints.",
               "properties": {
@@ -422,19 +390,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "MQTT/5.0"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "MQTT message metadata constraints.",
               "properties": {
@@ -529,19 +497,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
-                "KAFKA/0.11"
+                "KAFKA"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "The Apache Kafka message metadata constraints.",
               "properties": {
@@ -582,116 +550,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
-                "CloudEvents/1.0"
+                "HTTP"
               ]
             },
-            "metadata": {
-              "type": "object",
-              "description": "CloudEvents metadata constraints.",
-              "properties": {
-                "type": {
-                  "type": "object",
-                  "description": "CloudEvents type.",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents type value template."
-                    }
-                  }
-                },
-                "source": {
-                  "type": "object",
-                  "description": "CloudEvents source",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents source value template."
-                    }
-                  }
-                },
-                "subject": {
-                  "type": "object",
-                  "description": "CloudEvents subject",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents subject value template."
-                    },
-                    "required": {
-                      "type": "boolean",
-                      "description": "CloudEvents subject required."
-                    }
-                  }
-                },
-                "id": {
-                  "type": "object",
-                  "description": "CloudEvents id",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents id value template."
-                    }
-                  }
-                },
-                "time": {
-                  "type": "object",
-                  "description": "The timestamp of when the event happened.",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "The timestamp value template."
-                    },
-                    "required": {
-                      "type": "boolean",
-                      "description": "The timestamp required."
-                    }
-                  }
-                },
-                "dataschema": {
-                  "type": "string",
-                  "format": "uri-template",
-                  "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default."
-                }
-              },
-              "additionalProperties": {
-                "type": "object",
-                "description": "CloudEvent extension property",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "The value template."
-                  },
-                  "required": {
-                    "type": "boolean",
-                    "description": "Whether the extension is required"
-                  }
-                }
-              }
-            }
-          },
-          "required": [
-            "format"
-          ]
-        },
-        {
-          "properties": {
-            "format": {
-              "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
-              "enum": [
-                "HTTP/1.1"
-              ]
-            },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "The HTTP message metadata constraints.",
               "properties": {
@@ -727,7 +598,7 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         }
       ]
@@ -891,9 +762,6 @@
                       "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message."
                     }
                   },
-                  "required": [
-                    "node"
-                  ],
                   "additionalProperties": {
                     "type": "string",
                     "description": "Further options to configure the AMQP 1.0 client"
@@ -1051,10 +919,7 @@
                         ]
                       }
                     }
-                  },
-                  "required": [
-                    "method"
-                  ]
+                  }
                 }
               },
               "required": [

--- a/message/model.json
+++ b/message/model.json
@@ -8,9 +8,14 @@
             "plural": "definitionGroups",
             "attributes": {
                 "format": {
-                    "description": "Message format identifier. All definitions in this group share this format. Mixed-format groups are not permitted.",
+                    "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted.",
                     "type": "string",
-                    "required": true
+                    "required": false
+                },
+                "binding": {
+                    "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted.",
+                    "type": "string",
+                    "required": false
                 }
             },
             "resources": {
@@ -22,11 +27,133 @@
                         "format": {
                             "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
                             "type": "string",
-                            "required": true,
+                            "required": false,
+                            "ifValue" : {
+                                "CloudEvents/1.0": {
+                                    "siblingAttributes": {
+                                        "metadata": {
+                                            "description": "CloudEvents metadata constraints.",
+                                            "type": "object",
+                                            "required": false,
+                                            "attributes": {
+                                                "type": {
+                                                    "description": "CloudEvents type.",
+                                                    "type": "object",
+                                                    "required": false,
+                                                    "attributes": {
+                                                        "value": {
+                                                            "description": "CloudEvents type value template.",
+                                                            "type": "string",
+                                                            "required": false
+                                                        }
+                                                    }
+                                                },
+                                                "source": {
+                                                    "description": "CloudEvents source",
+                                                    "type": "object",
+                                                    "required": false,
+                                                    "attributes": {
+                                                        "value": {
+                                                            "description": "CloudEvents source value template.",
+                                                            "type": "string",
+                                                            "required": false
+                                                        }
+                                                    }
+                                                },
+                                                "subject": {
+                                                    "description": "CloudEvents subject",
+                                                    "type": "object",
+                                                    "required": false,
+                                                    "attributes": {
+                                                        "value": {
+                                                            "description": "CloudEvents subject value template.",
+                                                            "type": "string",
+                                                            "required": false
+                                                        },
+                                                        "required": {
+                                                            "description": "CloudEvents subject required.",
+                                                            "type": "boolean",
+                                                            "required": false
+                                                        }
+                                                    }
+                                                },
+                                                "id": {
+                                                    "description": "CloudEvents id",
+                                                    "type": "object",
+                                                    "required": false,
+                                                    "attributes": {
+                                                        "value": {
+                                                            "description": "CloudEvents id value template.",
+                                                            "type": "string",
+                                                            "required": false
+                                                        }
+                                                    }
+                                                },
+                                                "time": {
+                                                    "description": "The timestamp of when the event happened.",
+                                                    "type": "object",
+                                                    "required": false,
+                                                    "attributes": {
+                                                        "value": {
+                                                            "description": "The timestamp value template.",
+                                                            "type": "string",
+                                                            "required": false
+                                                        },
+                                                        "required": {
+                                                            "description": "The timestamp required.",
+                                                            "type": "boolean",
+                                                            "required": false
+                                                        }
+                                                    }
+                                                },
+                                                "dataschema": {
+                                                    "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default.",
+                                                    "type": "uritemplate",
+                                                    "required": false,
+                                                    "attributes": {
+                                                        "value": {
+                                                            "description": "The uri value template.",
+                                                            "type": "string",
+                                                            "required": false
+                                                        },
+                                                        "required": {
+                                                            "description": "The uri required.",
+                                                            "type": "boolean",
+                                                            "required": false
+                                                        }
+                                                    }
+                                                },
+                                                "*": {
+                                                    "description": "CloudEvent extension property",
+                                                    "type": "object",
+                                                    "required": false,
+                                                    "attributes": {
+                                                        "value": {
+                                                            "description": "The value template.",
+                                                            "type": "string",
+                                                            "required": false
+                                                        },
+                                                        "required": {
+                                                            "description": "Whether the extension is required",
+                                                            "type": "boolean",
+                                                            "required": false
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "binding": {
+                            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+                            "type": "string",
+                            "required": false,
                             "ifValue": {
                                 "AMQP/1.0": {
                                     "siblingAttributes": {
-                                        "metadata": {
+                                        "message": {
                                             "description": "AMQP message metadata constraints.",
                                             "type": "object",
                                             "required": false,
@@ -247,11 +374,6 @@
                                                     "itemType": "object",
                                                     "keyType": "string",
                                                     "attributes": {
-                                                        "name": {
-                                                            "description": "The application property name.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
                                                         "value": {
                                                             "description": "The application property value template.",
                                                             "type": "string",
@@ -275,11 +397,6 @@
                                                     "itemType": "object",
                                                     "keyType": "string",
                                                     "attributes": {
-                                                        "name": {
-                                                            "description": "The message annotation name.",
-                                                            "type": "string",
-                                                            "required": true
-                                                        },
                                                         "value": {
                                                             "description": "The message annotation value",
                                                             "type": "string",
@@ -303,11 +420,6 @@
                                                     "itemType": "object",
                                                     "keyType": "string",
                                                     "attributes": {
-                                                        "name": {
-                                                            "description": "The delivery annotation name.",
-                                                            "type": "string",
-                                                            "required": true
-                                                        },
                                                         "value": {
                                                             "description": "The delivery annotation value",
                                                             "type": "string",
@@ -331,11 +443,6 @@
                                                     "itemType": "object",
                                                     "keyType": "string",
                                                     "attributes": {
-                                                        "name": {
-                                                            "description": "AMQP header name.",
-                                                            "type": "string",
-                                                            "required": true
-                                                        },
                                                         "value": {
                                                             "description": "AMQP header value.",
                                                             "type": "string",
@@ -359,11 +466,6 @@
                                                     "itemType": "object",
                                                     "keyType": "string",
                                                     "attributes": {
-                                                        "name": {
-                                                            "description": "AMQP footer name.",
-                                                            "type": "string",
-                                                            "required": true
-                                                        },
                                                         "value": {
                                                             "description": "AMQP footer value.",
                                                             "type": "string",
@@ -387,7 +489,7 @@
                                 },
                                 "MQTT/3.1.1": {
                                     "siblingAttributes": {
-                                        "metadata": {
+                                        "message": {
                                             "description": "MQTT message metadata constraints.",
                                             "type": "object",
                                             "required": false,
@@ -434,7 +536,7 @@
                                 },
                                 "MQTT/5.0": {
                                     "siblingAttributes": {
-                                        "metadata": {
+                                        "message": {
                                             "description": "MQTT message metadata constraints.",
                                             "type": "object",
                                             "required": false,
@@ -545,9 +647,9 @@
                                         }
                                     }
                                 },
-                                "KAFKA/0.11": {
+                                "KAFKA": {
                                     "siblingAttributes": {
-                                        "metadata": {
+                                        "message": {
                                             "description": "The Apache Kafka message metadata constraints.",
                                             "type": "object",
                                             "required": false,
@@ -595,124 +697,9 @@
                                         }
                                     }
                                 },
-                                "CloudEvents/1.0": {
+                                "HTTP": {
                                     "siblingAttributes": {
-                                        "metadata": {
-                                            "description": "CloudEvents metadata constraints.",
-                                            "type": "object",
-                                            "required": false,
-                                            "attributes": {
-                                                "type": {
-                                                    "description": "CloudEvents type.",
-                                                    "type": "object",
-                                                    "required": false,
-                                                    "attributes": {
-                                                        "value": {
-                                                            "description": "CloudEvents type value template.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                },
-                                                "source": {
-                                                    "description": "CloudEvents source",
-                                                    "type": "object",
-                                                    "required": false,
-                                                    "attributes": {
-                                                        "value": {
-                                                            "description": "CloudEvents source value template.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                },
-                                                "subject": {
-                                                    "description": "CloudEvents subject",
-                                                    "type": "object",
-                                                    "required": false,
-                                                    "attributes": {
-                                                        "value": {
-                                                            "description": "CloudEvents subject value template.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "required": {
-                                                            "description": "CloudEvents subject required.",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                },
-                                                "id": {
-                                                    "description": "CloudEvents id",
-                                                    "type": "object",
-                                                    "required": false,
-                                                    "attributes": {
-                                                        "value": {
-                                                            "description": "CloudEvents id value template.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                },
-                                                "time": {
-                                                    "description": "The timestamp of when the event happened.",
-                                                    "type": "object",
-                                                    "required": false,
-                                                    "attributes": {
-                                                        "value": {
-                                                            "description": "The timestamp value template.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "required": {
-                                                            "description": "The timestamp required.",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                },
-                                                "dataschema": {
-                                                    "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default.",
-                                                    "type": "uritemplate",
-                                                    "required": false,
-                                                    "attributes": {
-                                                        "value": {
-                                                            "description": "The uri value template.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "required": {
-                                                            "description": "The uri required.",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                },
-                                                "*": {
-                                                    "description": "CloudEvent extension property",
-                                                    "type": "object",
-                                                    "required": false,
-                                                    "attributes": {
-                                                        "value": {
-                                                            "description": "The value template.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "required": {
-                                                            "description": "Whether the extension is required",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "HTTP/1.1": {
-                                    "siblingAttributes": {
-                                        "metadata": {
+                                        "message": {
                                             "description": "The HTTP message metadata constraints.",
                                             "type": "object",
                                             "required": false,

--- a/message/schemas/document-schema.avsc
+++ b/message/schemas/document-schema.avsc
@@ -94,7 +94,12 @@
             {
               "type": "string",
               "name": "Format",
-              "doc": "Message format identifier. All definitions in this group share this format. Mixed-format groups are not permitted."
+              "doc": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted."
+            },
+            {
+              "type": "string",
+              "name": "Binding",
+              "doc": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted."
             },
             {
               "name": "definitions",
@@ -187,701 +192,6 @@
                     {
                       "name": "Format",
                       "type": [
-                        {
-                          "type": "record",
-                          "name": "FormatAmqp10Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatAmqp10MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatAmqp10PropertiesType",
-                                      "fields": [
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10MessageIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP message-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP message-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "MessageId",
-                                          "doc": "AMQP message-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10UserIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP user-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP user-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "UserId",
-                                          "doc": "AMQP user-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ToType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP to value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP to required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "To",
-                                          "doc": "AMQP to."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10SubjectType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP subject value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP subject required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "Subject",
-                                          "doc": "AMQP subject."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ReplyToType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP reply-to value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP reply-to required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ReplyTo",
-                                          "doc": "AMQP reply-to."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10CorrelationIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP correlation-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP correlation-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "CorrelationId",
-                                          "doc": "AMQP correlation-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ContentTypeType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP content-type value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP content-type required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ContentType",
-                                          "doc": "AMQP content-type."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ContentEncodingType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP content-encoding value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP content-encoding required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ContentEncoding",
-                                          "doc": "AMQP content-encoding."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10AbsoluteExpiryTimeType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP absolute-expiry-time value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP absolute-expiry-time required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "AbsoluteExpiryTime",
-                                          "doc": "AMQP absolute-expiry-time."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10GroupIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP group-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP group-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "GroupId",
-                                          "doc": "AMQP group-id."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10GroupSequenceType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP group-sequence value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP group-sequence required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "GroupSequence",
-                                          "doc": "AMQP group-sequence."
-                                        },
-                                        {
-                                          "type": {
-                                            "type": "record",
-                                            "name": "FormatAmqp10ReplyToGroupIdType",
-                                            "fields": [
-                                              {
-                                                "type": "string",
-                                                "name": "Value",
-                                                "doc": "AMQP reply-to-group-id value template."
-                                              },
-                                              {
-                                                "type": "boolean",
-                                                "name": "Required",
-                                                "doc": "AMQP reply-to-group-id required."
-                                              }
-                                            ]
-                                          },
-                                          "name": "ReplyToGroupId",
-                                          "doc": "AMQP reply-to-group-id."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Properties"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10ApplicationPropertiesType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10ApplicationPropertiesItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The application property name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The application property value template."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "The application property required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The application property type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "ApplicationProperties"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10MessageAnnotationsType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10MessageAnnotationsItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The message annotation name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The message annotation value"
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "Whether the message annotation is required"
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The message annotation type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "MessageAnnotations"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10DeliveryAnnotationsType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10DeliveryAnnotationsItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The delivery annotation name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The delivery annotation value"
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "Whether the annotation is required"
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "The annotation type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "DeliveryAnnotations"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10HeaderType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10HeaderItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "AMQP header name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "AMQP header value."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "AMQP header required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "AMQP header type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Header"
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatAmqp10FooterType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatAmqp10FooterItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "AMQP footer name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "AMQP footer value."
-                                          },
-                                          {
-                                            "type": "boolean",
-                                            "name": "Required",
-                                            "doc": "AMQP footer required."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Type",
-                                            "doc": "AMQP footer type."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Footer"
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "AMQP message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatMqtt311Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatMqtt311MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311QosType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT qos value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Qos",
-                                    "doc": "MQTT qos."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311RetainType",
-                                      "fields": [
-                                        {
-                                          "type": "boolean",
-                                          "name": "Value",
-                                          "doc": "MQTT retain value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Retain",
-                                    "doc": "MQTT retain."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt311TopicNameType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT topic-name value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "TopicName",
-                                    "doc": "MQTT topic-name."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "MQTT message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatMqtt50Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatMqtt50MetadataType",
-                                "fields": [
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50QosType",
-                                      "fields": [
-                                        {
-                                          "type": "int",
-                                          "name": "Value",
-                                          "doc": "MQTT qos value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Qos",
-                                    "doc": "MQTT qos."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50RetainType",
-                                      "fields": [
-                                        {
-                                          "type": "boolean",
-                                          "name": "Value",
-                                          "doc": "MQTT retain value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "Retain",
-                                    "doc": "MQTT retain."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50TopicNameType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT topic-name value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "TopicName",
-                                    "doc": "MQTT topic-name."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50MessageExpiryIntervalType",
-                                      "fields": [
-                                        {
-                                          "type": "int",
-                                          "name": "Value",
-                                          "doc": "MQTT message-expiry-interval value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "MessageExpiryInterval",
-                                    "doc": "MQTT message-expiry-interval."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50ResponseTopicType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT response-topic value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "ResponseTopic",
-                                    "doc": "MQTT response-topic."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50CorrelationDataType",
-                                      "fields": [
-                                        {
-                                          "type": "bytes",
-                                          "name": "Value",
-                                          "doc": "MQTT correlation-data value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "CorrelationData",
-                                    "doc": "MQTT correlation-data."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "record",
-                                      "name": "FormatMqtt50ContentTypeType",
-                                      "fields": [
-                                        {
-                                          "type": "string",
-                                          "name": "Value",
-                                          "doc": "MQTT content-type value template."
-                                        }
-                                      ]
-                                    },
-                                    "name": "ContentType",
-                                    "doc": "MQTT content-type."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "record",
-                                        "name": "FormatMqtt50UserPropertiesType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "MQTT user-property name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "MQTT user-property value."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "UserProperties",
-                                    "doc": "MQTT user-properties."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "MQTT message metadata constraints."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "record",
-                          "name": "FormatKafka011Type",
-                          "fields": [
-                            {
-                              "type": {
-                                "type": "record",
-                                "name": "FormatKafka011MetadataType",
-                                "fields": [
-                                  {
-                                    "type": "string",
-                                    "name": "Topic",
-                                    "doc": "The Apache Kafka topic."
-                                  },
-                                  {
-                                    "type": "int",
-                                    "name": "Partition",
-                                    "doc": "The Apache Kafka partition."
-                                  },
-                                  {
-                                    "type": "bytes",
-                                    "name": "Key",
-                                    "doc": "The Apache Kafka key."
-                                  },
-                                  {
-                                    "type": {
-                                      "type": "map",
-                                      "name": "FormatKafka011HeadersType",
-                                      "values": {
-                                        "type": "record",
-                                        "name": "FormatKafka011HeadersItemType",
-                                        "fields": [
-                                          {
-                                            "type": "string",
-                                            "name": "Name",
-                                            "doc": "The Apache Kafka header name."
-                                          },
-                                          {
-                                            "type": "string",
-                                            "name": "Value",
-                                            "doc": "The Apache Kafka header value."
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "name": "Headers",
-                                    "doc": "The Apache Kafka headers."
-                                  },
-                                  {
-                                    "type": "int",
-                                    "name": "Timestamp",
-                                    "doc": "The Apache Kafka timestamp."
-                                  }
-                                ]
-                              },
-                              "name": "Metadata",
-                              "doc": "The Apache Kafka message metadata constraints."
-                            }
-                          ]
-                        },
                         {
                           "type": "record",
                           "name": "FormatCloudevents10Type",
@@ -1012,22 +322,698 @@
                               "doc": "CloudEvents metadata constraints."
                             }
                           ]
-                        },
+                        }
+                      ],
+                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
+                    },
+                    {
+                      "name": "Binding",
+                      "type": [
                         {
                           "type": "record",
-                          "name": "FormatHttp11Type",
+                          "name": "BindingAmqp10Type",
                           "fields": [
                             {
                               "type": {
                                 "type": "record",
-                                "name": "FormatHttp11MetadataType",
+                                "name": "BindingAmqp10MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingAmqp10PropertiesType",
+                                      "fields": [
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10MessageIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP message-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP message-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "MessageId",
+                                          "doc": "AMQP message-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10UserIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP user-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP user-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "UserId",
+                                          "doc": "AMQP user-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ToType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP to value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP to required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "To",
+                                          "doc": "AMQP to."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10SubjectType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP subject value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP subject required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "Subject",
+                                          "doc": "AMQP subject."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ReplyToType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP reply-to value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP reply-to required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ReplyTo",
+                                          "doc": "AMQP reply-to."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10CorrelationIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP correlation-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP correlation-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "CorrelationId",
+                                          "doc": "AMQP correlation-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ContentTypeType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP content-type value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP content-type required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ContentType",
+                                          "doc": "AMQP content-type."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ContentEncodingType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP content-encoding value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP content-encoding required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ContentEncoding",
+                                          "doc": "AMQP content-encoding."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10AbsoluteExpiryTimeType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP absolute-expiry-time value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP absolute-expiry-time required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "AbsoluteExpiryTime",
+                                          "doc": "AMQP absolute-expiry-time."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10GroupIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP group-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP group-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "GroupId",
+                                          "doc": "AMQP group-id."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10GroupSequenceType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP group-sequence value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP group-sequence required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "GroupSequence",
+                                          "doc": "AMQP group-sequence."
+                                        },
+                                        {
+                                          "type": {
+                                            "type": "record",
+                                            "name": "BindingAmqp10ReplyToGroupIdType",
+                                            "fields": [
+                                              {
+                                                "type": "string",
+                                                "name": "Value",
+                                                "doc": "AMQP reply-to-group-id value template."
+                                              },
+                                              {
+                                                "type": "boolean",
+                                                "name": "Required",
+                                                "doc": "AMQP reply-to-group-id required."
+                                              }
+                                            ]
+                                          },
+                                          "name": "ReplyToGroupId",
+                                          "doc": "AMQP reply-to-group-id."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Properties"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10ApplicationPropertiesType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10ApplicationPropertiesItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The application property value template."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "The application property required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The application property type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "ApplicationProperties"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10MessageAnnotationsType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10MessageAnnotationsItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The message annotation value"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "Whether the message annotation is required"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The message annotation type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "MessageAnnotations"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10DeliveryAnnotationsType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10DeliveryAnnotationsItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The delivery annotation value"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "Whether the annotation is required"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "The annotation type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "DeliveryAnnotations"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10HeaderType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10HeaderItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "AMQP header value."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "AMQP header required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "AMQP header type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Header"
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingAmqp10FooterType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingAmqp10FooterItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "AMQP footer value."
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "name": "Required",
+                                            "doc": "AMQP footer required."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Type",
+                                            "doc": "AMQP footer type."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Footer"
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "AMQP message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingMqtt311Type",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingMqtt311MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311QosType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT qos value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Qos",
+                                    "doc": "MQTT qos."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311RetainType",
+                                      "fields": [
+                                        {
+                                          "type": "boolean",
+                                          "name": "Value",
+                                          "doc": "MQTT retain value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Retain",
+                                    "doc": "MQTT retain."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt311TopicNameType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT topic-name value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "TopicName",
+                                    "doc": "MQTT topic-name."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "MQTT message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingMqtt50Type",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingMqtt50MessageType",
+                                "fields": [
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50QosType",
+                                      "fields": [
+                                        {
+                                          "type": "int",
+                                          "name": "Value",
+                                          "doc": "MQTT qos value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Qos",
+                                    "doc": "MQTT qos."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50RetainType",
+                                      "fields": [
+                                        {
+                                          "type": "boolean",
+                                          "name": "Value",
+                                          "doc": "MQTT retain value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "Retain",
+                                    "doc": "MQTT retain."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50TopicNameType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT topic-name value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "TopicName",
+                                    "doc": "MQTT topic-name."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50MessageExpiryIntervalType",
+                                      "fields": [
+                                        {
+                                          "type": "int",
+                                          "name": "Value",
+                                          "doc": "MQTT message-expiry-interval value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "MessageExpiryInterval",
+                                    "doc": "MQTT message-expiry-interval."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50ResponseTopicType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT response-topic value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "ResponseTopic",
+                                    "doc": "MQTT response-topic."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50CorrelationDataType",
+                                      "fields": [
+                                        {
+                                          "type": "bytes",
+                                          "name": "Value",
+                                          "doc": "MQTT correlation-data value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "CorrelationData",
+                                    "doc": "MQTT correlation-data."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "record",
+                                      "name": "BindingMqtt50ContentTypeType",
+                                      "fields": [
+                                        {
+                                          "type": "string",
+                                          "name": "Value",
+                                          "doc": "MQTT content-type value template."
+                                        }
+                                      ]
+                                    },
+                                    "name": "ContentType",
+                                    "doc": "MQTT content-type."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "record",
+                                        "name": "BindingMqtt50UserPropertiesType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Name",
+                                            "doc": "MQTT user-property name."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "MQTT user-property value."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "UserProperties",
+                                    "doc": "MQTT user-properties."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "MQTT message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingKAFKAType",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingKAFKAMessageType",
+                                "fields": [
+                                  {
+                                    "type": "string",
+                                    "name": "Topic",
+                                    "doc": "The Apache Kafka topic."
+                                  },
+                                  {
+                                    "type": "int",
+                                    "name": "Partition",
+                                    "doc": "The Apache Kafka partition."
+                                  },
+                                  {
+                                    "type": "bytes",
+                                    "name": "Key",
+                                    "doc": "The Apache Kafka key."
+                                  },
+                                  {
+                                    "type": {
+                                      "type": "map",
+                                      "name": "BindingKAFKAHeadersType",
+                                      "values": {
+                                        "type": "record",
+                                        "name": "BindingKAFKAHeadersItemType",
+                                        "fields": [
+                                          {
+                                            "type": "string",
+                                            "name": "Name",
+                                            "doc": "The Apache Kafka header name."
+                                          },
+                                          {
+                                            "type": "string",
+                                            "name": "Value",
+                                            "doc": "The Apache Kafka header value."
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "name": "Headers",
+                                    "doc": "The Apache Kafka headers."
+                                  },
+                                  {
+                                    "type": "int",
+                                    "name": "Timestamp",
+                                    "doc": "The Apache Kafka timestamp."
+                                  }
+                                ]
+                              },
+                              "name": "Message",
+                              "doc": "The Apache Kafka message metadata constraints."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "record",
+                          "name": "BindingHTTPType",
+                          "fields": [
+                            {
+                              "type": {
+                                "type": "record",
+                                "name": "BindingHTTPMessageType",
                                 "fields": [
                                   {
                                     "type": {
                                       "type": "array",
                                       "items": {
                                         "type": "record",
-                                        "name": "FormatHttp11HeadersType",
+                                        "name": "BindingHTTPHeadersType",
                                         "fields": [
                                           {
                                             "type": "string",
@@ -1098,13 +1084,13 @@
                                   }
                                 ]
                               },
-                              "name": "Metadata",
+                              "name": "Message",
                               "doc": "The HTTP message metadata constraints."
                             }
                           ]
                         }
                       ],
-                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
+                      "doc": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups."
                     }
                   ]
                 }

--- a/message/schemas/document-schema.json
+++ b/message/schemas/document-schema.json
@@ -57,14 +57,14 @@
       "oneOf": [
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "AMQP/1.0"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "AMQP message metadata constraints.",
               "properties": {
@@ -245,10 +245,6 @@
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The application property name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The application property value template."
@@ -268,10 +264,6 @@
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The message annotation name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The message annotation value"
@@ -284,20 +276,13 @@
                         "type": "string",
                         "description": "The message annotation type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "delivery-annotations": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "The delivery annotation name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "The delivery annotation value"
@@ -310,20 +295,13 @@
                         "type": "string",
                         "description": "The annotation type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "header": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "AMQP header name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP header value."
@@ -336,20 +314,13 @@
                         "type": "string",
                         "description": "AMQP header type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 },
                 "footer": {
                   "type": "object",
                   "additionalProperties": {
                     "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "AMQP footer name."
-                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP footer value."
@@ -362,29 +333,26 @@
                         "type": "string",
                         "description": "AMQP footer type."
                       }
-                    },
-                    "required": [
-                      "name"
-                    ]
+                    }
                   }
                 }
               }
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "MQTT/3.1.1"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "MQTT message metadata constraints.",
               "properties": {
@@ -422,19 +390,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
                 "MQTT/5.0"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "MQTT message metadata constraints.",
               "properties": {
@@ -529,19 +497,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
-                "KAFKA/0.11"
+                "KAFKA"
               ]
             },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "The Apache Kafka message metadata constraints.",
               "properties": {
@@ -582,116 +550,19 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         },
         {
           "properties": {
-            "format": {
+            "binding": {
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
               "enum": [
-                "CloudEvents/1.0"
+                "HTTP"
               ]
             },
-            "metadata": {
-              "type": "object",
-              "description": "CloudEvents metadata constraints.",
-              "properties": {
-                "type": {
-                  "type": "object",
-                  "description": "CloudEvents type.",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents type value template."
-                    }
-                  }
-                },
-                "source": {
-                  "type": "object",
-                  "description": "CloudEvents source",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents source value template."
-                    }
-                  }
-                },
-                "subject": {
-                  "type": "object",
-                  "description": "CloudEvents subject",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents subject value template."
-                    },
-                    "required": {
-                      "type": "boolean",
-                      "description": "CloudEvents subject required."
-                    }
-                  }
-                },
-                "id": {
-                  "type": "object",
-                  "description": "CloudEvents id",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "CloudEvents id value template."
-                    }
-                  }
-                },
-                "time": {
-                  "type": "object",
-                  "description": "The timestamp of when the event happened.",
-                  "properties": {
-                    "value": {
-                      "type": "string",
-                      "description": "The timestamp value template."
-                    },
-                    "required": {
-                      "type": "boolean",
-                      "description": "The timestamp required."
-                    }
-                  }
-                },
-                "dataschema": {
-                  "type": "string",
-                  "format": "uri-template",
-                  "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default."
-                }
-              },
-              "additionalProperties": {
-                "type": "object",
-                "description": "CloudEvent extension property",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "The value template."
-                  },
-                  "required": {
-                    "type": "boolean",
-                    "description": "Whether the extension is required"
-                  }
-                }
-              }
-            }
-          },
-          "required": [
-            "format"
-          ]
-        },
-        {
-          "properties": {
-            "format": {
-              "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
-              "enum": [
-                "HTTP/1.1"
-              ]
-            },
-            "metadata": {
+            "message": {
               "type": "object",
               "description": "The HTTP message metadata constraints.",
               "properties": {
@@ -727,7 +598,7 @@
             }
           },
           "required": [
-            "format"
+            "binding"
           ]
         }
       ]
@@ -760,7 +631,7 @@
         },
         "format": {
           "type": "string",
-          "description": "Message format identifier. All definitions in this group share this format. Mixed-format groups are not permitted."
+          "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted."
         },
         "createdBy": {
           "type": "string"
@@ -776,6 +647,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "binding": {
+          "type": "string",
+          "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted."
+        },
         "definitions": {
           "type": "object",
           "additionalProperties": {
@@ -784,8 +659,7 @@
         }
       },
       "required": [
-        "id",
-        "format"
+        "id"
       ]
     }
   }

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -1104,16 +1104,113 @@
           }
         }
       },
-      "format_AMQP_1_0": {
+      "format_CloudEvents_1_0": {
         "properties": {
           "format": {
             "type": "string",
             "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
-              "AMQP/1.0"
+              "CloudEvents/1.0"
             ]
           },
           "metadata": {
+            "type": "object",
+            "description": "CloudEvents metadata constraints.",
+            "properties": {
+              "type": {
+                "type": "object",
+                "description": "CloudEvents type.",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents type value template."
+                  }
+                }
+              },
+              "source": {
+                "type": "object",
+                "description": "CloudEvents source",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents source value template."
+                  }
+                }
+              },
+              "subject": {
+                "type": "object",
+                "description": "CloudEvents subject",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents subject value template."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents subject required."
+                  }
+                }
+              },
+              "id": {
+                "type": "object",
+                "description": "CloudEvents id",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents id value template."
+                  }
+                }
+              },
+              "time": {
+                "type": "object",
+                "description": "The timestamp of when the event happened.",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "The timestamp value template."
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "The timestamp required."
+                  }
+                }
+              },
+              "dataschema": {
+                "type": "string",
+                "format": "uri-template",
+                "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default."
+              }
+            },
+            "additionalProperties": {
+              "type": "object",
+              "description": "CloudEvent extension property",
+              "properties": {
+                "value": {
+                  "type": "string",
+                  "description": "The value template."
+                },
+                "required": {
+                  "type": "boolean",
+                  "description": "Whether the extension is required"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "format"
+        ]
+      },
+      "binding_AMQP_1_0": {
+        "properties": {
+          "binding": {
+            "type": "string",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "enum": [
+              "AMQP/1.0"
+            ]
+          },
+          "message": {
             "type": "object",
             "description": "AMQP message metadata constraints.",
             "properties": {
@@ -1294,10 +1391,6 @@
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "The application property name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "The application property value template."
@@ -1317,10 +1410,6 @@
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "The message annotation name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "The message annotation value"
@@ -1333,20 +1422,13 @@
                       "type": "string",
                       "description": "The message annotation type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               },
               "delivery-annotations": {
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "The delivery annotation name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "The delivery annotation value"
@@ -1359,20 +1441,13 @@
                       "type": "string",
                       "description": "The annotation type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               },
               "header": {
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "AMQP header name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP header value."
@@ -1385,20 +1460,13 @@
                       "type": "string",
                       "description": "AMQP header type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               },
               "footer": {
                 "type": "object",
                 "additionalProperties": {
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "AMQP footer name."
-                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP footer value."
@@ -1411,29 +1479,26 @@
                       "type": "string",
                       "description": "AMQP footer type."
                     }
-                  },
-                  "required": [
-                    "name"
-                  ]
+                  }
                 }
               }
             }
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_MQTT_3_1_1": {
+      "binding_MQTT_3_1_1": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
               "MQTT/3.1.1"
             ]
           },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "MQTT message metadata constraints.",
             "properties": {
@@ -1471,19 +1536,19 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_MQTT_5_0": {
+      "binding_MQTT_5_0": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
               "MQTT/5.0"
             ]
           },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "MQTT message metadata constraints.",
             "properties": {
@@ -1578,19 +1643,19 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_KAFKA_0_11": {
+      "binding_KAFKA": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
-              "KAFKA/0.11"
+              "KAFKA"
             ]
           },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "The Apache Kafka message metadata constraints.",
             "properties": {
@@ -1631,116 +1696,19 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
-      "format_CloudEvents_1_0": {
+      "binding_HTTP": {
         "properties": {
-          "format": {
+          "binding": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
+            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
             "enum": [
-              "CloudEvents/1.0"
+              "HTTP"
             ]
           },
-          "metadata": {
-            "type": "object",
-            "description": "CloudEvents metadata constraints.",
-            "properties": {
-              "type": {
-                "type": "object",
-                "description": "CloudEvents type.",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents type value template."
-                  }
-                }
-              },
-              "source": {
-                "type": "object",
-                "description": "CloudEvents source",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents source value template."
-                  }
-                }
-              },
-              "subject": {
-                "type": "object",
-                "description": "CloudEvents subject",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents subject value template."
-                  },
-                  "required": {
-                    "type": "boolean",
-                    "description": "CloudEvents subject required."
-                  }
-                }
-              },
-              "id": {
-                "type": "object",
-                "description": "CloudEvents id",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "CloudEvents id value template."
-                  }
-                }
-              },
-              "time": {
-                "type": "object",
-                "description": "The timestamp of when the event happened.",
-                "properties": {
-                  "value": {
-                    "type": "string",
-                    "description": "The timestamp value template."
-                  },
-                  "required": {
-                    "type": "boolean",
-                    "description": "The timestamp required."
-                  }
-                }
-              },
-              "dataschema": {
-                "type": "string",
-                "format": "uri-template",
-                "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default."
-              }
-            },
-            "additionalProperties": {
-              "type": "object",
-              "description": "CloudEvent extension property",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "The value template."
-                },
-                "required": {
-                  "type": "boolean",
-                  "description": "Whether the extension is required"
-                }
-              }
-            }
-          }
-        },
-        "required": [
-          "format"
-        ]
-      },
-      "format_HTTP_1_1": {
-        "properties": {
-          "format": {
-            "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
-            "enum": [
-              "HTTP/1.1"
-            ]
-          },
-          "metadata": {
+          "message": {
             "type": "object",
             "description": "The HTTP message metadata constraints.",
             "properties": {
@@ -1776,7 +1744,7 @@
           }
         },
         "required": [
-          "format"
+          "binding"
         ]
       },
       "definition": {
@@ -1824,14 +1792,13 @@
           "id"
         ],
         "discriminator": {
-          "propertyName": "format",
+          "propertyName": "binding",
           "mapping": {
-            "AMQP/1.0": "#/components/schemas/format_AMQP_1_0",
-            "MQTT/3.1.1": "#/components/schemas/format_MQTT_3_1_1",
-            "MQTT/5.0": "#/components/schemas/format_MQTT_5_0",
-            "KAFKA/0.11": "#/components/schemas/format_KAFKA_0_11",
-            "CloudEvents/1.0": "#/components/schemas/format_CloudEvents_1_0",
-            "HTTP/1.1": "#/components/schemas/format_HTTP_1_1"
+            "AMQP/1.0": "#/components/schemas/binding_AMQP_1_0",
+            "MQTT/3.1.1": "#/components/schemas/binding_MQTT_3_1_1",
+            "MQTT/5.0": "#/components/schemas/binding_MQTT_5_0",
+            "KAFKA": "#/components/schemas/binding_KAFKA",
+            "HTTP": "#/components/schemas/binding_HTTP"
           }
         }
       },
@@ -1863,7 +1830,7 @@
           },
           "format": {
             "type": "string",
-            "description": "Message format identifier. All definitions in this group share this format. Mixed-format groups are not permitted."
+            "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted."
           },
           "createdBy": {
             "type": "string"
@@ -1879,6 +1846,10 @@
             "type": "string",
             "format": "date-time"
           },
+          "binding": {
+            "type": "string",
+            "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted."
+          },
           "definitions": {
             "type": "object",
             "additionalProperties": {
@@ -1887,8 +1858,7 @@
           }
         },
         "required": [
-          "id",
-          "format"
+          "id"
         ]
       }
     }

--- a/message/spec.md
+++ b/message/spec.md
@@ -93,23 +93,39 @@ The Group (GROUP) name is `definitionGroups`. The type of a group is
 The following attributes are defined for the `definitionGroup` object in
 addition to the basic [attributes](../core/spec.md#attributes-and-extensions):
 
-#### `format` (Message format)
+#### `format` (Metadata format)
 
 - Type: String
-- Description: Identifies the message metadata format. Message metadata formats
-  are referenced by name and version as `{NAME}/{VERSION}`. This specification
-  defines a set of common [message format names](#message-formats) that MUST be
-  used for the given formats, but applications MAY define extensions for other
-  formats on their own. All definitions inside a group MUST use this same
-  format.
+- Description: Identifies the common, transport protocol independent message
+  metadata format. Message metadata formats are referenced by name and version
+  as `{NAME}/{VERSION}`. This specification defines a set of common
+  [metadata format names](#message-formats) that MUST be used for the given
+  formats, but applications MAY define extensions for other formats on their
+  own. All definitions inside a group MUST use this same format.
 - Constraints:
-  - REQUIRED
-  - MUST be a non-empty string
-  - MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is
-    the name of the message format and `{VERSION}` is the version of the schema
-    format in the format defined by the schema format itself.
+  - At least one of `metadata` and `binding` MUST be specified.
+  - if present, MUST be a non-empty string
+  - if present, MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is
+    the name of the metadata format and `{VERSION}` is the version of the
+    metadata format.
 - Examples:
   - `CloudEvents/1.0`
+
+#### `binding` (Message binding)
+
+- Type: String
+- Description: Identifies a transport protocol message binding. Bindings are
+  referenced by name and version as `{NAME}/{VERSION}`. This specification
+  defines a set of common [message binding names](#message-bindings) that MUST
+  be used for the given protocols, but applications MAY define extensions for
+  other protocol bindings on their own. All definitions inside a group MUST use
+  this same binding.
+- Constraints:
+  - At least one of `metadata` and `binding` MUST be specified.
+  - if present, MUST be a non-empty string
+  - if present, MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is
+    the name of the protocol and `{VERSION}` is the version of protocol.
+- Examples:
   - `MQTT/3.1.1`
   - `AMQP/1.0`
   - `Kafka/0.11`
@@ -126,7 +142,7 @@ different definitions.
 The following extension is defined for the `definition` object in addition to
 the basic [attributes](../core/spec.md#attributes-and-extensions):
 
-#### `format` (Message format, definition)
+#### `format` (Metadata format, definition)
 
 Same as the [`format`](#format-message-format) attribute of the
 `definitionGroup` object.
@@ -186,9 +202,26 @@ Illustrating example:
   formats use a common schema for the constraints defined for their metadata
   headers, properties or attributes.
 - Constraints:
+  - REQUIRED if `format` is specified.
+- Examples:
+  - See [Metadata Formats](#metadata-formats)
+
+#### `binding` (Protocol binding, definition)
+
+- Same as the [`binding`](#binding-message-binding) attribute of the
+  `definitionGroup` object.
+
+#### `message` (Protocol binding)
+
+- Type: Object
+- Description: Describes the message constraints for the protocol message
+  binding. The content of the metadata property is defined by the protocol
+  message binding, but all bindings use a common schema model for the
+  constraints defined for their metadata headers, properties or attributes.
+- Constraints:
   - REQUIRED
 - Examples:
-  - See [Message Formats](#message-formats)
+  - See [Message Bindings](#message-bindings)
 
 #### `schemaformat`
 
@@ -236,19 +269,31 @@ Illustrating example:
   - Mutually exclusive with the `schema` attribute.
   - If present, `schemaformat` MUST be present.
 
-### Message Formats
+### Metadata Formats and Message Bindings
 
-This section defines the message formats that are directly supported by this
-specification. Message formats lean on a protocol-neutral metadata definition
-like CloudEvents or on the message model definition of a specific protocol like
-AMQP or MQTT or Kafka. A message format defines constraints for the fixed and
-variable headers/properties/attributes of the event format or protocol message
-model.
+This section defines the metadata formats and message bindings that are directly
+supported by this specification. 
 
-> Message format definitions might be specific to a particular client instance
-> and used to configure that client. Therefore, the message format definitions
-> allow for specifying very narrow constraints like the exact value of an Apache
-> Kafka record `key`.
+Metadata formats lean on a protocol-neutral metadata definition like
+CloudEvents. Message bindings lean on a message model definition of a specific
+protocol like AMQP or MQTT or Kafka.
+
+A definition can use either a metadata `format`, a message `binding`, or both.
+
+If a definition only uses a metadata format, any implicit protocol bindings
+defined by the format apply. For instance, a message definition that uses the
+"CloudEvents/1.0" format but no explicit `binding` implicitly applies to all
+protocols for which CloudEvents bindings exist, and using the respective
+protocol binding rules.
+
+If a definition uses both a metadata `format` and a message `binding`, the
+message binding rules apply over the metadata format rules. For instance, if a
+message definition uses the "CloudEvents/1.0" format and an "AMQP/1.0" binding,
+then the implicit protocol bindings of the "CloudEvents/1.0" format are
+overridden by the "AMQP/1.0" binding rules.
+
+If a definition uses only a message `binding`, only the metadata constraints
+defined by the message binding rules apply. 
 
 #### Common properties
 
@@ -331,6 +376,10 @@ current timestamp when creating a message.
   human-readable specification of the property.
 - Constraints:
   - OPTIONAL
+
+#### Metadata Formats
+
+This specification only defines one metadata format: "CloudEvents/1.0".
 
 ##### CloudEvents/1.0
 
@@ -421,12 +470,16 @@ CloudEvents base specification. The implied `datacontenttype` is
 For clarity of the definition, you MAY always declare all implied attribute
 properties explicitly, but they MUST conform with the rules above.
 
-### "HTTP/1.1", "HTTP/2", "HTTP/3"
+#### Message Bindings
 
-The "HTTP" format is used to define messages that are sent over an HTTP
-connection. The format is based on the [HTTP Message Format][HTTP Message Format] and is common across all version of HTTP.
+##### "HTTP/1.1", "HTTP/2", "HTTP/3" binding
 
-The [`metadata`](#metadata-message-metadata) object MAY contain several
+The "HTTP" binding is used to define messages that are sent over an HTTP
+connection. The binding is based on the
+[HTTP Message Format][HTTP Message Format] and is common across all version of
+HTTP.
+
+The [`message`](#message-protocol-binding) object MAY contain several
 properties:
 
 | Property  | Type          | Description                  |
@@ -460,8 +513,8 @@ The following example defines a message that is sent over HTTP/1.1:
 
 ```JSON
 {
-  "format": "HTTP/1.1",
-  "metadata": {
+  "binding": "HTTP/1.1",
+  "message": {
     "headers": [
       {
         "name": "Content-Type",
@@ -479,13 +532,13 @@ The following example defines a message that is sent over HTTP/1.1:
 }
 ```
 
-### "AMQP/1.0"
+##### "AMQP/1.0" binding
 
-The "AMQP/1.0" format is used to define messages that are sent over an
-[AMQP][AMQP 1.0] connection. The format is based on the default
+The "AMQP/1.0" binding is used to define messages that are sent over an
+[AMQP][AMQP 1.0] connection. The bindings is based on the default
 [AMQP 1.0 Message Format][AMQP 1.0 Message Format].
 
-The [`metadata`](#metadata-message-metadata) object MAY contain several
+The [`message`](#message-protocol-binding) object MAY contain several
 properties, each of which corresponds to a section of the AMQP 1.0 Message:
 
 | Property                 | Type | Description                                                                     |
@@ -511,8 +564,8 @@ definition:
 
 ```JSON
 {
-  "format": "AMQP/1.0",
-  "metadata": {
+  "binding": "AMQP/1.0",
+  "message": {
     "properties": {
       "message-id": {
         "required": true
@@ -540,7 +593,7 @@ definition:
 }
 ```
 
-#### `properties` (AMQP 1.0 Message Properties)
+##### `properties` (AMQP 1.0 Message Properties)
 
 The `properties` property is an object that contains the properties of the
 AMQP 1.0 [Message Properties][AMQP 1.0 Message Properties] section. The
@@ -561,7 +614,7 @@ following properties are defined, with type constraints:
 | `group-sequence`       | `integer`     | position of this message within its group                                        |
 | `reply-to-group-id`    | `uritemplate` | group-id to which the receiver of this message ought to send replies to          |
 
-#### `application-properties` (AMQP 1.0 Application Properties)
+##### `application-properties` (AMQP 1.0 Application Properties)
 
 The `application-properties` property is an object that contains the custom
 properties of the AMQP 1.0 [Application Properties][AMQP 1.0 Application Properties] section.
@@ -569,7 +622,7 @@ properties of the AMQP 1.0 [Application Properties][AMQP 1.0 Application Propert
 The names of the properties MUST be of type `symbol` and MUST be unique.
 The values of the properties MAY be of any permitted type.
 
-#### `message-annotations` (AMQP 1.0 Message Annotations)
+##### `message-annotations` (AMQP 1.0 Message Annotations)
 
 The `message-annotations` property is an object that contains the custom
 properties of the AMQP 1.0 [Message Annotations][AMQP 1.0 Message Annotations]
@@ -578,7 +631,7 @@ section.
 The names of the properties MUST be of type `symbol` and MUST be unique.
 The values of the properties MAY be of any permitted type.
 
-#### `delivery-annotations` (AMQP 1.0 Delivery Annotations)
+##### `delivery-annotations` (AMQP 1.0 Delivery Annotations)
 
 The `delivery-annotations` property is an object that contains the custom
 properties of the AMQP 1.0
@@ -587,7 +640,7 @@ properties of the AMQP 1.0
 The names of the properties MUST be of type `symbol` and MUST be unique.
 The values of the properties MAY be of any permitted type.
 
-##### `header` (AMQP 1.0 Message Header)
+###### `header` (AMQP 1.0 Message Header)
 
 The `header` property is an object that contains the properties of the
 AMQP 1.0 [Message Header][AMQP 1.0 Message Header] section. The
@@ -601,7 +654,7 @@ following properties are defined, with type constraints:
 | `first-acquirer` | `boolean` | indicates whether the message has not been acquired previously |
 | `delivery-count` | `integer` | number of prior unsuccessful delivery attempts                 |
 
-#### `footer` (AMQP 1.0 Message Footer)
+###### `footer` (AMQP 1.0 Message Footer)
 
 The `footer` property is an object that contains the custom properties of the
 AMQP 1.0 [Message Footer][AMQP 1.0 Message Footer] section.
@@ -609,13 +662,13 @@ AMQP 1.0 [Message Footer][AMQP 1.0 Message Footer] section.
 The names of the properties MUST be of type `symbol` and MUST be unique.
 The values of the properties MAY be of any permitted type.
 
-### "MQTT/3.1.1" and "MQTT/5.0"
+##### "MQTT/3.1.1" and "MQTT/5.0" bindings
 
-The "MQTT/3.1.1" and "MQTT/5.0" formats are used to define messages that are
+The "MQTT/3.1.1" and "MQTT/5.0" bindings are used to define messages that are
 sent over [MQTT 3.1.1][MQTT 3.1.1] or [MQTT 5.0][MQTT 5.0] connections. The
 format describes the [MQTT PUBLISH packet][MQTT 5.0] content.
 
-The [`metadata`](#metadata-message-metadata) object contains the elements of the
+The [`message`](#message-protocol-binding) object contains the elements of the
 MQTT PUBLISH packet directly, with the `user-properties` element corresponding
 to the application properties collection of other protocols.
 
@@ -643,14 +696,14 @@ user-properties MAY contain placeholders using the [RFC6570][RFC6570] Level 1
 URI Template syntax. When the same placeholder is used in multiple properties,
 the value of the placeholder is assumed to be identical.
 
-The following example shows a message with the "MQTT/5.0" format, asking for
+The following example shows a message with the "MQTT/5.0" binding, asking for
 QoS 1 delivery, with a topic name of "mytopic", and a user property of
 "my-application-property" with a value of "my-application-property-value":
 
 ```JSON
 {
-  "format": "MQTT/5.0",
-  "metadata": {
+  "binding": "MQTT/5.0",
+  "message": {
     "qos": {
       "value": 1
     },
@@ -670,17 +723,18 @@ QoS 1 delivery, with a topic name of "mytopic", and a user property of
 }
 ```
 
-### "Kafka/0.11" format
+### "Kafka" binding
 
-The "Kafka" format is used to define messages that are sent over [Apache
+The "Kafka" binding is used to define messages that are sent over [Apache
 Kafka][Apache Kafka] connections. The version number reflects the last version
 in which the record structure was changed in the Apache Kafka project, not the
 current version. If the version number is omitted, the latest version is
 assumed.
 
-The [`metadata`](#metadata-message-metadata) object contains the common elements
-of the Kafka [producer][Apache Kafka producer] and [consumer][Apache Kafka consumer] records, with the `headers` element corresponding to the application
-properties collection of other protocols.
+The [`message`](#message-protocol-binding) object contains the common elements
+of the Kafka [producer][Apache Kafka producer] and
+[consumer][Apache Kafka consumer] records, with the `headers` element
+corresponding to the application properties collection of other protocols.
 
 The following properties are defined:
 
@@ -701,8 +755,8 @@ Example:
 
 ```JSON
 {
-  "format": "Kafka/0.11",
-  "metadata": {
+  "binding": "Kafka",
+  "message": {
     "topic": {
       "value": "mytopic"
     },

--- a/tools/schema-generator.py
+++ b/tools/schema-generator.py
@@ -302,7 +302,8 @@ def generate_json_schema(model_definition, for_openapi=False) -> dict:
 
                 if attr_name in resource_schema["properties"]:
                     resource_schema["properties"].pop(attr_name)
-                    resource_schema["required"].remove(attr_name)
+                    if "required" in resource_schema and attr_name in resource_schema["required"]:
+                        resource_schema["required"].remove(attr_name)
 
                 one_of = []
                 for condition_value, condition_props in attr_props["ifValue"].items():


### PR DESCRIPTION
Signed-off-by: Clemens Vasters <clemens@vasters.com>

Splits definitions to allow either/or/both of "format"/"metadata" (CloudEvents) and "binding"/"message" (HTTP, AMQP, MQTT, Kafka)