### PR TITLE
Changes for week of May 20

### DIFF
--- a/core/primer.md
+++ b/core/primer.md
@@ -11,7 +11,7 @@ Resources, like all xRegistry entities, have unique `id` values. Resource
 meaning of the purpose of the underlying Resource document. Also, since they
 are static values and as the Resource changes over time (meaning, new Versions
 are created), it's important for end-users to have a static URL reference to
-the latest Version of the Resource.
+the default Version of the Resource.
 
 Versions of a Resource, on the other hand, might change quite often and the
 `id` isn't meant to convey the purpose of the underlying entity, rather it is
@@ -45,7 +45,7 @@ Some of the challenges:
   networking components.
 - often attribute names, or object property names, are mapped into code
   variable or properties within code structures. While many programming
-  langugaes allow for a mapping from those names to their serialization
+  languages allow for a mapping from those names to their serialization
   names, often these mapping can introduce pain - either because they require
   additional work/configuration or simply due to errors being introduced
   by not using the language specific default mapping.
@@ -66,17 +66,17 @@ variable or structure property names - they're usually just stored as
   model. However, the spec does support an extension of "*" to allow for
   unknown/runtime-provided extensions. Since extensions can appear in case-
   insensitive situations (e.g. http header) we can't know the case of them
-  when storing in the backend. As a result, all attributes and keyNames MUST
+  when storing in the backend. As a result, all attributes and key names MUST
   be lowercase.
 
-- "latest" Resource is just a pointer, NOT a set of default values
+- "default" Resource is just a pointer, NOT a set of default values
 - we allow for implicit creation of a resource's tree rather than requiring
-  multiple create operations - just for convinience
+  multiple create operations - just for convenience
 - if/when we support serializing in non-json formats, we'll need to define
   the serialization rules. E.g. when attributes appear as xml attributes vs
   nested elements
 - when hasdocument=false, we might need to talk about when ?meta appears on the
-  various URLs (self, latestversionurl, location,...). Right now its presence
+  various URLs (self, defaultversionurl, location,...). Right now its presence
   will match what was used in the request (either explicitly or implicity).
   So GET resource?meta or GET group?inline both ask for metadata
 - xRegistry- headers: first "-" separates xRegistry from attribute name,
@@ -89,18 +89,18 @@ variable or structure property names - they're usually just stored as
 - discuss any potential semantic gotchas when one attribute is required
   but a nested attribute is optional, or also required (and visa-versa)
   - reminder: clientrequired=true means serverrequired=true as well, else error
-- how MIGHT someone implement mutli-tenancy with xRegistry
+- how MIGHT someone implement multi-tenancy with xRegistry
   - and layers of xRegistries to get multi-level grouping ??
 
 ### Deleting entities
 
 The "delete" operation typically has two variants:
-- DELETE .../ID[?setlatestversionid=vID]
-- DELETE .../COLLECTION[?setlatestversionid=vID]
+- DELETE .../ID[?setdefaultversionid=vID]
+- DELETE .../COLLECTION[?setdefaultversionid=vID]
 
 where the first will delete a single entity, and the second can be used to
 delete multiple entities. In the second case there are a couple of design
-points wother noting:
+points worth noting:
 - if the HTTP body is empty, then the entire collection will be deleted.
   If the collection is `versions`, then the owning Resource must also be
   deleted since a Resource must always have at least one Version
@@ -113,43 +113,43 @@ points wother noting:
   This is because the net result will be what the user is asking for.
   Note, that this is different from `DELETE ../ID` case where if the
   referenced entity can not be found then a `404` must be generated.
