### PR TITLE
Updates for week of Feb18

### DIFF
--- a/core/primer.md
+++ b/core/primer.md
@@ -1,14 +1,74 @@
 # xRegistry Primer
 
-Possible future topics to cover:
-- Resource.ID and Resource.Version.ID might have the same values but they are
-  very different properties with no relation to each other.
+<!-- no verify-specs -->
+
+## Design decisions
+
+### Resource.ID vs Resource.Version.ID
+
+Resources, like all xRegistry entities, have unique `id` values. Resource
+`id`s are often user-friendly values that often have an implied semantic
+meaning of the purpose of the underlying Resource document. Also, since they
+are static values and as the Resource changes over time (meaning, new Versions
+are created), it's important for end-users to have a static URL reference to
+the latest Version of the Resource.
+
+Versions of a Resource, on the other hand, might change quite often and the
+`id` isn't meant to convey the purpose of the underlying entity, rather it is
+meant to uniquely specify its "version number".  As such, the semantics
+meaning and usage of the two `id` values are quite different. This means that
+there might be times when they are the same value However, while this is
+allowable, it has no influence on any specification defined semantics of the
+xRegistry model. As a result, implementations might want to avoid using `id`
+values that could appear on a Resource and one of its Versions simply to avoid
+potential confusion for their end-users.
+
+### Valid Characters
+
+The xRegistry specification restricts the allowable characters for attribute
+and map key names. While it can be considered overly restrictive, for example
+uppercase characters are not permitted, this was done because considerations
+had to be made to take into account where these names might appear.
+
+Some of the challenges:
+- attribute and key name might appear as HTTP headers, which are
+  case insensitive. On the surface this would mean that simply not allowing
+  more than one name of different cases would suffice. However, in the case
+  of the name being part of a open-ended extension (e.g. allowable due to a
+  `*` defined attribute), the server has no way of knowing its proper case.
+  And when they're serialized in the HTTP body, case then matters.
+- some network proxying software limit the allowable characters that can
+  appear in HTTP header names by default. For example, nginx will drop all
+  HTTP headers that include underscore (`_`) characters. While there are most
+  likely configuration flags to disable this behavior, it might not always
+  be possible (or easy) for xRegistry implementations to modify those
+  networking components.
+- often attribute names, or object property names, are mapped into code
+  variable or properties within code structures. While many programming
+  langugaes allow for a mapping from those names to their serialization
+  names, often these mapping can introduce pain - either because they require
+  additional work/configuration or simply due to errors being introduced
+  by not using the language specific default mapping.
+
+So rather than raising the bar for installation, maintenance, and debugging
+(detecting the possible issues mentioned above), it was deemed better to
+simply avoid the problem (and hopefully increase interoperability) by just
+limiting the allowable characters.
+
+Note though, map key names allow more characters than well-define object
+attribute names because map key names are not usually mapped to well defined
+variable or structure property names - they're usually just stored as
+"strings" a map data structure.
+
+### Extensions
+
 - it's RECOMMENDED that all extensions be defined in advance as part of the
   model. However, the spec does support an extension of "*" to allow for
   unknown/runtime-provided extensions. Since extensions can appear in case-
   insensitive situations (e.g. http header) we can't know the case of them
   when storing in the backend. As a result, all attributes and keyNames MUST
   be lowercase.
+
 - "latest" Resource is just a pointer, NOT a set of default values
 - we allow for implicit creation of a resource's tree rather than requiring
   multiple create operations - just for convinience
@@ -19,3 +79,13 @@ Possible future topics to cover:
   various URLs (self, latestversionurl, location,...). Right now its presence
   will match what was used in the request (either explicitly or implicity).
   So GET resource?meta or GET group?inline both ask for metadata
