### PR TITLE
Week of Feb 12 changes

### DIFF
--- a/core/primer.md
+++ b/core/primer.md
@@ -15,4 +15,7 @@ Possible future topics to cover:
 - if/when we support serializing in non-json formats, we'll need to define
   the serialization rules. E.g. when attributes appear as xml attributes vs
   nested elements
-
+- when hasdocument=false, we might need to talk about when ?meta appears on the
+  various URLs (self, latestversionurl, location,...). Right now its presence
+  will match what was used in the request (either explicitly or implicity).
+  So GET resource?meta or GET group?inline both ask for metadata

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -1,366 +1,449 @@
 {
-    "schemas": [
-        "json-schema/draft-07"
-    ],
-    "groups": {
-        "endpoints": {
-            "singular": "endpoint",
-            "plural": "endpoints",
+  "schemas": [
+    "json-schema/draft-07"
+  ],
+  "groups": {
+    "endpoints": {
+      "singular": "endpoint",
+      "plural": "endpoints",
+
+      "attributes": {
+        "usage": {
+          "name": "usage",
+          "type": "string",
+          "description": "Client's expected usage of this endpoint",
+          "enum": ["subscriber", "consumer", "producer" ],
+          "strict": true,
+          "clientrequired": true,
+          "serverrequired": true
+        },
+        "format": {
+          "name": "format",
+          "type": "string",
+          "description": "Endpoint metadata format identifier. If set, all definitions MUST use this format value",
+          "clientrequired": false,
+          "serverrequired": false
+        },
+        "binding": {
+          "name": "binding",
+          "type": "string",
+          "description": "Endpoint message binding identifier. If set, all definitions MUST use this binding value",
+          "clientrequired": false,
+          "serverrequired": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "string",
+          "description": "tbd"
+        },
+        "deprecated": {
+          "name": "deprecated",
+          "type": "object",
+          "description": "tbd",
+          "item": {
             "attributes": {
-                "format": {
-                    "description": "Endpoint metadata format identifier. If set, all definitions MUST use this format value.",
-                    "type": "string",
-                    "required": false
-                },
-                "binding": {
-                    "description": "Endpoint message binding identifier. If set, all definitions MUST use this binding value.",
-                    "type": "string",
-                    "required": false
-                },
-                "config": {
-                    "description": "Configuration information for this endpoint",
-                    "type": "object",
-                    "item": {
-                        "attributes": {
-                            "authorization": {
-                                "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration.",
-                                "type": "array",
-                                "required": false,
-                                "item": {
-                                    "type": "object",
-                                    "item": {
-                                        "attributes": {
-                                            "type": {
-                                                "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined.",
-                                                "type": "string",
-                                                "required": true
-                                            },
-                                            "resourceuri": {
-                                                "description": "The resource uri for which authorization shall be granted (if applicable)",
-                                                "type": "string",
-                                                "required": false
-                                            },
-                                            "authorityuri": {
-                                                "description": "The authority uri where authorization shall be requested (if applicable)",
-                                                "type": "string",
-                                                "required": false
-                                            },
-                                            "grant_types": {
-                                                "description": "The grant types that can be requested (if applicable)",
-                                                "type": "array",
-                                                "required": false,
-                                                "item": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "protocol": {
-                                "description": "endpoint protocol identifier",
-                                "type": "string",
-                                "required": true,
-                                "ifvalue": {
-                                    "AMQP/1.0": {
-                                        "siblingattributes": {
-                                            "options": {
-                                                "description": "AMQP 1.0 connection options",
-                                                "type": "object",
-                                                "item": {
-                                                    "attributes": {
-                                                        "node": {
-                                                            "description": "The AMQP node name. Commonly the name of a queue or a topic.",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "durable": {
-                                                            "description": "The AMQP durable flag. Whether the node is durable or transient.",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        },
-                                                        "link_properties": {
-                                                            "description": "An optional map of AMQP link properties to use with the endpoint",
-                                                            "type": "map",
-                                                            "required": false,
-                                                            "item": {
-                                                                "type": "string",
-                                                                "description": "Link property value"
-                                                            }
-                                                        },
-                                                        "connection_properties": {
-                                                            "description": "An optional map of AMQP connection properties to use with the endpoint",
-                                                            "type": "map",
-                                                            "required": false,
-                                                            "item": {
-                                                                "description": "Connection property value",
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "distribution_mode": {
-                                                            "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message.",
-                                                            "type": "string",
-                                                            "required": false,
-                                                            "values": [
-                                                                "move",
-                                                                "copy"
-                                                            ]
-                                                        },
-                                                        "*": {
-                                                            "description": "Further options to configure the AMQP 1.0 client",
-                                                            "type": "string",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "MQTT/5.0": {
-                                        "siblingattributes": {
-                                            "options": {
-                                                "description": "MQTT 5.0 connection options",
-                                                "type": "object",
-                                                "item": {
-                                                    "attributes": {
-                                                        "topic": {
-                                                            "description": "The MQTT topic path",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "qos": {
-                                                            "description": "The MQTT QoS level. May be 0, 1, or 2.",
-                                                            "type": "integer",
-                                                            "required": false
-                                                        },
-                                                        "retain": {
-                                                            "description": "The MQTT retain flag to use for publishers on ths endpoint",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        },
-                                                        "clean_session": {
-                                                            "description": "The MQTT clean session flag to use for publishers on this endpoint",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        },
-                                                        "will_topic": {
-                                                            "description": "The MQTT will topic to configure for publishers on this endpoint",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "will_message": {
-                                                            "description": "The MQTT will message definition to configure for publishers on this endpoint",
-                                                            "type": "uri",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "MQTT/3.1.1": {
-                                        "siblingattributes": {
-                                            "options": {
-                                                "description": "MQTT 3.1.1 connection options",
-                                                "type": "object",
-                                                "item": {
-                                                    "attributes": {
-                                                        "topic": {
-                                                            "description": "MQTT topic path",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "qos": {
-                                                            "description": "The MQTT QoS levelö. May be 0, 1, or 2.",
-                                                            "type": "integer",
-                                                            "required": false
-                                                        },
-                                                        "retain": {
-                                                            "description": "The MQTT retain flag to use for publishers on ths endpoint",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        },
-                                                        "clean_session": {
-                                                            "description": "The MQTT clean session flag to use for publishers on this endpoint",
-                                                            "type": "boolean",
-                                                            "required": false
-                                                        },
-                                                        "will_topic": {
-                                                            "description": "The MQTT will topic to configure for publishers on this endpoint",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "will_message": {
-                                                            "description": "The MQTT will message definition to configure for publishers on this endpoint",
-                                                            "type": "uri",
-                                                            "required": false
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "HTTP": {
-                                        "siblingattributes": {
-                                            "options": {
-                                                "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions.",
-                                                "type": "object",
-                                                "item": {
-                                                    "attributes": {
-                                                        "method": {
-                                                            "description": "The HTTP method name",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "headers": {
-                                                            "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive.",
-                                                            "type": "array",
-                                                            "required": false,
-                                                            "item": {
-                                                                "type": "object",
-                                                                "item": {
-                                                                    "attributes": {
-                                                                        "name": {
-                                                                            "description": "HTTP header name",
-                                                                            "type": "string",
-                                                                            "required": true
-                                                                        },
-                                                                        "value": {
-                                                                            "description": "HTTP header value",
-                                                                            "type": "string",
-                                                                            "required": true
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        },
-                                                        "query": {
-                                                            "description": "HTTP query parameters",
-                                                            "type": "array",
-                                                            "required": false,
-                                                            "item": {
-                                                                "type": "object",
-                                                                "item": {
-                                                                    "attributes": {
-                                                                        "name": {
-                                                                            "description": "The HTTP query parameter name",
-                                                                            "type": "string",
-                                                                            "required": true
-                                                                        },
-                                                                        "value": {
-                                                                            "description": "The HTTP query parameter value",
-                                                                            "type": "string",
-                                                                            "required": true
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "KAFKA": {
-                                        "siblingattributes": {
-                                            "options": {
-                                                "description": "Apache Kafka options",
-                                                "type": "object",
-                                                "item": {
-                                                    "attributes": {
-                                                        "topic": {
-                                                            "description": "Apache Kafka topic name",
-                                                            "type": "string",
-                                                            "required": true
-                                                        },
-                                                        "acks": {
-                                                            "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1.",
-                                                            "type": "integer",
-                                                            "required": false
-                                                        },
-                                                        "key": {
-                                                            "description": "The Apache Kafka record key",
-                                                            "type": "binary",
-                                                            "required": false
-                                                        },
-                                                        "consumergroup": {
-                                                            "description": "The Apache Kafka consumer group name to use for consumers",
-                                                            "type": "string",
-                                                            "required": false
-                                                        },
-                                                        "partition": {
-                                                            "description": "Optional. The Apache Kafka partition number to use when writing to or receiving from Apache Kafka",
-                                                            "type": "integer",
-                                                            "required": false
-                                                        },
-                                                        "headers": {
-                                                            "description": "The Apache Kafka headers for publishers on this endpoint",
-                                                            "type": "map",
-                                                            "required": false,
-                                                            "item": {
-                                                                "type": "object",
-                                                                "item": {
-                                                                    "attributes": {
-                                                                        "name": {
-                                                                            "description": "The Apache Kafka header name",
-                                                                            "type": "string",
-                                                                            "required": true
-                                                                        },
-                                                                        "value": {
-                                                                            "description": "The Apache Kafka header value",
-                                                                            "type": "string",
-                                                                            "required": true
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "NATS": {
-                                        "siblingattributes": {
-                                            "options": {
-                                                "description": "NATS options",
-                                                "type": "object",
-                                                "item": {
-                                                    "attributes": {
-                                                        "subject": {
-                                                            "description": "The NATS subject",
-                                                            "type": "string",
-                                                            "required": true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "endpoints": {
-                                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific.",
-                                "type": "array",
-                                "required": false,
-                                "item": {
-                                    "type": "uri"
-                                }
-                            },
-                            "deployed": {
-                                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint.",
-                                "type": "boolean",
-                                "required": false
-                            }
-                        }
-                    }
-                }
-            },
-            "resources": {
-                "definitions": {
-                    "uri": "../message/model.json#/groups/definitiongroups/resources/definitions"
-                }
+              "effective": {
+                "name": "effective",
+                "type": "timestamp",
+                "description": "tbd"
+              },
+              "removal": {
+                "name": "removal",
+                "type": "timestamp",
+                "description": "tbd"
+              },
+              "alternative": {
+                "name": "alternative",
+                "type": "url",
+                "description": "tbd"
+              },
+              "docs": {
+                "name": "docs",
+                "type": "url",
+                "description": "tbd"
+              },
+              "*": {
+                "name": "*",
+                "type": "any"
+              }
             }
+          }
+        },
+        "config": {
+          "name": "config",
+          "type": "object",
+          "description": "Configuration information for this endpoint",
+          "item": {
+            "attributes": {
+              "protocol": {
+                "name": "protocol",
+                "type": "string",
+                "description": "endpoint protocol identifier",
+                "clientrequired": true,
+                "serverrequired": true,
+
+                "ifvalue": {
+                  "AMQP/1.0": {
+                    "siblingattributes": {
+                      "options": {
+                        "name": "options",
+                        "type": "object",
+                        "description": "AMQP 1.0 connection options",
+                        "item": {
+                          "attributes": {
+                            "node": {
+                              "name": "node",
+                              "type": "string",
+                              "description": "The AMQP node name. Commonly the name of a queue or a topic"
+                            },
+                            "durable": {
+                              "name": "durable",
+                              "type": "boolean",
+                              "description": "The AMQP durable flag. Whether the node is durable or transient"
+                            },
+                            "linkproperties": {
+                              "name": "linkproperties",
+                              "type": "map",
+                              "description": "An optional map of AMQP link properties to use with the endpoint",
+                              "item": {
+                                "type": "string",
+                                "description": "Link property value"
+                              }
+                            },
+                            "connectionproperties": {
+                              "name": "connectionproperties",
+                              "type": "map",
+                              "description": "An optional map of AMQP connection properties to use with the endpoint",
+                              "item": {
+                                "description": "Connection property value",
+                                "type": "string"
+                              }
+                            },
+                            "distributionmode": {
+                              "name": "distributionmode",
+                              "type": "string",
+                              "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
+                              "enum": [
+                                "move",
+                                "copy"
+                              ]
+                            },
+                            "*": {
+                              "name": "*",
+                              "type": "any"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "MQTT/5.0": {
+                    "siblingattributes": {
+                      "options": {
+                        "name": "options",
+                        "type": "object",
+                        "description": "MQTT 5.0 connection options",
+                        "item": {
+                          "attributes": {
+                            "topic": {
+                              "name": "topic",
+                              "type": "string",
+                              "description": "The MQTT topic path"
+                            },
+                            "qos": {
+                              "name": "qos",
+                              "type": "uinteger",
+                              "description": "The MQTT QoS level. May be 0, 1, or 2"
+                            },
+                            "retain": {
+                              "name": "retain",
+                              "type": "boolean",
+                              "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                            },
+                            "cleansession": {
+                              "name": "cleansession",
+                              "type": "boolean",
+                              "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                            },
+                            "willtopic": {
+                              "name": "willtopic",
+                              "type": "string",
+                              "description": "The MQTT will topic to configure for publishers on this endpoint"
+                            },
+                            "willmessage": {
+                              "name": "willmessage",
+                              "type": "string",
+                              "description": "The MQTT will message definition to configure for publishers on this endpoint"
+                            },
+                            "*": {
+                              "name": "*",
+                              "type" "any"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "MQTT/3.1.1": {
+                    "siblingattributes": {
+                      "options": {
+                        "name": "options",
+                        "type": "object",
+                        "description": "MQTT 3.1.1 connection options",
+                        "item": {
+                          "attributes": {
+                            "topic": {
+                              "name": "topic",
+                              "type": "string",
+                              "description": "MQTT topic path"
+                            },
+                            "qos": {
+                              "name": "qos",
+                              "type": "uinteger",
+                              "description": "The MQTT QoS levelö. May be 0, 1, or 2"
+                            },
+                            "retain": {
+                              "name": "retain",
+                              "type": "boolean",
+                              "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                            },
+                            "cleansession": {
+                              "name": "cleansession",
+                              "type": "boolean",
+                              "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                            },
+                            "willtopic": {
+                              "name": "willtopic",
+                              "type": "string",
+                              "description": "The MQTT will topic to configure for publishers on this endpoint"
+                            },
+                            "willmessage": {
+                              "name": "willmessage",
+                              "type": "string",
+                              "description": "The MQTT will message definition to configure for publishers on this endpoint"
+                            },
+                            "*": {
+                              "name": "*",
+                              "type": "any"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "HTTP": {
+                    "siblingattributes": {
+                      "options": {
+                        "name": "options",
+                        "type": "object",
+                        "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions",
+                        "item": {
+                          "attributes": {
+                            "method": {
+                              "name": "method",
+                              "type": "string",
+                              "description": "The HTTP method name"
+                            },
+                            "headers": {
+                              "name": "headers",
+                              "type": "array",
+                              "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive",
+                              "item": {
+                                "type": "object",
+                                "attributes": {
+                                  "name": {
+                                    "name": "name",
+                                    "type": "string",
+                                    "description": "HTTP header name",
+                                    "clientrequired": true,
+                                    "serverrequired": true
+                                  },
+                                  "value": {
+                                    "name": "value",
+                                    "type": "string",
+                                    "description": "HTTP header value",
+                                    "clientrequired": true,
+                                    "serverrequired": true
+                                  }
+                                }
+                              }
+                            },
+                            "query": {
+                              "name": "query",
+                              "type": "map",
+                              "description": "HTTP query parameters",
+                              "item": {
+                                "type": "string"
+                              }
+                            },
+                            "*": {
+                              "name": "*",
+                              "type": "any"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "KAFKA": {
+                    "siblingattributes": {
+                      "options": {
+                        "name": "options",
+                        "type": "object",
+                        "description": "Apache Kafka options",
+                        "item": {
+                          "attributes": {
+                            "topic": {
+                              "name": "topic",
+                              "type": "string",
+                              "description": "Apache Kafka topic name",
+                              "clientrequired": true,
+                              "cserverequired": true
+                            },
+                            "acks": {
+                              "name": "acks",
+                              "type": "integer",
+                              "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                            },
+                            "key": {
+                              "name": "key",
+                              "type": "string",
+                              "description": "The Apache Kafka record key"
+                            },
+                            "partition": {
+                              "name": "partition",
+                              "type": "integer",
+                              "description": "The Apache Kafka partition number to use when writing to or receiving from Apache Kafka"
+                            },
+                            "consumergroup": {
+                              "name": "consumergroup",
+                              "type": "string",
+                              "description": "The Apache Kafka consumer group name to use for consumers"
+                            },
+                            "headers": {
+                              "name": "headers",
+                              "type": "map",
+                              "description": "The Apache Kafka headers for publishers on this endpoint",
+                              "item": {
+                                "type": "string"
+                              }
+                            },
+                            "*": {
+                              "name": "*",
+                              "type": "any"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "NATS": {
+                    "siblingattributes": {
+                      "options": {
+                        "name": "options",
+                        "type": "object",
+                        "description": "NATS options",
+                        "item": {
+                          "attributes": {
+                            "subject": {
+                              "name": "subject",
+                              "type": "string",
+                              "description": "The NATS subject",
+                              "clientrequired": true,
+                              "serverrequired": true
+                            },
+                            "*": {
+                              "name": "*",
+                              "type": "any"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "endpoints": {
+                "name": "endpoints",
+                "type": "array",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "item": {
+                  "attributes": {
+                    "uri": {
+                      "name": "uri",
+                      "type": "uri",
+                      "description": "Network accessible location",
+                      "clientrequired": true,
+                      "serverrequired": true
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }
+              },
+              "authorization": {
+                "name": "authorization",
+                "type": "array",
+                "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                "item": {
+                  "type": "object",
+                  "attributes": {
+                    "type": {
+                      "name": "type",
+                      "type": "string",
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                      "clientrequired": true,
+                      "serverrequired": true
+                    },
+                    "resourceurl": {
+                      "name": "resourceurl",
+                      "type": "url",
+                      "description": "The resource uri for which authorization shall be granted (if applicable)"
+                    },
+                    "authorityuri": {
+                      "name": "authorityuri",
+                      "type": "uri",
+                      "description": "The authority uri where authorization shall be requested (if applicable)"
+                    },
+                    "granttypes": {
+                      "name": "granttypes",
+                      "type": "array",
+                      "description": "The grant types that can be requested (if applicable)",
+                      "item": {
+                        "type": "string"
+                      }
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }
+              },
+              "deployed": {
+                "name": "deployed",
+                "type": "boolean",
+                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+              },
+              "*": {
+                "name": "*",
+                "type": "any"
+              }
+            }
+          }
+        },
+        "*": {
+          "name": "*",
+          "type": "any"
         }
+      },
+      "resources": {
+        "definitions": {
+          # See ../message/model.json#/groups/definitiongroups/resources/definitions
+        }
+      }
     }
+  }
 }

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -56,6 +56,7 @@ this form:
 
       "usage": "STRING",                        # subscriber, consumer, producer
       "format": "STRING", ?
+      "binding": "STRING", ?
       "channel": "STRING", ?
       "deprecated": {
         "effective": "TIMESTAMP", ?
@@ -82,34 +83,43 @@ this form:
         "options": {
           "STRING": JSON-VALUE *
 
-          # "http" protocol options
+          # "HTTP" protocol options
           "method": "STRING", ?                          # default: POST
-          "headers": { { "name": "STRING", "value": "STRING" } * }, ?
+          "headers": [ { "name": "STRING", "value": "STRING" } * ], ?
           "query": { "STRING": "STRING" * } ?
 
-          # "amqp" protocol options
+          # "AMQP/1.0" protocol options
           "node": "STRING", ?
           "durable": BOOLEAN, ?                          # default: false
           "linkproperties": { "STRING": "STRING" * }, ?
-          "connection-properties": { "STRING": "STRING" * }, ?
-          "distribution-mode": "move" | "copy" ?         # default: "move"
+          "connectionproperties": { "STRING": "STRING" * }, ?
+          "distributionmode": "move" | "copy" ?          # default: "move"
 
-          # "mqtt" protocol options
+          # "MQTT/3.1.1" protocol options
           "topic": "STRING", ?
           "qos": UINTEGER, ?                             # default: 0
           "retrain": BOOLEAN, ?                          # default: false
-          "cleansession": BOOLEAN, ?                    # default: true
+          "cleansession": BOOLEAN, ?                     # default: true
           "willtopic": "STRING", ?
           "willmessage": "STRING" ?
 
-          # "kafka" protocol options
+          # "MQTT/5.0" protocol options
+          "topic": "STRING", ?
+          "qos": UINTEGER, ?                             # default: 0
+          "retrain": BOOLEAN, ?                          # default: false
+          "cleansession": BOOLEAN, ?                     # default: true
+          "willtopic": "STRING", ?
+          "willmessage": "STRING" ?
+
+          # "KAFKA" protocol options
           "topic": "STRING", ?
           "acks": INTEGER, ?                             # default: 1
           "key": "STRING", ?
           "partition": INTEGER, ?
-          "consumergroup": "STRING" ?
+          "consumergroup": "STRING", ?
+          "headers": { "STRING": "STRING" * } ?
 
-          # "nats" protocol options
+          # "NATS" protocol options
           "subject": "STRING" ?
         } ?
       }, ?
@@ -256,8 +266,8 @@ The following attributes are defined for the `endpoint` type:
   provides a mechanism by which it can be determined without examination of
   the Resource at all
 - Constraints:
-  - REQUIRED
-  - if present, MUST be a non-empty string of the form `SPEC[/VERSION]`,
+  - At least one of `format` and `binding` MUST be specified
+  - MUST be a non-empty string of the form `SPEC[/VERSION]`,
     where `SPEC` is the non-empty string name of the specification that
     defines the Resource. An OPTIONAL `VERSION` value SHOULD be included if
     there are multiple versions of the specification available
@@ -276,6 +286,27 @@ The following attributes are defined for the `endpoint` type:
 - Examples:
   - `CloudEvents/1.0`
   - `MQTT`
+
+### `binding`
+
+- Type: String
+- Description: Identifies a transport protocol message binding. Bindings are
+  referenced by name and version as `{NAME}/{VERSION}`. The Messaging
+  specification defines a set of common
+  [message binding names](../message/spec.md#message-bindings) that MUST
+  be used for the given protocols, but applications MAY define extensions for
+  other protocol bindings on their own. All messages inside an Endpoint MUST
+  use this same binding
+- Constraints:
+  - At least one of `format` and `binding` MUST be specified
+  - if present, MUST be a non-empty string
+  - if present, MUST follow the naming convention `{NAME}/{VERSION}`,
+    whereby `{NAME}` is the name of the protocol and `{VERSION}` is the
+    version of protocol.
+- Examples:
+  - `MQTT/3.1.1`
+  - `AMQP/1.0`
+  - `Kafka/0.11`
 
 ### `channel`
 

--- a/message/model.json
+++ b/message/model.json
@@ -1,878 +1,884 @@
 {
-    "schemas": [
-        "json-schema/draft-07"
-    ],
-    "groups": {
-        "definitiongroups": {
-            "singular": "definitiongroup",
-            "plural": "definitiongroups",
-            "attributes": {
-                "format": {
-                    "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted.",
-                    "type": "string",
-                    "required": false
-                },
-                "binding": {
-                    "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted.",
-                    "type": "string",
-                    "required": false
-                }
-            },
-            "resources": {
-                "definitions": {
-                    "singular": "definition",
-                    "plural": "definitions",
-                    "versions": 1,
-                    "attributes": {
-                        "baseDefinitionUrl": {
-                            "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition.",
-                            "type": "uri",
-                            "required": false
-                        },
-                        "format": {
-                            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
-                            "type": "string",
-                            "required": false,
-                            "ifvalue": {
-                                "None" : {
-                                },
-                                "CloudEvents/1.0": {
-                                    "siblingattributes": {
-                                        "metadata": {
-                                            "description": "CloudEvents metadata constraints.",
-                                            "type": "object",
-                                            "required": false,
-                                            "item": {
-                                                "attributes": {
-                                                    "type": {
-                                                        "description": "CloudEvents type.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "CloudEvents type value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "source": {
-                                                        "description": "CloudEvents source",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "CloudEvents source value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "subject": {
-                                                        "description": "CloudEvents subject",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "CloudEvents subject value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                },
-                                                                "required": {
-                                                                    "description": "CloudEvents subject required.",
-                                                                    "type": "boolean",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "id": {
-                                                        "description": "CloudEvents id",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "CloudEvents id value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "time": {
-                                                        "description": "The timestamp of when the event happened.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "The timestamp value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                },
-                                                                "required": {
-                                                                    "description": "The timestamp required.",
-                                                                    "type": "boolean",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "dataschema": {
-                                                        "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "The uri value template.",
-                                                                    "type": "uritemplate",
-                                                                    "required": false
-                                                                },
-                                                                "required": {
-                                                                    "description": "The uri required.",
-                                                                    "type": "boolean",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "*": {
-                                                        "description": "CloudEvent extension property",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "The value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                },
-                                                                "required": {
-                                                                    "description": "Whether the extension is required",
-                                                                    "type": "boolean",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "binding": {
-                            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups.",
-                            "type": "string",
-                            "required": false,
-                            "ifvalue": {
-                                "None" : {
-                                },
-                                "AMQP/1.0": {
-                                    "siblingattributes": {
-                                        "message": {
-                                            "description": "AMQP message metadata constraints.",
-                                            "type": "object",
-                                            "required": false,
-                                            "item": {
-                                                "attributes": {
-                                                    "properties": {
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "message_id": {
-                                                                    "description": "AMQP message-id.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP message-id value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP message-id required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "user_id": {
-                                                                    "description": "AMQP user-id.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP user-id value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP user-id required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "to": {
-                                                                    "description": "AMQP to.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP to value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP to required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "subject": {
-                                                                    "description": "AMQP subject.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP subject value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP subject required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "reply_to": {
-                                                                    "description": "AMQP reply-to.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP reply-to value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP reply-to required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "correlation_id": {
-                                                                    "description": "AMQP correlation-id.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP correlation-id value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP correlation-id required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "content_type": {
-                                                                    "description": "AMQP content-type.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP content-type value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP content-type required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "content_encoding": {
-                                                                    "description": "AMQP content-encoding.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP content-encoding value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP content-encoding required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "absolute_expiry_time": {
-                                                                    "description": "AMQP absolute-expiry-time.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP absolute-expiry-time value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP absolute-expiry-time required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "group_id": {
-                                                                    "description": "AMQP group-id.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP group-id value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP group-id required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "group_sequence": {
-                                                                    "description": "AMQP group-sequence.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP group-sequence value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP group-sequence required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                },
-                                                                "reply_to_group_id": {
-                                                                    "description": "AMQP reply-to-group-id.",
-                                                                    "type": "object",
-                                                                    "required": false,
-                                                                    "item": {
-                                                                        "attributes": {
-                                                                            "value": {
-                                                                                "description": "AMQP reply-to-group-id value template.",
-                                                                                "type": "string",
-                                                                                "required": false
-                                                                            },
-                                                                            "required": {
-                                                                                "description": "AMQP reply-to-group-id required.",
-                                                                                "type": "boolean",
-                                                                                "required": false
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "application_properties": {
-                                                        "type": "map",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "value": {
-                                                                        "description": "The application property value template.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "required": {
-                                                                        "description": "The application property required.",
-                                                                        "type": "boolean",
-                                                                        "required": false
-                                                                    },
-                                                                    "type": {
-                                                                        "description": "The application property type.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "message_annotations": {
-                                                        "type": "map",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "value": {
-                                                                        "description": "The message annotation value",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "required": {
-                                                                        "description": "Whether the message annotation is required",
-                                                                        "type": "boolean",
-                                                                        "required": false
-                                                                    },
-                                                                    "type": {
-                                                                        "description": "The message annotation type.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "delivery_annotations": {
-                                                        "type": "map",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "value": {
-                                                                        "description": "The delivery annotation value",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "required": {
-                                                                        "description": "Whether the annotation is required",
-                                                                        "type": "boolean",
-                                                                        "required": false
-                                                                    },
-                                                                    "type": {
-                                                                        "description": "The annotation type.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "header": {
-                                                        "type": "map",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "value": {
-                                                                        "description": "AMQP header value.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "required": {
-                                                                        "description": "AMQP header required.",
-                                                                        "type": "boolean",
-                                                                        "required": false
-                                                                    },
-                                                                    "type": {
-                                                                        "description": "AMQP header type.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "footer": {
-                                                        "type": "map",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "value": {
-                                                                        "description": "AMQP footer value.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "required": {
-                                                                        "description": "AMQP footer required.",
-                                                                        "type": "boolean",
-                                                                        "required": false
-                                                                    },
-                                                                    "type": {
-                                                                        "description": "AMQP footer type.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "MQTT/3.1.1": {
-                                    "siblingattributes": {
-                                        "message": {
-                                            "description": "MQTT message metadata constraints.",
-                                            "type": "object",
-                                            "required": false,
-                                            "item": {
-                                                "attributes": {
-                                                    "qos": {
-                                                        "description": "MQTT qos.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT qos value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "retain": {
-                                                        "description": "MQTT retain.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT retain value template.",
-                                                                    "type": "boolean",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "topic_name": {
-                                                        "description": "MQTT topic-name.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT topic-name value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "MQTT/5.0": {
-                                    "siblingattributes": {
-                                        "message": {
-                                            "description": "MQTT message metadata constraints.",
-                                            "type": "object",
-                                            "required": false,
-                                            "item": {
-                                                "attributes": {
-                                                    "qos": {
-                                                        "description": "MQTT qos.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT qos value template.",
-                                                                    "type": "integer",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "retain": {
-                                                        "description": "MQTT retain.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT retain value template.",
-                                                                    "type": "boolean",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "topic_name": {
-                                                        "description": "MQTT topic-name.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT topic-name value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "message_expiry_interval": {
-                                                        "description": "MQTT message-expiry-interval.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT message-expiry-interval value template.",
-                                                                    "type": "integer",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "response_topic": {
-                                                        "description": "MQTT response-topic.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT response-topic value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "correlation_data": {
-                                                        "description": "MQTT correlation-data.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT correlation-data value template.",
-                                                                    "type": "binary",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "content_type": {
-                                                        "description": "MQTT content-type.",
-                                                        "type": "object",
-                                                        "required": false,
-                                                        "item": {
-                                                            "attributes": {
-                                                                "value": {
-                                                                    "description": "MQTT content-type value template.",
-                                                                    "type": "string",
-                                                                    "required": false
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "user_properties": {
-                                                        "description": "MQTT user-properties.",
-                                                        "type": "array",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "name": {
-                                                                        "description": "MQTT user-property name.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "value": {
-                                                                        "description": "MQTT user-property value.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "KAFKA": {
-                                    "siblingattributes": {
-                                        "message": {
-                                            "description": "The Apache Kafka message metadata constraints.",
-                                            "type": "object",
-                                            "required": false,
-                                            "item": {
-                                                "attributes": {
-                                                    "topic": {
-                                                        "description": "The Apache Kafka topic.",
-                                                        "type": "string",
-                                                        "required": false
-                                                    },
-                                                    "partition": {
-                                                        "description": "The Apache Kafka partition.",
-                                                        "type": "integer",
-                                                        "required": false
-                                                    },
-                                                    "key": {
-                                                        "description": "The Apache Kafka key.",
-                                                        "type": "binary",
-                                                        "required": false
-                                                    },
-                                                    "headers": {
-                                                        "description": "The Apache Kafka headers.",
-                                                        "type": "map",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "name": {
-                                                                        "description": "The Apache Kafka header name.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "value": {
-                                                                        "description": "The Apache Kafka header value.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "timestamp": {
-                                                        "description": "The Apache Kafka timestamp.",
-                                                        "type": "integer",
-                                                        "required": false
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "HTTP": {
-                                    "siblingattributes": {
-                                        "message": {
-                                            "description": "The HTTP message metadata constraints.",
-                                            "type": "object",
-                                            "required": false,
-                                            "item": {
-                                                "attributes": {
-                                                    "headers": {
-                                                        "description": "The HTTP headers.",
-                                                        "type": "array",
-                                                        "required": false,
-                                                        "item": {
-                                                            "type": "object",
-                                                            "item": {
-                                                                "attributes": {
-                                                                    "name": {
-                                                                        "description": "The HTTP header name.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    },
-                                                                    "value": {
-                                                                        "description": "The HTTP header value.",
-                                                                        "type": "string",
-                                                                        "required": false
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "query": {
-                                                        "description": "The HTTP query parameters.",
-                                                        "type": "object",
-                                                        "required": false
-                                                    },
-                                                    "path": {
-                                                        "description": "The HTTP path as a uri template.",
-                                                        "type": "string",
-                                                        "required": false
-                                                    },
-                                                    "method": {
-                                                        "description": "The HTTP method.",
-                                                        "type": "string",
-                                                        "required": false
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "schemaformat": {
-                                "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry.",
-                                "type": "string",
-                                "required": false
-                            },
-                            "schema": {
-                                "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry.",
-                                "type": "string",
-                                "required": false
-                            },
-                            "schemaobject": {
-                                "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry.",
-                                "type": "string",
-                                "required": false
-                            },
-                            "schemaurl": {
-                                "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry.",
-                                "type": "string",
-                                "required": false
-                            }
-                        }
-                    }
-                }
-            }
+  "schemas": [
+    "json-schema/draft-07"
+  ],
+  "groups": {
+    "definitiongroups": {
+      "singular": "definitiongroup",
+      "plural": "definitiongroups",
+
+      "attributes": {
+        "format": {
+          "name": "format",
+          "type": "string",
+          "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+        },
+        "binding": {
+          "name": "binding",
+          "type": "string"
+          "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted",
+        },
+        "*": {
+          "name": "*",
+          "type": any
         }
+      },
+
+      "resources": {
+        "definitions": {
+          "singular": "definition",
+          "plural": "definitions",
+          "versions": 1,
+
+          "attributes": {
+            "basemessageurl": {
+              "name": "basemessageurl",
+              "type": "uri",
+              "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
+            },
+            "format": {
+              "type": "string",
+              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+              "ifvalue": {
+                "None" : {
+                },
+                "CloudEvents/1.0": {
+                  "siblingattributes": {
+                    "metadata": {
+                      "name": "metadata",
+                      "type": "object",
+                      "description": "CloudEvents metadata constraints",
+                      "item": {
+                        "attributes": {
+                          "type": {
+                            "name": "type",
+                            "type": "object",
+                            "description": "CloudEvents type",
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "name": "value,
+                                  "type": "string",
+                                  "description": "CloudEvents type value template"
+                                }
+                              }
+                            }
+                          },
+                          "source": {
+                            "description": "CloudEvents source",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "CloudEvents source value template",
+                                  "type": "string",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "subject": {
+                            "description": "CloudEvents subject",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "CloudEvents subject value template",
+                                  "type": "string",
+                                  "required": false
+                                },
+                                "required": {
+                                  "description": "CloudEvents subject required",
+                                  "type": "boolean",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "id": {
+                            "description": "CloudEvents id",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "CloudEvents id value template",
+                                  "type": "string",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "time": {
+                            "description": "The timestamp of when the event happened",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "The timestamp value template",
+                                  "type": "string",
+                                  "required": false
+                                },
+                                "required": {
+                                  "description": "The timestamp required",
+                                  "type": "boolean",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "dataschema": {
+                            "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "The uri value template",
+                                  "type": "uritemplate",
+                                  "required": false
+                                },
+                                "required": {
+                                  "description": "The uri required",
+                                  "type": "boolean",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "*": {
+                            "description": "CloudEvent extension property",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "The value template",
+                                  "type": "string",
+                                  "required": false
+                                },
+                                "required": {
+                                  "description": "Whether the extension is required",
+                                  "type": "boolean",
+                                  "required": false
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "binding": {
+              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+              "type": "string",
+              "required": false,
+              "ifvalue": {
+                "None" : {
+                },
+                "AMQP/1.0": {
+                  "siblingattributes": {
+                    "message": {
+                      "description": "AMQP message metadata constraints",
+                      "type": "object",
+                      "required": false,
+                      "item": {
+                        "attributes": {
+                          "properties": {
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "message_id": {
+                                  "description": "AMQP message-id",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP message-id value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP message-id required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "user_id": {
+                                  "description": "AMQP user-id",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP user-id value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP user-id required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "to": {
+                                  "description": "AMQP to",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP to value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP to required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "subject": {
+                                  "description": "AMQP subject",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP subject value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP subject required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "reply_to": {
+                                  "description": "AMQP reply-to",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP reply-to value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP reply-to required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "correlation_id": {
+                                  "description": "AMQP correlation-id",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP correlation-id value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP correlation-id required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "content_type": {
+                                  "description": "AMQP content-type",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP content-type value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP content-type required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "content_encoding": {
+                                  "description": "AMQP content-encoding",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP content-encoding value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP content-encoding required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "absolute_expiry_time": {
+                                  "description": "AMQP absolute-expiry-time",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP absolute-expiry-time value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP absolute-expiry-time required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "group_id": {
+                                  "description": "AMQP group-id",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP group-id value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP group-id required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "group_sequence": {
+                                  "description": "AMQP group-sequence",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP group-sequence value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP group-sequence required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                },
+                                "reply_to_group_id": {
+                                  "description": "AMQP reply-to-group-id",
+                                  "type": "object",
+                                  "required": false,
+                                  "item": {
+                                    "attributes": {
+                                      "value": {
+                                        "description": "AMQP reply-to-group-id value template",
+                                        "type": "string",
+                                        "required": false
+                                      },
+                                      "required": {
+                                        "description": "AMQP reply-to-group-id required",
+                                        "type": "boolean",
+                                        "required": false
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "application_properties": {
+                            "type": "map",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "value": {
+                                    "description": "The application property value template",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "required": {
+                                    "description": "The application property required",
+                                    "type": "boolean",
+                                    "required": false
+                                  },
+                                  "type": {
+                                    "description": "The application property type",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "message_annotations": {
+                            "type": "map",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "value": {
+                                    "description": "The message annotation value",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "required": {
+                                    "description": "Whether the message annotation is required",
+                                    "type": "boolean",
+                                    "required": false
+                                  },
+                                  "type": {
+                                    "description": "The message annotation type",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "delivery_annotations": {
+                            "type": "map",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "value": {
+                                    "description": "The delivery annotation value",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "required": {
+                                    "description": "Whether the annotation is required",
+                                    "type": "boolean",
+                                    "required": false
+                                  },
+                                  "type": {
+                                    "description": "The annotation type",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "header": {
+                            "type": "map",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "value": {
+                                    "description": "AMQP header value",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "required": {
+                                    "description": "AMQP header required",
+                                    "type": "boolean",
+                                    "required": false
+                                  },
+                                  "type": {
+                                    "description": "AMQP header type",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "footer": {
+                            "type": "map",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "value": {
+                                    "description": "AMQP footer value",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "required": {
+                                    "description": "AMQP footer required",
+                                    "type": "boolean",
+                                    "required": false
+                                  },
+                                  "type": {
+                                    "description": "AMQP footer type",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "MQTT/3.1.1": {
+                  "siblingattributes": {
+                    "message": {
+                      "description": "MQTT message metadata constraints",
+                      "type": "object",
+                      "required": false,
+                      "item": {
+                        "attributes": {
+                          "qos": {
+                            "description": "MQTT qos",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT qos value template",
+                                  "type": "string",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "retain": {
+                            "description": "MQTT retain",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT retain value template",
+                                  "type": "boolean",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "topic_name": {
+                            "description": "MQTT topic-name",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT topic-name value template",
+                                  "type": "string",
+                                  "required": false
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "MQTT/5.0": {
+                  "siblingattributes": {
+                    "message": {
+                      "description": "MQTT message metadata constraints",
+                      "type": "object",
+                      "required": false,
+                      "item": {
+                        "attributes": {
+                          "qos": {
+                            "description": "MQTT qos",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT qos value template",
+                                  "type": "integer",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "retain": {
+                            "description": "MQTT retain",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT retain value template",
+                                  "type": "boolean",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "topic_name": {
+                            "description": "MQTT topic-name",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT topic-name value template",
+                                  "type": "string",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "message_expiry_interval": {
+                            "description": "MQTT message-expiry-interval",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT message-expiry-interval value template",
+                                  "type": "integer",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "response_topic": {
+                            "description": "MQTT response-topic",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT response-topic value template",
+                                  "type": "string",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "correlation_data": {
+                            "description": "MQTT correlation-data",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT correlation-data value template",
+                                  "type": "binary",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "content_type": {
+                            "description": "MQTT content-type",
+                            "type": "object",
+                            "required": false,
+                            "item": {
+                              "attributes": {
+                                "value": {
+                                  "description": "MQTT content-type value template",
+                                  "type": "string",
+                                  "required": false
+                                }
+                              }
+                            }
+                          },
+                          "user_properties": {
+                            "description": "MQTT user-properties",
+                            "type": "array",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "name": {
+                                    "description": "MQTT user-property name",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "value": {
+                                    "description": "MQTT user-property value",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "KAFKA": {
+                  "siblingattributes": {
+                    "message": {
+                      "description": "The Apache Kafka message metadata constraints",
+                      "type": "object",
+                      "required": false,
+                      "item": {
+                        "attributes": {
+                          "topic": {
+                            "description": "The Apache Kafka topic",
+                            "type": "string",
+                            "required": false
+                          },
+                          "partition": {
+                            "description": "The Apache Kafka partition",
+                            "type": "integer",
+                            "required": false
+                          },
+                          "key": {
+                            "description": "The Apache Kafka key",
+                            "type": "binary",
+                            "required": false
+                          },
+                          "headers": {
+                            "description": "The Apache Kafka headers",
+                            "type": "map",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "name": {
+                                    "description": "The Apache Kafka header name",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "value": {
+                                    "description": "The Apache Kafka header value",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "timestamp": {
+                            "description": "The Apache Kafka timestamp",
+                            "type": "integer",
+                            "required": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "HTTP": {
+                  "siblingattributes": {
+                    "message": {
+                      "description": "The HTTP message metadata constraints",
+                      "type": "object",
+                      "required": false,
+                      "item": {
+                        "attributes": {
+                          "headers": {
+                            "description": "The HTTP headers",
+                            "type": "array",
+                            "required": false,
+                            "item": {
+                              "type": "object",
+                              "item": {
+                                "attributes": {
+                                  "name": {
+                                    "description": "The HTTP header name",
+                                    "type": "string",
+                                    "required": false
+                                  },
+                                  "value": {
+                                    "description": "The HTTP header value",
+                                    "type": "string",
+                                    "required": false
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "query": {
+                            "description": "The HTTP query parameters",
+                            "type": "object",
+                            "required": false
+                          },
+                          "path": {
+                            "description": "The HTTP path as a uri template",
+                            "type": "string",
+                            "required": false
+                          },
+                          "method": {
+                            "description": "The HTTP method",
+                            "type": "string",
+                            "required": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "schemaformat": {
+                "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry",
+                "type": "string",
+                "required": false
+              },
+              "schema": {
+                "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry",
+                "type": "string",
+                "required": false
+              },
+              "schemaobject": {
+                "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry",
+                "type": "string",
+                "required": false
+              },
+              "schemaurl": {
+                "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry",
+                "type": "string",
+                "required": false
+              }
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/message/spec.md
+++ b/message/spec.md
@@ -97,6 +97,11 @@ this form:
                 "required": BOOLEAN ?          # Default is 'false'
               } *
             } ?
+
+            # "CloudEvents/1.0" format metadata
+            "type": {
+              "value": "STRING" ?
+            }
           }, ?
 
 


### PR DESCRIPTION
- More model/spec sync'ing
- clarify that attribute.item.type is only used by map/array attributes (not objects)
- ifvalue.VALUE must be a string serialization of the possible runtime value
- ifvalue.VALUE must not be an empty string
- ifvalue can not include nested ifvalue
- can't implicitly create higher-level entities if they have clientrequired attributes
- add attribute.default to define an attribute's default value
- default attribute.versions to zero (unlimited versions), was 1
- more possible topics for the primer