-- when the `?setlatestversionid` query parameter is specified (when
+- when the `?setdefaultversionid` query parameter is specified (when
   deleting Version) then it will be applied after all requested items have
-  been deleted scucessfully. It can be used even if the current "latest"
+  been deleted successfully. It can be used even if the current "default"
   Version isn't being deleted.  Note that a `404` in the `DELETE .../ID` case
-  is an error and no changes to the "latest" Version will occur.
+  is an error and no changes to the "default" Version will occur.
 
-# Latest Version and Maximum Versions
+# Default Version and Maximum Versions
 
 Each Resource type can specify the maximum number of Versions that the
 server must save. Once that limit is reached then it must delete Versions
 to stay within the limit - by deleting oldest Versions first. However, since
-tagging a Version as "latest" marks that Version as special, this pruning
-logic must skip the "latest" Version. There is one exception to this rule.
+tagging a Version as "default" marks that Version as special, this pruning
+logic must skip the "default" Version. There is one exception to this rule.
 If the maximum Versions is set to 1 then when a new Version is created, that
-Version will become the "latest" Version regardless of whether or not the
+Version will become the "default" Version regardless of whether or not the
 user asked for it to be.
 
 In general, during an operation that creates, updates or deletes the Versions
 of a Resource, the following logic is applied:
 - Modify the Versions collection as requested
-- Apply the "latest" processing logic by setting (or not) which Version is the
-  "latest"
+- Apply the "default" processing logic by setting (or not) which Version is the
+  "default"
 - If the number of Versions exceeds the maximum allowed Versions then, starting
   with the oldest, keep deleting until the collection is within the limit.
   Except if the limit is 1, in which case if a new Version is created then it
-  it tagged as "latest"
+  it tagged as "default"
 
 Let's walk through a complex example:
 - Max allowed Versions is 2
-- Initially the following Versions exist: v4, v2 (latest)
+- Initially the following Versions exist: v4, v2 (default)
 - Max allowed Versions is now set to 0 (meaning unlimited)
-- New Versions are created in this order: v5 (latest=true), v6, v7
-- The resulting Versions are (newest to oldest): v7, v6, v5 (latest), v4, v2
+- New Versions are created in this order: v5 (default=true), v6, v7
+- The resulting Versions are (newest to oldest): v7, v6, v5 (default), v4, v2
 - The maximum allowed Version is now set to 1, this will cause pruning
-- The result is: v5. Note that it is not v7 because v5 was tagged as "latest"
+- The result is: v5. Note that it is not v7 because v5 was tagged as "default"
 - A new Version (v8) is created
-- The result is: v8 regardless of whether v8 was created with latest=true or
+- The result is: v8 regardless of whether v8 was created with isdefault=true or
   not
 
 # Potential Extensions
@@ -160,7 +160,92 @@ Let's walk through a complex example:
   `*at` attribute, and are use to track the identity of the person or
   component that performed the related operation.
 
-  The xRegistry specfication does not define these since it does not define
+  The xRegistry specification does not define these since it does not define
   any authentication mechanisms, or even manage tracking of these identities.
   However, if an implementation does track this information, these attributes
   might be of interest.
+
+# Why Epoch?
+
+Why such an unusual name? As the specification describes, `epoch` is used as a
+way to help detect when an entity has been modified. It is very similar to
+HTTP's [ETag](https://datatracker.ietf.org/doc/html/rfc9110#name-etag)
+header.
+
+When choosing a name for this attribute the most obvious choices revolved
+the word `version`. However, the potential overlapping naming and differing
+semantics conflicts with the Version entity of the model could lead to
+confusion. We decided to use `epoch` because "epoch" is about "time",
+which is indirectly related to what this attribute is meant to convey: has
+this entity's history changed?
+
+Additionally, the word is unique enough that the chances of people assuming
+they know what it means due to some other usage in this technology space
+seemed unlikely. In fact, use of this word might pique people's curiosity
+and cause them to look it up in the specification to find out more about it.
+
+# Naming and Case Sensitivity
+
+The following explains some of the reasoning behind the casing and case
+sensitivity rules in the specification.
+
+- Attributes must be lower case.
+  Attributes, include extensions attributes, can appear in many different
+  locations. When serialized as part of the xRegistry metadata for an entity,
+  they would appear in a JSON object as an attribute name and in those cases
+  the case of the name matters. However, that same name might also appear in
+  an HTTP header name - where its case is not relevant, and can be freely
+  changed by middleware.
+
+  Since it is possible for unknown attributes to appear in case insensitive
+  locations, it would then be impossible for implementations of the
+  specification to know what the true/intended case of the attribute name
+  should be. To avoid mismatches, confusion and interoperability issues, the
+  specification requires all attribute names to be in lower case. This avoids
+  complicated logic to guess as to the proper case of these names.
+
+- Groups and Resources must be lower case.
+  The plural version of the Group and Resource type names can appear in URLs
+  (which is case sensitive). Additionally, the plural variant can also appear
+  in attribute names (e.g. COLLECTION attributes), and as discussed above,
+  attributes must be lower case.
+
+  The singular version of the Group and Resource type names, can also appear
+  in the RESOURCE attributes, which (again) means they must be lower case.
+
+  For these reasons, both the plural and singular names of Group and Resource
+  types must be defined as lower case.
+
+- IDs are case sensitive and case insensitive.
+  Entity identifiers (`id`s), never appear as attribute or HTTP header
+  names. Meaning, they never appear in case insensitive locations, so they
+  do not have the same constraints that attributes, Groups or Resources do.
+  For this reason, IDs are not restricted to using just lower case letters.
+  This then also means that when there is a "look-up" done by an ID, it must
+  be done in a case sensitive way.
+
+  However, there is another aspect of IDs that needs to be taken into account:
+  the human factor. Despite them being case sensitive, if the specification
+  allowed for two entities at the same location in the data model to exist
+  where they had the same IDs except for their case, it could make things very
+  error prone for users and leave them with a bad user experience.
+
+  For this reason, while the processing of IDs is treated as case sensitive
+  values, the specification requires that IDs must be case insensitive unique
+  within the scope of its parent entity.
+
+  While it may have been more consistent to just require IDs to be lower case
+  like many of the other names in the specification, it was deemed unnecessary
+  from a technical perspective. Additionally, IDs are often exposed to end
+  users as unique identifiers (almost as a "name"), allowing mixed case can
+  provider a better user experience.
+
+  Additionally, treating them in a case insensitive way could lead to
+  inconsistencies and frustration for users. If a user purposely used a certain
+  casing pattern, but then someone else use a different pattern for the same
+  entity, it is possible that one of those users would end up seeing an
+  unexpected casing and could be confused or believe there was an error.
+
+  All of these concerns are avoided by requiring IDs to be stored and compared
+  in case insensitively.
+

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,30 +4,10 @@ verify: spellcheck tabcheck test_tools
 	@python tools/verify.py .
 
 spellcheck:
-	@echo Spell-checking
-	@# Words from: https://raw.githubusercontent.com/dwyl/english-words/master/words_alpha.txt
-	@ sed "s/\([a-z0-9]\+\)/\n\1\n/gI" < core/spec.md | sort -iu | \
-		grep "^[a-z]" | grep -v "[0-9]" > specwords
-	@ sort -u tools/words tools/dict > words
-	@ comm -23 specwords words > extra
-	@ wc -l extra | grep "^0 extra" > /dev/null || \
-		( echo "\nMISSPELLED:" ; cat extra ; exit 1 )
-	@ rm specwords words extra
+	tools/spellcheck core/spec.md core/primer.md
 
 tabcheck:
-	@echo Checking for tabs
-	@if grep -P '\t' core/spec.md > /dev/null ; then \
-	  echo "spec.md contains tabs" ; \
-	  exit 1 ; \
-	else \
-	  exit 0 ; \
-	fi
-	@if grep "  *$$" core/spec.md > /dev/null ; then \
-	  echo "spec.md contains lines with extra spaces at the end" ; \
-	  exit 1 ; \
-	else \
-	  exit 0 ; \
-	fi
+	tools/tabcheck core/spec.md core/primer.md
 
 deps:
 	@echo Loading python deps

--- a/tools/dict
+++ b/tools/dict
@@ -1,7 +1,9 @@
+backend
 charset
 clientrequired
 contenttype
 createdat
+createdby
 datastore
 datatracker
 defaultversionid
@@ -12,8 +14,10 @@ emoji
 endpointscount
 endpointsurl
 enum
+etag
 filesystem
 gID
+gotchas
 hasdocument
 html
 http
@@ -32,7 +36,9 @@ json
 jsonSchema
 maxversions
 metadata
+middleware
 modifiedat
+modifiedby
 myattr
 myendpoint
 myEndpoint
@@ -45,6 +51,7 @@ myschema
 mySchema
 mySchemas
 nbsp
+nginx
 nodefaultversionid
 noepoch
 nostickydefaultversion
@@ -84,5 +91,7 @@ xreg
 xregbasicmodel
 xregfullmodel
 xRegistry
+xRegistries
+xml
 xy
 yaml

--- a/tools/spellcheck
+++ b/tools/spellcheck
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Words from:
+# https://raw.githubusercontent.com/dwyl/english-words/master/words_alpha.txt
+
+set -e
+
+for f in $* ; do
+
+  echo Spell-checking: $f
+
+  sed "s/\([a-z0-9]\+\)/\n\1\n/gI" < $f | sort -iu | \
+	grep "^[a-z]" | grep -v "[0-9]" > specwords
+  sort -u tools/words tools/dict > words
+  comm -23 specwords words > extra
+  wc -l extra | grep "^0 extra" > /dev/null || \
+	( echo -e "\nMISSPELLED:" ; cat extra ; exit 1 )
+  rm specwords words extra
+
+done

--- a/tools/tabcheck
+++ b/tools/tabcheck
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+for f in $* ; do
+  echo Checking for tabs: $f
+
+  if grep -P '\t' $f > /dev/null ; then
+    echo "$f contains tabs" 
+    exit 1
+  fi
+
+  if grep "  *$" $f > /dev/null ; then 
+    echo "$f contains lines with extra spaces at the end" 
+    exit 1
+  fi
+
+done


### PR DESCRIPTION
- epoch and modifiedat are always updated on any write operation, even empty (`{}` ) PATCH
- s/?meta/$meta/
  - POST to `/GROUPs/gID/RESOURCEs/rID[$meta]` now only creates/updates one Version. 
  - POST to `/GROUPs/gID/RESOURCEs/rID/versions` is used to update or create one or more Versions as metadata
  - Before this PR `/GROUPs/gID/RESOURCEs/rID` was an alias for `.../versions` and we could tell if they wanted to create a single version by doc because of the missing "?meta". But now w/o ?meta, `.../versions$meta` is just too weird so `.../versions` is treated like all other collections- it takes a map, which means it takes a map of Resource metadata
- make all query params optional (via SHOULD) to enable simple static file server implemenations
- `id` is now case insensitive for uniqueness, but case sensitive for look-up
   - e.g. `PUT /dirs/d1/files/f1/versions/v1`  and then `GET /dirs/D1/files/F1/versions/V1` will fail for any of the 3 IDs specified 
- move logic from Makefile into new tools
- add casing explanation to primer
