### PR TITLE
First proposal how to add .well-known URI location to xRegistry

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-end_of_line = lf
-indent_style = space
-trim_trailing_whitespace = true
-
-[*.{md}]
-max_line_length: 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.{md}]
+max_line_length: 80

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .vscode/launch.json
+.editorconfig

--- a/core/spec.md
+++ b/core/spec.md
@@ -1130,7 +1130,7 @@ following [RFC8615](https://datatracker.ietf.org/doc/html/rfc8615).
 It acts as a single entrypoint from where locations and capabilities of the
 xRegistry implementation can be retrieved. Since this URL is always the same,
 it can be used to find out whether xRegistry is supported and where to find the API.
-It also allows to support multiple versions of the xRegistry protocol at the same time
+It allows for support of multiple versions of the xRegistry protocol at the same time
 and allows implementers to choose their own API base path.
 
 The capabilities described on this level are independent from the xRegistry protocol version or its current meta model.

--- a/core/spec.md
+++ b/core/spec.md
@@ -1137,7 +1137,6 @@ and allows implementers to choose their own API base path.
 {
   # The following top-level attributes are identical to the xRegistry API root response
   # We may consider removing them here if we're bothered by the duplication.
-  "specversion": "STRING", # latest version of spec that is supported (?)
   "id": "STRING",
   "name": "STRING", ?
   "epoch": UINTEGER,
@@ -1150,14 +1149,15 @@ and allows implementers to choose their own API base path.
 
   # Describe where to find the xRegistry API and its capabilities
   "apis": {
-    "v1": { # Version of the xRegistry API protocol. In the future, there could be v2 in parallel.
-      "apiUrl": "URL", ? # Point to root URL of xRegistry API, e.g. /x-registry/v1/
+    "v1": { # Major version of the xRegistry API protocol. In the future, there could be v2 in parallel.
+      "specversion": "STRING", # full specversion, as returned by the API root response
+      "apiurl": "URL", ? # Point to root URL of xRegistry API, e.g. /x-registry/v1/
       "capabilities": ["inline", ""] # TODO: TBD
       # TODO: Also indicate whether API is available without protection or if protected, how to get access?
     }
   }
 
-  "modelUrl": { Registry model }, ? # Point to registry meta model
+  "modelurl": "URL", ? # Point to registry meta model
 }
 ```
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -1156,6 +1156,8 @@ They resemble the capabilities of the xRegistry implementation itself that consu
 
 It is RECOMMENDED to leave this endpoint unprotected as it SHOULD NOT contain any sensitive information.
 
+The well-known location SHOULD be available starting from the base URL, to enable fully automated discovery of the xRegistry capability.
+
 ### Registry Entity
 
 The Registry entity represents the root of a Registry and is the main

--- a/core/spec.md
+++ b/core/spec.md
@@ -1152,7 +1152,7 @@ and allows implementers to choose their own API base path.
     "v1": { # Major version of the xRegistry API protocol. In the future, there could be v2 in parallel.
       "specversion": "STRING", # full specversion, as returned by the API root response
       "apiurl": "URL", ? # Point to root URL of xRegistry API, e.g. /x-registry/v1/
-      "capabilities": ["inline", ""] # TODO: TBD
+      "capabilities": ["write", "update", "inline", "filter", "..."] # TODO: TBD
       # TODO: Also indicate whether API is available without protection or if protected, how to get access?
     }
   }

--- a/core/spec.md
+++ b/core/spec.md
@@ -58,13 +58,13 @@ can be defined that expose model specific Resources and metadata.
 
 A Registry consists of two main types of entities: Groups and Resources.
 
-Groups, as the name implies, is a mechanism by which related Resources are
+**Groups**, as the name implies, is a mechanism by which related Resources are
 arranged together under a single collection - the Group. The reason for the
 grouping is not defined by this specification, so the owners of the Registry
 can choose to define (or enforce) any pattern they wish. In this sense, a
 Group is similar to a "directory" on a filesystem.
 
-Resources represent the main data of interest for the Registry. In the
+**Resources** represent the main data of interest for the Registry. In the
 filesystem analogy, these would be the "files". A Resource exist under a
 single Group and, similar to Groups, have a set of Registry metadata.
 However, unlike a Group which only has Registry metadata, each Resource can
@@ -85,6 +85,11 @@ to a "Schema" document - all within the same Registry instance:
  height="300">&nbsp;&nbsp;&nbsp;<img
  src="./xregfullmodel.png" height="300">&nbsp;&nbsp;&nbsp;<img
  src="./sample.png" height="300">
+
+One purpose of the xRegistry is to enable easy and fully automated,
+machine-readable discovery. The starting point of the discovery is via a
+[well-known location](#registry-well-known-config): `/.well-known/xregistry.json`.
+This is relative to the base URL of the server.
 
 For easy reference, the JSON serialization of a Registry adheres to this form:
 
@@ -1116,6 +1121,47 @@ if, as an extension, the server chooses to return additional data in the
 HTTP body.
 
 ---
+
+### Registry Well-Known Config
+
+The registry comes with a well known location `/.well-known/xregistry.json`,
+following [RFC8615](https://datatracker.ietf.org/doc/html/rfc8615).
+
+It acts as a single entrypoint from where locations and capabilities of the
+xRegistry implementation can be retrieved. Since this URL is always the same,
+it can be used to find out whether xRegistry is supported and where to find the API.
+It also allows to support multiple versions of the xRegistry protocol at the same time
+and allows implementers to choose their own API base path.
+
+```yaml
+{
+  # The following top-level attributes are identical to the xRegistry API root response
+  # We may consider removing them here if we're bothered by the duplication.
+  "specversion": "STRING", # latest version of spec that is supported (?)
+  "id": "STRING",
+  "name": "STRING", ?
+  "epoch": UINTEGER,
+  "self": "URL",
+  "description": "STRING", ?
+  "documentation": "URL", ?
+  "labels": { "STRING": "STRING" * }, ?
+  "createdat": "TIME",
+  "modifiedat": "TIME",
+
+  # Describe where to find the xRegistry API and its capabilities
+  "apis": {
+    "v1": { # Version of the xRegistry API protocol. In the future, there could be v2 in parallel.
+      "apiUrl": "URL", ? # Point to root URL of xRegistry API, e.g. /x-registry/v1/
+      "capabilities": ["inline", ""] # TODO: TBD
+      # TODO: Also indicate whether API is available without protection or if protected, how to get access?
+    }
+  }
+
+  "modelUrl": { Registry model }, ? # Point to registry meta model
+}
+```
+
+It is RECOMMENDED to leave this endpoint unprotected as it SHOULD NOT contain any sensitive information.
 
 ### Registry Entity
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -1133,31 +1133,24 @@ it can be used to find out whether xRegistry is supported and where to find the 
 It also allows to support multiple versions of the xRegistry protocol at the same time
 and allows implementers to choose their own API base path.
 
+The capabilities described on this level are independent from the xRegistry protocol version or its current meta model.
+They resemble the capabilities of the xRegistry implementation itself that consumers can rely upon.
+
 ```yaml
 {
-  # The following top-level attributes are identical to the xRegistry API root response
-  # We may consider removing them here if we're bothered by the duplication.
-  "id": "STRING",
-  "name": "STRING", ?
-  "epoch": UINTEGER,
-  "self": "URL",
+  # Some high-level description of the xRegistry that are independent from version of the protocol nor its meta model
   "description": "STRING", ?
   "documentation": "URL", ?
-  "labels": { "STRING": "STRING" * }, ?
-  "createdat": "TIME",
-  "modifiedat": "TIME",
+  "labels": { "STRING": "STRING" * }, ? #
 
   # Describe where to find the xRegistry API and its capabilities
-  "apis": {
-    "v1": { # Major version of the xRegistry API protocol. In the future, there could be v2 in parallel.
-      "specversion": "STRING", # full specversion, as returned by the API root response
-      "apiurl": "URL", ? # Point to root URL of xRegistry API, e.g. /x-registry/v1/
-      "capabilities": ["write", "update", "inline", "filter", "..."] # TODO: TBD
-      # TODO: Also indicate whether API is available without protection or if protected, how to get access?
-    }
-  }
-
-  "modelurl": "URL", ? # Point to registry meta model
+  "apis": [{ # Major version of the xRegistry API protocol. In the future, there could be v2 in parallel.
+    "specversion": "STRING", # full specversion, as returned by the API root response
+    "apiurl": "URL", ? # Point to root URL of xRegistry API, e.g. /x-registry/v1/
+    "capabilities": ["write", "update", "inline", "filter", "..."] # TODO: TBD
+    "modelurl": "URL", ? # Point to registry meta model
+    # TODO: Also indicate whether API is available without protection or if protected, how to get access?
+  }], ? # To clarify if APIs are mandatory or if we want to allow an alternative, document based approach. (but not in this PR)
 }
 ```
 


### PR DESCRIPTION
As discussed in the meeting series, here is a first draft how we could incorporate the .well-known URI concept into the xRegistry.

This proposal only contains the minimum: Pointing to the xRegistry API location, which protocol version it is supporting and its capabilities. 

Related: #120 
Related: #106 

## Proposed Changes

- add  `.well-known/xregistry.json` as the entry point to an xRegistry server
- describe there where to find the xRegistry APIs (in the future, we may have v1 and v2) and their supported capabilities
- add top-level information that are free to give out openly (non-sensitive)
- adds `modelurl` to point to xRegistry metadata (or should this be protocol version dependent, too?)

**Release Note**

TODO: Will write this after we reviewed this.

```release-note

```
