### PR TITLE
Changes for week of June 25

### DIFF
--- a/tools/words
+++ b/tools/words
@@ -107794,6 +107794,7 @@ exported
 exporter
 exporters
 exporting
+exportrequired
 exports
 expos
 exposable
@@ -183317,6 +183318,8 @@ mess
 message
 messaged
 messageer
+messagegroup
+messagegroups
 messagery
 messages
 messaging
@@ -295494,6 +295497,7 @@ source
 sourceful
 sourcefulness
 sourceless
+sourceresource
 sources
 sourcrout
 sourd
@@ -315424,6 +315428,7 @@ targeting
 targetless
 targetlike
 targetman
+targetresource
 targets
 targetshooter
 targing
@@ -367378,6 +367383,7 @@ xicaque
 xii
 xiii
 ximenia
+ximport
 xina
 xinca
 xint


### PR DESCRIPTION
- add support for xref (cross referencing Resources
- add support for ximport - sharing of Resource definitions
- drop support for $import (the old "include-like" feature)
- add support for ?export query parameter
- add support for `exportrequired` flag in model

Fixes #112 