### PR TITLE
Week of Feb 5th edits

### DIFF
--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -347,7 +347,7 @@
                                     "type": "uri"
                                 }
                             },
-                            "strict": {
+                            "deployed": {
                                 "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint.",
                                 "type": "boolean",
                                 "required": false

--- a/message/spec.md
+++ b/message/spec.md
@@ -53,7 +53,7 @@ this form:
       "description": "STRING", ?
       "documentation": "URL", ?
       "labels": { "STRING": "STRING" * }, ?
-      "format": "STRING", ?
+      "origin": "STRING", ?
       "createdby": "STRING", ?
       "createdon": "TIME", ?
       "modifiedby": "STRING", ?
@@ -75,15 +75,15 @@ this form:
           "description": "STRING", ?
           "documentation": "URL", ?
           "labels": { "STRING": "STRING" * }, ?
-          "format": "STRING", ?
+          "origin": "STRING", ?
           "createdby": "STRING", ?
           "createdon": "TIME", ?
           "modifiedby": "STRING", ?
           "modifiedon": "TIME", ?
 
-          "basemessageurl": "URL", ?        # Message attributes
+          "basemessageurl": "URL", ?           # Message attributes
 
-          "format": "STRING",                  # or "binding"
+          "format": "STRING", ?                # or "binding"
           "metadata": {
             "required": BOOLEAN, ?
             "description": "STRING", ?
@@ -528,10 +528,11 @@ The following rules apply to the attribute declarations:
   absent.
 - The `type` of the property definition defaults to the CloudEvents type
   definition for the attribute, if any. The `type` of an attribute MAY be
-  modified. For instance, the `source` type `urireference` MAY be changed to
+  modified be to further constrainted. For instance, the `source` type
+  `urireference` MAY be changed to
   `uritemplate` or the `subject` type `string` MAY be constrained to a
-  `urireference` or `integer`. If no CloudEvents type definition exists, the
-  type defaults to `string`.
+  `urireference` or `stringified integer`. If no CloudEvents type definition
+  exists, the type defaults to `string`.
 
 The values of all `string` and `uritemplate`-typed attributes MAY contain
 placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the

--- a/schema/model.json
+++ b/schema/model.json
@@ -6,31 +6,31 @@
     "schemagroups": {
       "singular": "schemagroup",
       "plural": "schemagroups",
+
+      "attributes": {
+        "*": {
+          "name": "*",
+          "type": "any"
+        }
+      },
+
       "resources": {
         "schemas": {
           "singular": "schema",
           "plural": "schemas",
           "versions": 0,
+
           "attributes": {
             "format": {
-              "description": "Schema format identifier for this schema version.",
+              "name": "format",
               "type": "string",
-              "required": true
+              "description": "Schema format identifier for this schema version",
+              "clientrequired": true,
+              "serverrequired": true
             },
-            "schemaobject": {
-              "description": "Inlined schema document object",
-              "type": "object",
-              "required": false
-            },
-            "schema": {
-              "description": "Inlined schema document string",
-              "type": "string",
-              "required": false
-            },
-            "schemaurl": {
-              "description": "Inlined schema document string",
-              "type": "uri",
-              "required": false
+            "*": {
+              "name": "*",
+              "type": "any"
             }
           }
         }

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -48,7 +48,7 @@ this form:
       "description": "STRING", ?
       "documentation": "URL", ?
       "labels": { "STRING": "STRING" * }, ?
-      "format": "STRING", ?
+      "origin": "STRING", ?
       "createdby": "STRING", ?
       "createdon": "TIME", ?
       "modifiedby": "STRING", ?
@@ -67,11 +67,13 @@ this form:
           "description": "STRING", ?
           "documentation": "URL", ?
           "labels": { "STRING": "STRING" * }, ?
-          "format": "STRING",                      # Notice it is mandatory
+          "origin": "STRING", ?
           "createdby": "STRING", ?
           "createdon": "TIME", ?
           "modifiedby": "STRING", ?
           "modifiedon": "TIME", ?
+
+          "format": "STRING",                      # Notice it is mandatory
 
           "schemaobject": { ... }, ?               # TODO - check this
           "schema": "STRING", ?
@@ -160,16 +162,20 @@ detail below, is as follows:
     {
       "singular": "schemagroup",
       "plural": "schemagroups",
+
       "resources": [
         {
           "singular": "schema",
           "plural": "schemas",
           "versions": 0,
+
           "attributes": {
             "format": {
-              "description": "Schema format identifier",
-              "type": "STRING",
-              "required": true
+              "name": "format",
+              "type": "string",
+              "description": "Schema format identifier for this schema version",
+              "clientrequired": true,
+              "serverrequired": true
             }
           }
         }
@@ -227,10 +233,10 @@ The type of the resource is `schema`. Any single `schema` is a container for
 one or more `Versions`, which hold the concrete schema documents or schema
 document references.
 
-Any new schema Version that is added to a schema definition MUST be backwards
+Any new schema Version that is added to a schema definition SHOULD be backwards
 compatible with all previous Versions of the schema, meaning that a consumer
-using the new schema MUST be able to understand data encoded using a prior
-Version of the schema. If a new Version introduces a breaking change, it MUST
+using the new schema would be able to understand data encoded using a prior
+Version of the schema. If a new Version introduces a breaking change, it SHOULD
 be registered as a new schema with a new name.
 
 Implementations of this specification SHOULD use the xRegistry default
@@ -255,8 +261,7 @@ core xRegistry Resource
 #### `format`
 
 - Type: String
-- Description: This is a modified version of the xRegistry `format` attribute.
-  Identifies the schema format. In absence of formal media-type
+- Description: Identifies the schema format. In absence of formal media-type
   definitions for several important schema formats, we define a convention here
   to reference schema formats by name and version as `{NAME}/{VERSION}`. This
   specification defines a set of common [schema format names](#schema-formats)

--- a/tools/verify.py
+++ b/tools/verify.py
@@ -48,8 +48,9 @@ _MARKDOWN_BOOKMARK_PATTERN = re.compile(r"(?<![\\])\[[^\?=].+?\]\[.+?\]", re.IGN
 _PHRASES_THAT_MUST_BE_CAPITALIZED_PATTERN = re.compile(
     r"(?<!`)(MUST(\s+NOT)?|"
     # ignore the "required" in the jsonschema of the json-format.md
+	# and ignore `required` cases (attribute name is `required`)
 	# and ignore .required cases (attribute name is "required")
-    r'(?<![.`"])REQUIRED(?!")|'
+    r'(?<![.`"])REQUIRED(?![`"])|'
     r"(?<!mar)SHALL(\s+NOT)?|"  # ignore the word "marshall"
     r"(?<!`)SHOULD(\s+NOT)?|"
     r"(?<!`)RECOMMENDED|"


### PR DESCRIPTION
- Add a "readonly" attribute to Resources in the model
- rename "strict" to "deployed" in Endpoint spec
- removed all "-" from attribute names in Endpoint spec
- soften Schema spec to say schema versions SHOULD be backwards compatible,
  not MUST be
- s/required/clientrequired/ & add "serverrequired" for model attributes
- maps must be specified in their entirety when appearing as HTTP headers
- move "origin" to Core spec
- move "format" from Core to Endpoints, Message and Schema specs
- clarify when self/latestversionurl have ?meta (or not)
- clean-up some of the spec's `model.json` files