### PR TITLE
Changes for the week of May 1

### DIFF
--- a/core/primer.md
+++ b/core/primer.md
@@ -152,3 +152,15 @@ Let's walk through a complex example:
 - The result is: v8 regardless of whether v8 was created with latest=true or
   not
 
+# Potential Extensions
+
+- `createdby`, `modifiedby`<br>
+  These are related to the `createdat` and `modifiedat` attributes in that
+  they would normally be updated at the same time as their corresponding
+  `*at` attribute, and are use to track the identity of the person or
+  component that performed the related operation.
+
+  The xRegistry specfication does not define these since it does not define
+  any authentication mechanisms, or even manage tracking of these identities.
+  However, if an implementation does track this information, these attributes
+  might be of interest.

--- a/tools/dict
+++ b/tools/dict
@@ -1,10 +1,11 @@
 charset
 clientrequired
 contenttype
-createdby
 createdat
 datastore
 datatracker
+defaultversionid
+defaultversionurl
 definitionscount
 definitionsurl
 emoji
@@ -29,11 +30,8 @@ interoperable
 isdefault
 json
 jsonSchema
-defaultversionid
-defaultversionurl
 maxversions
 metadata
-modifiedby
 modifiedat
 myattr
 myendpoint
@@ -47,6 +45,9 @@ myschema
 mySchema
 mySchemas
 nbsp
+nodefaultversionid
+noepoch
+nostickydefaultversion
 png
 readonly
 rID
@@ -55,8 +56,8 @@ schemagroups
 schemagroupscount
 schemagroupsurl
 serverrequired
-setstickydefaultversion
 setdefaultversionid
+setstickydefaultversion
 setversionid
 siblingattributes
 someattribute


### PR DESCRIPTION
- clarify that `id` is required in responses and doc view, not requests since
      the `id` can be inferred in most other cases
- fix some typos- lots of cleanup, mainly trying to remove duplicate information
- moved `createdby` and `modifiedby` to be "Potential extensions" mentioned
  in the Primer
- added `createdat` and `modifiedat` as Registry attributes, to be consistent
  with Groups, Resources and Versions
- made `createdat` and `modifiedat` required attributes for servers to support
  and expose. They're also now mutable, so clients can set them when needed
  and we preserve their values during an "import"
- all `createdat` and `modifiedat` that are updated during the SAME operation
  that use "now" MUST use the same value. This means that if you upload a
  set of Versions w/o `createdat` timestamps, it will be indeterminate as to
  which Version will be the newest
- added support for PATCH, same as PUT but missing attributes remain unchanged
- made `stickydefaultversion` and `defaultversionid` Resource properties
  mutable - this is now the preferred way to set "default"
  - `stickydefaultvertsion` is processed first, then if 'true' we'll look
    at the `defaultversionid` attribute
- removed `?setdefaultversionid` query parameter when the Resource entity
  is present in the request, however we still need it for cases where
  Versions are modified by the Resource entity isn't present in the request
  - e.g. deleting Versions, or uploading Versions directly to the "versions"
  collection
- removed the ability to set just the default version pointer via a special
  POST to the resource. Instead just PATCH the Resource
- when processing a Resource with nested Versions:
  - process the "versions" collection first
  - apply the "defaultversionid"
  - apply the Resource's "default" attributes IFF the default Version wasn't
    in the incoming "versions" collection - to avoid conflicts

Fixes: #88
Fixes: #90
Fixes: #93
Fixes: #103
Fixes: #102

Also see: 

![image](https://github.com/xregistry/spec/assets/1944671/44b31b5b-d906-4737-80f2-054081aba9aa)

for how each type of attribute is processed during a PUT, POST or PATCH