+- xRegistry- headers: first "-" separates xRegistry from attribute name,
+  next "-" separates attribute name from key, any subsequent "-" is part
+  of the key name. E.g xRegistry-labels-abc-def:xxx => labels["abc-def"]=xxx
+- impact of "*required" flags at multiple levels
+- why we don't use underscore in our property names, tho legal to do so
+  - not all http proxies (e.g. nginx) pass them along by default
+  - so, while spec allows underscores, use at your own risk
+- discuss any potential semantic gotchas when one attribute is required
+  but a nested attribute is optional, or also required (and visa-versa)
+  - reminder: clientrequired=true means serverrequired=true as well, else error

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -6,13 +6,16 @@
     "endpoints": {
       "singular": "endpoint",
       "plural": "endpoints",
-
       "attributes": {
         "usage": {
           "name": "usage",
           "type": "string",
           "description": "Client's expected usage of this endpoint",
-          "enum": ["subscriber", "consumer", "producer" ],
+          "enum": [
+            "subscriber",
+            "consumer",
+            "producer"
+          ],
           "strict": true,
           "clientrequired": true,
           "serverrequired": true
@@ -40,32 +43,30 @@
           "name": "deprecated",
           "type": "object",
           "description": "tbd",
-          "item": {
-            "attributes": {
-              "effective": {
-                "name": "effective",
-                "type": "timestamp",
-                "description": "tbd"
-              },
-              "removal": {
-                "name": "removal",
-                "type": "timestamp",
-                "description": "tbd"
-              },
-              "alternative": {
-                "name": "alternative",
-                "type": "url",
-                "description": "tbd"
-              },
-              "docs": {
-                "name": "docs",
-                "type": "url",
-                "description": "tbd"
-              },
-              "*": {
-                "name": "*",
-                "type": "any"
-              }
+          "attributes": {
+            "effective": {
+              "name": "effective",
+              "type": "timestamp",
+              "description": "tbd"
+            },
+            "removal": {
+              "name": "removal",
+              "type": "timestamp",
+              "description": "tbd"
+            },
+            "alternative": {
+              "name": "alternative",
+              "type": "url",
+              "description": "tbd"
+            },
+            "docs": {
+              "name": "docs",
+              "type": "url",
+              "description": "tbd"
+            },
+            "*": {
+              "name": "*",
+              "type": "any"
             }
           }
         },
@@ -73,364 +74,348 @@
           "name": "config",
           "type": "object",
           "description": "Configuration information for this endpoint",
-          "item": {
-            "attributes": {
-              "protocol": {
-                "name": "protocol",
-                "type": "string",
-                "description": "endpoint protocol identifier",
-                "clientrequired": true,
-                "serverrequired": true,
-
-                "ifvalue": {
-                  "AMQP/1.0": {
-                    "siblingattributes": {
-                      "options": {
-                        "name": "options",
-                        "type": "object",
-                        "description": "AMQP 1.0 connection options",
-                        "item": {
-                          "attributes": {
-                            "node": {
-                              "name": "node",
-                              "type": "string",
-                              "description": "The AMQP node name. Commonly the name of a queue or a topic"
-                            },
-                            "durable": {
-                              "name": "durable",
-                              "type": "boolean",
-                              "description": "The AMQP durable flag. Whether the node is durable or transient"
-                            },
-                            "linkproperties": {
-                              "name": "linkproperties",
-                              "type": "map",
-                              "description": "An optional map of AMQP link properties to use with the endpoint",
-                              "item": {
+          "attributes": {
+            "protocol": {
+              "name": "protocol",
+              "type": "string",
+              "description": "endpoint protocol identifier",
+              "clientrequired": true,
+              "serverrequired": true,
+              "ifvalues": {
+                "AMQP/1.0": {
+                  "siblingattributes": {
+                    "options": {
+                      "name": "options",
+                      "type": "object",
+                      "description": "AMQP 1.0 connection options",
+                      "attributes": {
+                        "node": {
+                          "name": "node",
+                          "type": "string",
+                          "description": "The AMQP node name. Commonly the name of a queue or a topic"
+                        },
+                        "durable": {
+                          "name": "durable",
+                          "type": "boolean",
+                          "description": "The AMQP durable flag. Whether the node is durable or transient"
+                        },
+                        "linkproperties": {
+                          "name": "linkproperties",
+                          "type": "map",
+                          "description": "An optional map of AMQP link properties to use with the endpoint",
+                          "item": {
+                            "type": "string"
+                          }
+                        },
+                        "connectionproperties": {
+                          "name": "connectionproperties",
+                          "type": "map",
+                          "description": "An optional map of AMQP connection properties to use with the endpoint",
+                          "item": {
+                            "type": "string"
+                          }
+                        },
+                        "distributionmode": {
+                          "name": "distributionmode",
+                          "type": "string",
+                          "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
+                          "enum": [
+                            "move",
+                            "copy"
+                          ]
+                        },
+                        "*": {
+                          "name": "*",
+                          "type": "any"
+                        }
+                      }
+                    }
+                  }
+                },
+                "MQTT/5.0": {
+                  "siblingattributes": {
+                    "options": {
+                      "name": "options",
+                      "type": "object",
+                      "description": "MQTT 5.0 connection options",
+                      "attributes": {
+                        "topic": {
+                          "name": "topic",
+                          "type": "string",
+                          "description": "The MQTT topic path"
+                        },
+                        "qos": {
+                          "name": "qos",
+                          "type": "uinteger",
+                          "description": "The MQTT QoS level. May be 0, 1, or 2"
+                        },
+                        "retain": {
+                          "name": "retain",
+                          "type": "boolean",
+                          "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                        },
+                        "cleansession": {
+                          "name": "cleansession",
+                          "type": "boolean",
+                          "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                        },
+                        "willtopic": {
+                          "name": "willtopic",
+                          "type": "string",
+                          "description": "The MQTT will topic to configure for publishers on this endpoint"
+                        },
+                        "willmessage": {
+                          "name": "willmessage",
+                          "type": "string",
+                          "description": "The MQTT will message definition to configure for publishers on this endpoint"
+                        },
+                        "*": {
+                          "name": "*",
+                          "type": "any"
+                        }
+                      }
+                    }
+                  }
+                },
+                "MQTT/3.1.1": {
+                  "siblingattributes": {
+                    "options": {
+                      "name": "options",
+                      "type": "object",
+                      "description": "MQTT 3.1.1 connection options",
+                      "attributes": {
+                        "topic": {
+                          "name": "topic",
+                          "type": "string",
+                          "description": "MQTT topic path"
+                        },
+                        "qos": {
+                          "name": "qos",
+                          "type": "uinteger",
+                          "description": "The MQTT QoS levelö. May be 0, 1, or 2"
+                        },
+                        "retain": {
+                          "name": "retain",
+                          "type": "boolean",
+                          "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                        },
+                        "cleansession": {
+                          "name": "cleansession",
+                          "type": "boolean",
+                          "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                        },
+                        "willtopic": {
+                          "name": "willtopic",
+                          "type": "string",
+                          "description": "The MQTT will topic to configure for publishers on this endpoint"
+                        },
+                        "willmessage": {
+                          "name": "willmessage",
+                          "type": "string",
+                          "description": "The MQTT will message definition to configure for publishers on this endpoint"
+                        },
+                        "*": {
+                          "name": "*",
+                          "type": "any"
+                        }
+                      }
+                    }
+                  }
+                },
+                "HTTP": {
+                  "siblingattributes": {
+                    "options": {
+                      "name": "options",
+                      "type": "object",
+                      "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions",
+                      "attributes": {
+                        "method": {
+                          "name": "method",
+                          "type": "string",
+                          "description": "The HTTP method name"
+                        },
+                        "headers": {
+                          "name": "headers",
+                          "type": "array",
+                          "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "name": {
+                                "name": "name",
                                 "type": "string",
-                                "description": "Link property value"
+                                "description": "HTTP header name",
+                                "clientrequired": true,
+                                "serverrequired": true
+                              },
+                              "value": {
+                                "name": "value",
+                                "type": "string",
+                                "description": "HTTP header value",
+                                "clientrequired": true,
+                                "serverrequired": true
                               }
-                            },
-                            "connectionproperties": {
-                              "name": "connectionproperties",
-                              "type": "map",
-                              "description": "An optional map of AMQP connection properties to use with the endpoint",
-                              "item": {
-                                "description": "Connection property value",
-                                "type": "string"
-                              }
-                            },
-                            "distributionmode": {
-                              "name": "distributionmode",
-                              "type": "string",
-                              "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
-                              "enum": [
-                                "move",
-                                "copy"
-                              ]
-                            },
-                            "*": {
-                              "name": "*",
-                              "type": "any"
                             }
                           }
+                        },
+                        "query": {
+                          "name": "query",
+                          "type": "map",
+                          "description": "HTTP query parameters",
+                          "item": {
+                            "type": "string"
+                          }
+                        },
+                        "*": {
+                          "name": "*",
+                          "type": "any"
                         }
                       }
                     }
-                  },
-                  "MQTT/5.0": {
-                    "siblingattributes": {
-                      "options": {
-                        "name": "options",
-                        "type": "object",
-                        "description": "MQTT 5.0 connection options",
-                        "item": {
-                          "attributes": {
-                            "topic": {
-                              "name": "topic",
-                              "type": "string",
-                              "description": "The MQTT topic path"
-                            },
-                            "qos": {
-                              "name": "qos",
-                              "type": "uinteger",
-                              "description": "The MQTT QoS level. May be 0, 1, or 2"
-                            },
-                            "retain": {
-                              "name": "retain",
-                              "type": "boolean",
-                              "description": "The MQTT retain flag to use for publishers on ths endpoint"
-                            },
-                            "cleansession": {
-                              "name": "cleansession",
-                              "type": "boolean",
-                              "description": "The MQTT clean session flag to use for publishers on this endpoint"
-                            },
-                            "willtopic": {
-                              "name": "willtopic",
-                              "type": "string",
-                              "description": "The MQTT will topic to configure for publishers on this endpoint"
-                            },
-                            "willmessage": {
-                              "name": "willmessage",
-                              "type": "string",
-                              "description": "The MQTT will message definition to configure for publishers on this endpoint"
-                            },
-                            "*": {
-                              "name": "*",
-                              "type" "any"
-                            }
+                  }
+                },
+                "KAFKA": {
+                  "siblingattributes": {
+                    "options": {
+                      "name": "options",
+                      "type": "object",
+                      "description": "Apache Kafka options",
+                      "attributes": {
+                        "topic": {
+                          "name": "topic",
+                          "type": "string",
+                          "description": "Apache Kafka topic name",
+                          "clientrequired": true,
+                          "serverrequired": true
+                        },
+                        "acks": {
+                          "name": "acks",
+                          "type": "integer",
+                          "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                        },
+                        "key": {
+                          "name": "key",
+                          "type": "string",
+                          "description": "The Apache Kafka record key"
+                        },
+                        "partition": {
+                          "name": "partition",
+                          "type": "integer",
+                          "description": "The Apache Kafka partition number to use when writing to or receiving from Apache Kafka"
+                        },
+                        "consumergroup": {
+                          "name": "consumergroup",
+                          "type": "string",
+                          "description": "The Apache Kafka consumer group name to use for consumers"
+                        },
+                        "headers": {
+                          "name": "headers",
+                          "type": "map",
+                          "description": "The Apache Kafka headers for publishers on this endpoint",
+                          "item": {
+                            "type": "string"
                           }
+                        },
+                        "*": {
+                          "name": "*",
+                          "type": "any"
                         }
                       }
                     }
-                  },
-                  "MQTT/3.1.1": {
-                    "siblingattributes": {
-                      "options": {
-                        "name": "options",
-                        "type": "object",
-                        "description": "MQTT 3.1.1 connection options",
-                        "item": {
-                          "attributes": {
-                            "topic": {
-                              "name": "topic",
-                              "type": "string",
-                              "description": "MQTT topic path"
-                            },
-                            "qos": {
-                              "name": "qos",
-                              "type": "uinteger",
-                              "description": "The MQTT QoS levelö. May be 0, 1, or 2"
-                            },
-                            "retain": {
-                              "name": "retain",
-                              "type": "boolean",
-                              "description": "The MQTT retain flag to use for publishers on ths endpoint"
-                            },
-                            "cleansession": {
-                              "name": "cleansession",
-                              "type": "boolean",
-                              "description": "The MQTT clean session flag to use for publishers on this endpoint"
-                            },
-                            "willtopic": {
-                              "name": "willtopic",
-                              "type": "string",
-                              "description": "The MQTT will topic to configure for publishers on this endpoint"
-                            },
-                            "willmessage": {
-                              "name": "willmessage",
-                              "type": "string",
-                              "description": "The MQTT will message definition to configure for publishers on this endpoint"
-                            },
-                            "*": {
-                              "name": "*",
-                              "type": "any"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "HTTP": {
-                    "siblingattributes": {
-                      "options": {
-                        "name": "options",
-                        "type": "object",
-                        "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions",
-                        "item": {
-                          "attributes": {
-                            "method": {
-                              "name": "method",
-                              "type": "string",
-                              "description": "The HTTP method name"
-                            },
-                            "headers": {
-                              "name": "headers",
-                              "type": "array",
-                              "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive",
-                              "item": {
-                                "type": "object",
-                                "attributes": {
-                                  "name": {
-                                    "name": "name",
-                                    "type": "string",
-                                    "description": "HTTP header name",
-                                    "clientrequired": true,
-                                    "serverrequired": true
-                                  },
-                                  "value": {
-                                    "name": "value",
-                                    "type": "string",
-                                    "description": "HTTP header value",
-                                    "clientrequired": true,
-                                    "serverrequired": true
-                                  }
-                                }
-                              }
-                            },
-                            "query": {
-                              "name": "query",
-                              "type": "map",
-                              "description": "HTTP query parameters",
-                              "item": {
-                                "type": "string"
-                              }
-                            },
-                            "*": {
-                              "name": "*",
-                              "type": "any"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "KAFKA": {
-                    "siblingattributes": {
-                      "options": {
-                        "name": "options",
-                        "type": "object",
-                        "description": "Apache Kafka options",
-                        "item": {
-                          "attributes": {
-                            "topic": {
-                              "name": "topic",
-                              "type": "string",
-                              "description": "Apache Kafka topic name",
-                              "clientrequired": true,
-                              "cserverequired": true
-                            },
-                            "acks": {
-                              "name": "acks",
-                              "type": "integer",
-                              "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
-                            },
-                            "key": {
-                              "name": "key",
-                              "type": "string",
-                              "description": "The Apache Kafka record key"
-                            },
-                            "partition": {
-                              "name": "partition",
-                              "type": "integer",
-                              "description": "The Apache Kafka partition number to use when writing to or receiving from Apache Kafka"
-                            },
-                            "consumergroup": {
-                              "name": "consumergroup",
-                              "type": "string",
-                              "description": "The Apache Kafka consumer group name to use for consumers"
-                            },
-                            "headers": {
-                              "name": "headers",
-                              "type": "map",
-                              "description": "The Apache Kafka headers for publishers on this endpoint",
-                              "item": {
-                                "type": "string"
-                              }
-                            },
-                            "*": {
-                              "name": "*",
-                              "type": "any"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "NATS": {
-                    "siblingattributes": {
-                      "options": {
-                        "name": "options",
-                        "type": "object",
-                        "description": "NATS options",
-                        "item": {
-                          "attributes": {
-                            "subject": {
-                              "name": "subject",
-                              "type": "string",
-                              "description": "The NATS subject",
-                              "clientrequired": true,
-                              "serverrequired": true
-                            },
-                            "*": {
-                              "name": "*",
-                              "type": "any"
-                            }
-                          }
+                  }
+                },
+                "NATS": {
+                  "siblingattributes": {
+                    "options": {
+                      "name": "options",
+                      "type": "object",
+                      "description": "NATS options",
+                      "attributes": {
+                        "subject": {
+                          "name": "subject",
+                          "type": "string",
+                          "description": "The NATS subject",
+                          "clientrequired": true,
+                          "serverrequired": true
+                        },
+                        "*": {
+                          "name": "*",
+                          "type": "any"
                         }
                       }
                     }
                   }
                 }
-              },
-              "endpoints": {
-                "name": "endpoints",
-                "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
-                "item": {
-                  "attributes": {
-                    "uri": {
-                      "name": "uri",
-                      "type": "uri",
-                      "description": "Network accessible location",
-                      "clientrequired": true,
-                      "serverrequired": true
-                    },
-                    "*": {
-                      "name": "*",
-                      "type": "any"
-                    }
-                  }
-                }
-              },
-              "authorization": {
-                "name": "authorization",
-                "type": "array",
-                "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
-                "item": {
-                  "type": "object",
-                  "attributes": {
-                    "type": {
-                      "name": "type",
-                      "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                      "clientrequired": true,
-                      "serverrequired": true
-                    },
-                    "resourceurl": {
-                      "name": "resourceurl",
-                      "type": "url",
-                      "description": "The resource uri for which authorization shall be granted (if applicable)"
-                    },
-                    "authorityuri": {
-                      "name": "authorityuri",
-                      "type": "uri",
-                      "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "name": "granttypes",
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "item": {
-                        "type": "string"
-                      }
-                    },
-                    "*": {
-                      "name": "*",
-                      "type": "any"
-                    }
-                  }
-                }
-              },
-              "deployed": {
-                "name": "deployed",
-                "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
-              },
-              "*": {
-                "name": "*",
-                "type": "any"
               }
+            },
+            "endpoints": {
+              "name": "endpoints",
+              "type": "array",
+              "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+              "item": {
+                "type": "object",
+                "attributes": {
+                  "uri": {
+                    "name": "uri",
+                    "type": "uri",
+                    "description": "Network accessible location",
+                    "clientrequired": true,
+                    "serverrequired": true
+                  },
+                  "*": {
+                    "name": "*",
+                    "type": "any"
+                  }
+                }
+              }
+            },
+            "authorization": {
+              "name": "authorization",
+              "type": "array",
+              "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+              "item": {
+                "type": "object",
+                "attributes": {
+                  "type": {
+                    "name": "type",
+                    "type": "string",
+                    "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                    "clientrequired": true,
+                    "serverrequired": true
+                  },
+                  "resourceurl": {
+                    "name": "resourceurl",
+                    "type": "url",
+                    "description": "The resource uri for which authorization shall be granted (if applicable)"
+                  },
+                  "authorityuri": {
+                    "name": "authorityuri",
+                    "type": "uri",
+                    "description": "The authority uri where authorization shall be requested (if applicable)"
+                  },
+                  "granttypes": {
+                    "name": "granttypes",
+                    "type": "array",
+                    "description": "The grant types that can be requested (if applicable)",
+                    "item": {
+                      "type": "string"
+                    }
+                  },
+                  "*": {
+                    "name": "*",
+                    "type": "any"
+                  }
+                }
+              }
+            },
+            "deployed": {
+              "name": "deployed",
+              "type": "boolean",
+              "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+            },
+            "*": {
+              "name": "*",
+              "type": "any"
             }
           }
         },
@@ -441,7 +426,7 @@
       },
       "resources": {
         "definitions": {
-          # See ../message/model.json#/groups/definitiongroups/resources/definitions
+          "$uri": "See ../message/model.json#/groups/definitiongroups/resources/definitions"
         }
       }
     }

--- a/message/model.json
+++ b/message/model.json
@@ -23,13 +23,11 @@
           "type": "any"
         }
       },
-
       "resources": {
         "messages": {
           "singular": "message",
           "plural": "messages",
           "versions": 1,
-
           "attributes": {
             "basemessageurl": {
               "name": "basemessageurl",
@@ -37,119 +35,119 @@
               "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
             },
             "format": {
+              "name": "format",
               "type": "string",
               "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
-              "ifvalue": {
-                "None" : {
-                },
+              "ifvalues": {
+                "None": {},
                 "CloudEvents/1.0": {
                   "siblingattributes": {
                     "metadata": {
                       "name": "metadata",
                       "type": "object",
                       "description": "CloudEvents metadata constraints",
-                      "item": {
-                        "attributes": {
-                          "type": {
-                            "name": "type",
-                            "type": "object",
-                            "description": "CloudEvents type",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "name": "value",
-                                  "type": "string",
-                                  "description": "CloudEvents type value template"
-                                }
-                              }
+                      "attributes": {
+                        "type": {
+                          "name": "type",
+                          "type": "object",
+                          "description": "CloudEvents type",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "type": "string",
+                              "description": "CloudEvents type value template"
                             }
-                          },
-                          "source": {
-                            "description": "CloudEvents source",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "CloudEvents source value template",
-                                  "type": "string"
-                                }
-                              }
+                          }
+                        },
+                        "source": {
+                          "name": "source",
+                          "description": "CloudEvents source",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "CloudEvents source value template",
+                              "type": "string"
                             }
-                          },
-                          "subject": {
-                            "description": "CloudEvents subject",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "CloudEvents subject value template",
-                                  "type": "string"
-                                },
-                                "required": {
-                                  "description": "CloudEvents subject required",
-                                  "type": "boolean"
-                                }
-                              }
+                          }
+                        },
+                        "subject": {
+                          "name": "subject",
+                          "description": "CloudEvents subject",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "CloudEvents subject value template",
+                              "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "CloudEvents subject required",
+                              "type": "boolean"
                             }
-                          },
-                          "id": {
-                            "description": "CloudEvents id",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "CloudEvents id value template",
-                                  "type": "string"
-                                }
-                              }
+                          }
+                        },
+                        "id": {
+                          "name": "id",
+                          "description": "CloudEvents id",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "CloudEvents id value template",
+                              "type": "string"
                             }
-                          },
-                          "time": {
-                            "description": "The timestamp of when the event happened",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "The timestamp value template",
-                                  "type": "string"
-                                },
-                                "required": {
-                                  "description": "The timestamp required",
-                                  "type": "boolean"
-                                }
-                              }
+                          }
+                        },
+                        "time": {
+                          "name": "time",
+                          "description": "The timestamp of when the event happened",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "The timestamp value template",
+                              "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "The timestamp required",
+                              "type": "boolean"
                             }
-                          },
-                          "dataschema": {
-                            "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "The uri value template",
-                                  "type": "uritemplate"
-                                },
-                                "required": {
-                                  "description": "The uri required",
-                                  "type": "boolean"
-                                }
-                              }
+                          }
+                        },
+                        "dataschema": {
+                          "name": "dataschema",
+                          "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "The uri value template",
+                              "type": "uritemplate"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "The uri required",
+                              "type": "boolean"
                             }
-                          },
-                          "*": {
-                            "description": "CloudEvent extension property",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "The value template",
-                                  "type": "string"
-                                },
-                                "required": {
-                                  "description": "Whether the extension is required",
-                                  "type": "boolean"
-                                }
-                              }
+                          }
+                        },
+                        "*": {
+                          "name": "*",
+                          "description": "CloudEvent extension property",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "The value template",
+                              "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "Whether the extension is required",
+                              "type": "boolean"
                             }
                           }
                         }
@@ -160,324 +158,341 @@
               }
             },
             "binding": {
+              "name": "binding",
               "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
               "type": "string",
-              "ifvalue": {
-                "None" : {
-                },
+              "ifvalues": {
+                "None": {},
                 "AMQP/1.0": {
                   "siblingattributes": {
                     "message": {
+                      "name": "message",
                       "description": "AMQP message metadata constraints",
                       "type": "object",
-                      "item": {
-                        "attributes": {
-                          "properties": {
-                            "type": "object",
-                            "item": {
+                      "attributes": {
+                        "properties": {
+                          "name": "properties",
+                          "type": "object",
+                          "attributes": {
+                            "message_id": {
+                              "name": "message_id",
+                              "description": "AMQP message-id",
+                              "type": "object",
                               "attributes": {
-                                "message_id": {
-                                  "description": "AMQP message-id",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP message-id value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP message-id required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP message-id value template",
+                                  "type": "string"
                                 },
-                                "user_id": {
-                                  "description": "AMQP user-id",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP user-id value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP user-id required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP message-id required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "user_id": {
+                              "name": "user_id",
+                              "description": "AMQP user-id",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP user-id value template",
+                                  "type": "string"
                                 },
-                                "to": {
-                                  "description": "AMQP to",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP to value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP to required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP user-id required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "to": {
+                              "name": "to",
+                              "description": "AMQP to",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP to value template",
+                                  "type": "string"
                                 },
-                                "subject": {
-                                  "description": "AMQP subject",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP subject value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP subject required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP to required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "subject": {
+                              "name": "subject",
+                              "description": "AMQP subject",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP subject value template",
+                                  "type": "string"
                                 },
-                                "reply_to": {
-                                  "description": "AMQP reply-to",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP reply-to value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP reply-to required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP subject required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "reply_to": {
+                              "name": "reply_to",
+                              "description": "AMQP reply-to",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP reply-to value template",
+                                  "type": "string"
                                 },
-                                "correlation_id": {
-                                  "description": "AMQP correlation-id",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP correlation-id value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP correlation-id required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP reply-to required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "correlation_id": {
+                              "name": "correlation_id",
+                              "description": "AMQP correlation-id",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP correlation-id value template",
+                                  "type": "string"
                                 },
-                                "content_type": {
-                                  "description": "AMQP content-type",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP content-type value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP content-type required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP correlation-id required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "content_type": {
+                              "name": "content_type",
+                              "description": "AMQP content-type",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP content-type value template",
+                                  "type": "string"
                                 },
-                                "content_encoding": {
-                                  "description": "AMQP content-encoding",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP content-encoding value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP content-encoding required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP content-type required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "content_encoding": {
+                              "name": "content_encoding",
+                              "description": "AMQP content-encoding",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP content-encoding value template",
+                                  "type": "string"
                                 },
-                                "absolute_expiry_time": {
-                                  "description": "AMQP absolute-expiry-time",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP absolute-expiry-time value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP absolute-expiry-time required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP content-encoding required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "absolute_expiry_time": {
+                              "name": "absolute_expiry_time",
+                              "description": "AMQP absolute-expiry-time",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP absolute-expiry-time value template",
+                                  "type": "string"
                                 },
-                                "group_id": {
-                                  "description": "AMQP group-id",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP group-id value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP group-id required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP absolute-expiry-time required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "group_id": {
+                              "name": "group_id",
+                              "description": "AMQP group-id",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP group-id value template",
+                                  "type": "string"
                                 },
-                                "group_sequence": {
-                                  "description": "AMQP group-sequence",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP group-sequence value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP group-sequence required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP group-id required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "group_sequence": {
+                              "name": "group_sequence",
+                              "description": "AMQP group-sequence",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP group-sequence value template",
+                                  "type": "string"
                                 },
-                                "reply_to_group_id": {
-                                  "description": "AMQP reply-to-group-id",
-                                  "type": "object",
-                                  "item": {
-                                    "attributes": {
-                                      "value": {
-                                        "description": "AMQP reply-to-group-id value template",
-                                        "type": "string"
-                                      },
-                                      "required": {
-                                        "description": "AMQP reply-to-group-id required",
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP group-sequence required",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "reply_to_group_id": {
+                              "name": "reply_to_group_id",
+                              "description": "AMQP reply-to-group-id",
+                              "type": "object",
+                              "attributes": {
+                                "value": {
+                                  "name": "value",
+                                  "description": "AMQP reply-to-group-id value template",
+                                  "type": "string"
+                                },
+                                "required": {
+                                  "name": "required",
+                                  "description": "AMQP reply-to-group-id required",
+                                  "type": "boolean"
                                 }
                               }
                             }
-                          },
-                          "application_properties": {
-                            "type": "map",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "value": {
-                                    "description": "The application property value template",
-                                    "type": "string"
-                                  },
-                                  "required": {
-                                    "description": "The application property required",
-                                    "type": "boolean"
-                                  },
-                                  "type": {
-                                    "description": "The application property type",
-                                    "type": "string"
-                                  }
-                                }
+                          }
+                        },
+                        "application_properties": {
+                          "name": "application_properties",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "The application property value template",
+                              "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "The application property required",
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "name": "type",
+                              "description": "The application property type",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "message_annotations": {
+                          "name": "message_annotations",
+                          "type": "map",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "value": {
+                                "name": "value",
+                                "description": "The message annotation value",
+                                "type": "string"
+                              },
+                              "required": {
+                                "name": "required",
+                                "description": "Whether the message annotation is required",
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "The message annotation type",
+                                "type": "string"
                               }
                             }
-                          },
-                          "message_annotations": {
-                            "type": "map",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "value": {
-                                    "description": "The message annotation value",
-                                    "type": "string"
-                                  },
-                                  "required": {
-                                    "description": "Whether the message annotation is required",
-                                    "type": "boolean"
-                                  },
-                                  "type": {
-                                    "description": "The message annotation type",
-                                    "type": "string"
-                                  }
-                                }
+                          }
+                        },
+                        "delivery_annotations": {
+                          "name": "delivery_annotations",
+                          "type": "map",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "value": {
+                                "name": "value",
+                                "description": "The delivery annotation value",
+                                "type": "string"
+                              },
+                              "required": {
+                                "name": "required",
+                                "description": "Whether the annotation is required",
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "The annotation type",
+                                "type": "string"
                               }
                             }
-                          },
-                          "delivery_annotations": {
-                            "type": "map",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "value": {
-                                    "description": "The delivery annotation value",
-                                    "type": "string"
-                                  },
-                                  "required": {
-                                    "description": "Whether the annotation is required",
-                                    "type": "boolean"
-                                  },
-                                  "type": {
-                                    "description": "The annotation type",
-                                    "type": "string"
-                                  }
-                                }
+                          }
+                        },
+                        "header": {
+                          "name": "header",
+                          "type": "map",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "value": {
+                                "name": "value",
+                                "description": "AMQP header value",
+                                "type": "string"
+                              },
+                              "required": {
+                                "name": "required",
+                                "description": "AMQP header required",
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "AMQP header type",
+                                "type": "string"
                               }
                             }
-                          },
-                          "header": {
-                            "type": "map",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "value": {
-                                    "description": "AMQP header value",
-                                    "type": "string"
-                                  },
-                                  "required": {
-                                    "description": "AMQP header required",
-                                    "type": "boolean"
-                                  },
-                                  "type": {
-                                    "description": "AMQP header type",
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          },
-                          "footer": {
-                            "type": "map",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "value": {
-                                    "description": "AMQP footer value",
-                                    "type": "string"
-                                  },
-                                  "required": {
-                                    "description": "AMQP footer required",
-                                    "type": "boolean"
-                                  },
-                                  "type": {
-                                    "description": "AMQP footer type",
-                                    "type": "string"
-                                  }
-                                }
+                          }
+                        },
+                        "footer": {
+                          "name": "footer",
+                          "type": "map",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "value": {
+                                "name": "value",
+                                "description": "AMQP footer value",
+                                "type": "string"
+                              },
+                              "required": {
+                                "name": "required",
+                                "description": "AMQP footer required",
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "AMQP footer type",
+                                "type": "string"
                               }
                             }
                           }
@@ -489,44 +504,43 @@
                 "MQTT/3.1.1": {
                   "siblingattributes": {
                     "message": {
+                      "name": "message",
                       "description": "MQTT message metadata constraints",
                       "type": "object",
-                      "item": {
-                        "attributes": {
-                          "qos": {
-                            "description": "MQTT qos",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT qos value template",
-                                  "type": "string"
-                                }
-                              }
+                      "attributes": {
+                        "qos": {
+                          "name": "qos",
+                          "description": "MQTT qos",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT qos value template",
+                              "type": "string"
                             }
-                          },
-                          "retain": {
-                            "description": "MQTT retain",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT retain value template",
-                                  "type": "boolean"
-                                }
-                              }
+                          }
+                        },
+                        "retain": {
+                          "name": "retain",
+                          "description": "MQTT retain",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT retain value template",
+                              "type": "boolean"
                             }
-                          },
-                          "topic_name": {
-                            "description": "MQTT topic-name",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT topic-name value template",
-                                  "type": "string"
-                                }
-                              }
+                          }
+                        },
+                        "topic_name": {
+                          "name": "topic_name",
+                          "description": "MQTT topic-name",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT topic-name value template",
+                              "type": "string"
                             }
                           }
                         }
@@ -537,110 +551,110 @@
                 "MQTT/5.0": {
                   "siblingattributes": {
                     "message": {
+                      "name": "message",
                       "description": "MQTT message metadata constraints",
                       "type": "object",
-                      "item": {
-                        "attributes": {
-                          "qos": {
-                            "description": "MQTT qos",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT qos value template",
-                                  "type": "integer"
-                                }
-                              }
+                      "attributes": {
+                        "qos": {
+                          "name": "qos",
+                          "description": "MQTT qos",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT qos value template",
+                              "type": "integer"
                             }
-                          },
-                          "retain": {
-                            "description": "MQTT retain",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT retain value template",
-                                  "type": "boolean"
-                                }
-                              }
+                          }
+                        },
+                        "retain": {
+                          "name": "retain",
+                          "description": "MQTT retain",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT retain value template",
+                              "type": "boolean"
                             }
-                          },
-                          "topic_name": {
-                            "description": "MQTT topic-name",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT topic-name value template",
-                                  "type": "string"
-                                }
-                              }
+                          }
+                        },
+                        "topic_name": {
+                          "name": "topic_name",
+                          "description": "MQTT topic-name",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT topic-name value template",
+                              "type": "string"
                             }
-                          },
-                          "message_expiry_interval": {
-                            "description": "MQTT message-expiry-interval",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT message-expiry-interval value template",
-                                  "type": "integer"
-                                }
-                              }
+                          }
+                        },
+                        "message_expiry_interval": {
+                          "name": "message_expiry_interval",
+                          "description": "MQTT message-expiry-interval",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT message-expiry-interval value template",
+                              "type": "integer"
                             }
-                          },
-                          "response_topic": {
-                            "description": "MQTT response-topic",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT response-topic value template",
-                                  "type": "string"
-                                }
-                              }
+                          }
+                        },
+                        "response_topic": {
+                          "name": "response_topic",
+                          "description": "MQTT response-topic",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT response-topic value template",
+                              "type": "string"
                             }
-                          },
-                          "correlation_data": {
-                            "description": "MQTT correlation-data",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT correlation-data value template",
-                                  "type": "binary"
-                                }
-                              }
+                          }
+                        },
+                        "correlation_data": {
+                          "name": "correlation_data",
+                          "description": "MQTT correlation-data",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT correlation-data value template",
+                              "type": "string"
                             }
-                          },
-                          "content_type": {
-                            "description": "MQTT content-type",
-                            "type": "object",
-                            "item": {
-                              "attributes": {
-                                "value": {
-                                  "description": "MQTT content-type value template",
-                                  "type": "string"
-                                }
-                              }
+                          }
+                        },
+                        "content_type": {
+                          "name": "content_type",
+                          "description": "MQTT content-type",
+                          "type": "object",
+                          "attributes": {
+                            "value": {
+                              "name": "value",
+                              "description": "MQTT content-type value template",
+                              "type": "string"
                             }
-                          },
-                          "user_properties": {
-                            "description": "MQTT user-properties",
-                            "type": "array",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "name": {
-                                    "description": "MQTT user-property name",
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "description": "MQTT user-property value",
-                                    "type": "string"
-                                  }
-                                }
+                          }
+                        },
+                        "user_properties": {
+                          "name": "user_properties",
+                          "description": "MQTT user-properties",
+                          "type": "array",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "name": {
+                                "name": "name",
+                                "description": "MQTT user-property name",
+                                "type": "string"
+                              },
+                              "value": {
+                                "name": "value",
+                                "description": "MQTT user-property value",
+                                "type": "string"
                               }
                             }
                           }
@@ -652,45 +666,49 @@
                 "KAFKA": {
                   "siblingattributes": {
                     "message": {
+                      "name": "message",
                       "description": "The Apache Kafka message metadata constraints",
                       "type": "object",
-                      "item": {
-                        "attributes": {
-                          "topic": {
-                            "description": "The Apache Kafka topic",
-                            "type": "string"
-                          },
-                          "partition": {
-                            "description": "The Apache Kafka partition",
-                            "type": "integer"
-                          },
-                          "key": {
-                            "description": "The Apache Kafka key",
-                            "type": "binary"
+                      "attributes": {
+                        "topic": {
+                          "name": "topic",
+                          "description": "The Apache Kafka topic",
+                          "type": "string"
                         },
-                          "headers": {
-                            "description": "The Apache Kafka headers",
-                            "type": "map",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "name": {
-                                    "description": "The Apache Kafka header name",
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "description": "The Apache Kafka header value",
-                                    "type": "string"
-                                  }
-                                }
+                        "partition": {
+                          "name": "partition",
+                          "description": "The Apache Kafka partition",
+                          "type": "integer"
+                        },
+                        "key": {
+                          "name": "key",
+                          "description": "The Apache Kafka key",
+                          "type": "string"
+                        },
+                        "headers": {
+                          "name": "headers",
+                          "description": "The Apache Kafka headers",
+                          "type": "map",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "name": {
+                                "name": "name",
+                                "description": "The Apache Kafka header name",
+                                "type": "string"
+                              },
+                              "value": {
+                                "name": "value",
+                                "description": "The Apache Kafka header value",
+                                "type": "string"
                               }
                             }
-                          },
-                          "timestamp": {
-                            "description": "The Apache Kafka timestamp",
-                            "type": "integer"
                           }
+                        },
+                        "timestamp": {
+                          "name": "timestamp",
+                          "description": "The Apache Kafka timestamp",
+                          "type": "integer"
                         }
                       }
                     }
@@ -699,41 +717,44 @@
                 "HTTP": {
                   "siblingattributes": {
                     "message": {
+                      "name": "message",
                       "description": "The HTTP message metadata constraints",
                       "type": "object",
-                      "item": {
-                        "attributes": {
-                          "headers": {
-                            "description": "The HTTP headers",
-                            "type": "array",
-                            "item": {
-                              "type": "object",
-                              "item": {
-                                "attributes": {
-                                  "name": {
-                                    "description": "The HTTP header name",
-                                    "type": "string"
-                                  },
-                                  "value": {
-                                    "description": "The HTTP header value",
-                                    "type": "string"
-                                  }
-                                }
+                      "attributes": {
+                        "headers": {
+                          "name": "headers",
+                          "description": "The HTTP headers",
+                          "type": "array",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "name": {
+                                "name": "name",
+                                "description": "The HTTP header name",
+                                "type": "string"
+                              },
+                              "value": {
+                                "name": "value",
+                                "description": "The HTTP header value",
+                                "type": "string"
                               }
                             }
-                          },
-                          "query": {
-                            "description": "The HTTP query parameters",
-                            "type": "object"
-                          },
-                          "path": {
-                            "description": "The HTTP path as a uri template",
-                            "type": "string"
-                          },
-                          "method": {
-                            "description": "The HTTP method",
-                            "type": "string"
                           }
+                        },
+                        "query": {
+                          "name": "query",
+                          "description": "The HTTP query parameters",
+                          "type": "object"
+                        },
+                        "path": {
+                          "name": "path",
+                          "description": "The HTTP path as a uri template",
+                          "type": "string"
+                        },
+                        "method": {
+                          "name": "method",
+                          "description": "The HTTP method",
+                          "type": "string"
                         }
                       }
                     }


### PR DESCRIPTION
- define valid map key name chars: `[a-z0-9]`, `-`, `_` or a `.`
- key names: HTTP headers: xRegistry-ATTRIBUTENAME-KEY: VALUE
  - KEY can have `-`, so 3rd+ `-` is part of the key name
- more model clean-up
- add more primer stuff and start to elaborate on the primer topics
- `null` in a scalar array must generate an error
- s/ifValue/ifValues/g
- split `item` into two things: `attributes` and `item`
  - `item` is used for map/array
  - `attributes` are for objects
  - cleans up the model a bit - it was error prone before
- defined a `contenttype` attribute, use Content-Type http header
- allow for `latest` to be specified even when server doesn't support
  client-side setting of "latest version" as long as their desire matches
  what the server was going to do anyway. Else error