### PR TITLE
Week of Jan 30th edits

### DIFF
--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -104,7 +104,7 @@ this form:
 
           # "kafka" protocol options
           "topic": "STRING", ?
-          "acks": INTEGER,                               # default: 1
+          "acks": INTEGER, ?                             # default: 1
           "key": "STRING", ?
           "partition": INTEGER, ?
           "consumer-group": "STRING" ?
@@ -187,7 +187,8 @@ The following attributes are defined for the `endpoint` type:
 
 - Type: String (Enum: `subscriber`, `consumer`, `producer`)
 - Description: The `usage` attribute is a string that indicates the intended
-  usage of the endpoint by communicating parties.
+  usage of the endpoint by communicating parties. In other words, the role
+  of a client talking with the endpoint.
 
   Each of these parties will have a different perspective on an endpoint. For
   instance, a `producer` endpoint is seen as a "target" by the originator of
@@ -218,7 +219,7 @@ The following attributes are defined for the `endpoint` type:
     - Application which manages subscriptions for delivery of messages to the
       target application. This might be a message broker subscription manager.
 
-  - `consumer`: The endpoint offers messages being consumed from it.
+  - `consumer`: The endpoint offers messages being consumed (pulled) from it.
 
     Some perspectives that might exist on a consumer endpoint:
     - Message store or source which makes messages available for consumption;
@@ -227,7 +228,7 @@ The following attributes are defined for the `endpoint` type:
       forwards them to the target endpoint.
     - Application which consumes messages
 
-  - `producer`: The endpoint offers messages being produces (sent) to it.
+  - `producer`: The endpoint offers messages being produced (pushed) to it.
 
     Some perspectives might exist on a producer endpoint:
     - Application from which messages originate

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -230,29 +230,23 @@ document references.
 Any new schema Version that is added to a schema definition MUST be backwards
 compatible with all previous Versions of the schema, meaning that a consumer
 using the new schema MUST be able to understand data encoded using a prior
-Version of the schema. If a new Version introduces a breaking change, it MUST be
-registered as a new schema with a new name.
+Version of the schema. If a new Version introduces a breaking change, it MUST
+be registered as a new schema with a new name.
 
-When semantic versioning is used in a solution, it is RECOMMENDED to include a
-major version identifier in the schema `id`, like `"com.example.event.v1"` or
-`"com.example.event.2024-02"`, so that incompatible, but historically related
-schemas can be more easily identified by users and developers. The schema
-Version identifier then functions as the semantic minor version identifier.
-
-Implementations of this specification MUST use the xRegistry default algorithm
-for generating new `id` values and for determining which is the latest Version.
-See [Version IDs](../core/spec.md#version-ids) for more information, but in
-summary it means:
+Implementations of this specification SHOULD use the xRegistry default
+algorithm for generating new `id` values and for determining which is the
+latest Version. See [Version IDs](../core/spec.md#version-ids) for more
+information, but in summary it means:
 - `id`s are unsigned integers starting with `1`
 - they monotomically increase by `1` with each new Version
 - the latest is the Version with the lexically largest `id` value after all
   Version's `id`s have been left-padded with spaces to the same length
 
-When retrieving a schema document without qualifying the version, the latest
-version of the schema is returned, see [retrieving a
-resource](../core/spec.md#retrieving-a-resource). The latest version is the
-lexically greatest version number, whereby all Version ids MUST be left-padded
-with spaces to the same length before being compared.
+When semantic versioning is used in a solution, it is RECOMMENDED to include a
+major version identifier in the schema `id`, like `"com.example.event.v1"` or
+`"com.example.event.2024-02"`, so that incompatible, but historically related
+schemas can be more easily identified by users and developers. The schema
+Version `id` then functions as the semantic minor version identifier.
 
 The following extensions are defined for the `schema` object in addition to the
 core xRegistry Resource


### PR DESCRIPTION
- try to add more clarity around Endpoint.usage property
- make default version id algorithm optional for schemas spec
- clean-up text in schema spec w.r.t. versioning
- add 'readonly' property to model attributes
- "*" attributes can't have "ifvalue"s
- require that "ifvalue" attributes are unique within a section, across
  named attributes and active "ifvalue" sections
