### PR TITLE
WIP - Introducing URI scheme `xreg` 

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -5,7 +5,7 @@ jobs:
     name: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/core/spec.md
+++ b/core/spec.md
@@ -10,13 +10,16 @@ automation and tooling.
 
 - [Overview](#overview)
 - [Notations and Terminology](#notations-and-terminology)
-  - [Notational Conventions](#notational-conventions)
-  - [Terminology](#terminology)
+    - [Notational Conventions](#notational-conventions)
+    - [Terminology](#terminology)
 - [Registry Attributes and APIs](#registry-attributes-and-apis)
   - [Attributes and Extensions](#attributes-and-extensions)
+    - [Common Attributes](#common-attributes)
+    - [`xid` - Referencing xRegistry Entities](#xid---referencing-xregistry-entities)
   - [Registry APIs](#registry-apis)
     - [Registry Collections](#registry-collections)
     - [Entity Processing Rules](#entity-processing-rules)
+  - [`xid` Resolution API](#xid-resolution-api)
   - [Registry Entity](#registry-entity)
     - [Retrieving the Registry](#retrieving-the-registry)
     - [Updating the Registry Entity](#updating-the-registry-entity)
@@ -437,7 +440,9 @@ attributes. However they MUST adhere to the following rules:
   example, use of a model (or domain) specific prefix could be used to help
   avoid possible future conflicts.
 
-#### `xid` - Referencing xRegistry Entities
+#### `xid`
+
+##### Referencing xRegistry Entities
 
 An `xid` is a URI according to
 [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) that
@@ -448,8 +453,9 @@ is helpful to use a URI, e.g. events or knowledge graphs.
 Each entity has exactly one `xid`. Therefore, comparing two `xid`
 values is possible to determine, if they identify the same or different
 entities. To achieve this, an xRegistry-specific URI scheme `xreg` is defined:
+ABNF https://datatracker.ietf.org/doc/html/rfc5234
 
-`xid` = `"xreg://" authority "/" entity-path "/" entity-id`
+`xid` = `"xreg://" authority "/" entity-path`
 
 `entity-path` = `group-path` / `resource-path` / `version-path`
 
@@ -469,30 +475,30 @@ Where:
 - `rID` is the `id` of a single Resource.
 - `vID` is the `id` of a single Version of a Resource.
 
-##### `authority`
+###### `authority`
 
 The `authority` is a string that uniquely identifies the entity's authority.
-It could be regarded as a namespace and SHOULD be based on a domain name that is
-under the control of the entity's publisher.
+It could be regarded as a namespace and SHOULD be based on a unique name
+like an entry in the domain name system (DNS) that is under the control of
+the entity's publisher.
 
-##### `entity-path`
+###### `entity-path`
 
 As xRegistry entities are organized in a hierarchy, the `entity-path`
 outlines the entity's position in the hierarchy. As the ABNF above shows,
 there can be paths for groups, resources, and versions.
 
-##### `entity-id`
-
 ##### De-referencing a relative URI reference
 
 A relative URI reference can only be de-referenced if the base URI is known
-from the context. 
+from the context.
 
-If the relative URI reference consists of a relative path segment, i.e. it 
-does not begin with a slash, then the base URI is the URI of the surrounding 
+If the relative URI reference consists of a relative path segment, i.e. it
+does not begin with a slash, then the base URI is the URI of the surrounding
 entity.
 
 __Example:__
+
 ```
 xid of surrounding entity: xreg://example.com/messagegroups/group2
 
@@ -501,11 +507,12 @@ Reference: messages/message1
 De-referenced URI: xreg://example.com/messagegroups/group2/messages/message1
 ```
 
-If the relative URI reference consists of an absolute path segment, i.e. it 
-begins with a slash, then the base URI is the authority of the surrounding 
+If the relative URI reference consists of an absolute path segment, i.e. it
+begins with a slash, then the base URI is the authority of the surrounding
 group.
 
-__Example:__ 
+__Example:__
+
 ```
 xid of surrounding group: xreg://example.com/messagegroups/group2
 
@@ -516,27 +523,32 @@ De-referenced URI: xreg://example.com/messagegroups/group1/messages/message1
 
 ```
 
-##### Resolving an `xid`
+##### Binding an `xid`
 
-As an `xid` is an abstract identifier of an entity, it is necessary to 
+As an `xid` is an abstract identifier of an entity, it is necessary to
 transform it into URLs or URL references to access the entity.
 
-For the HTTP API, the information from an `xid` can be used to construct a 
+For the HTTP API, the information from an `xid` can be used to construct a
 URL like this:
 
 `<Registry-base-URL>/GROUPs/{authority}${gID}/RESOURCEs/{rID}/versions/{vID}`
 
-The authority is OPTIONAL if it is identical to the registry's default 
-authority. For a file-based registry, the URL looks similar but makes use of 
-a URL fragment section: 
+The authority is OPTIONAL if it is identical to the registry's default
+authority. For a file-based registry, the URL looks similar but makes use of
+a URL fragment section:
 
 `<File-URL>/#GROUPs/{authority}${gID}/RESOURCEs/{rID}/versions/{vID}`
 
-Bindings to HTTP, AMQP, registry as document  etc.
+Further bindings MAY be defined in the future, e.g. for AMQP or GraphQL.
 
 ##### Comparing `xid` values
 
+A key feature of the `xid` is that it is a URI and can be efficiently compared
+with other `xids`:
 
+__Two `xids` are equal if and only if their authority, their group type name,
+their resource type name (if applicable), and all ID fields they contain are 
+equal.__
 
 #### Common Attributes
 
@@ -588,9 +600,9 @@ The definition of each attribute is defined below:
     be generated.
   - MUST be immutable.
 - Examples:
-  - `a183e0a9-abf8-4763-99bc-e6b7fcc9544b`
-  - `myEntity`
-  - `myEntity.example.com`
+    - `a183e0a9-abf8-4763-99bc-e6b7fcc9544b`
+    - `myEntity`
+    - `myEntity.example.com`
 
 While `SINGULARid` can be something like a UUID, when possible, it is
 RECOMMENDED that it be something human friendly as these values will often
@@ -657,10 +669,10 @@ of the existing entity. Then the existing entity can be deleted.
   might result in an epoch validation error for the second update request
   mention above.
 - Constraints:
-  - MUST be an unsigned integer equal to or greater than zero.
-  - MUST increase in value each time the entity is updated.
+    - MUST be an unsigned integer equal to or greater than zero.
+    - MUST increase in value each time the entity is updated.
 - Examples:
-  - `0`, `1`, `2`, `3`
+    - `0`, `1`, `2`, `3`
 
 ##### `name` Attribute
 
@@ -691,9 +703,9 @@ of the existing entity. Then the existing entity can be deleted.
 - Type: String
 - Description: A human readable summary of the purpose of the entity.
 - Constraints:
-  - None
+    - None
 - Examples:
-  - `A queue of the sensor generated messages`
+    - `A queue of the sensor generated messages`
 
 ##### `documentation` Attribute
 
@@ -702,10 +714,10 @@ of the existing entity. Then the existing entity can be deleted.
   This specification does not place any constraints on the data returned from
   an HTTP `GET` to this URL.
 - Constraints:
-  - If present, MUST be a non-empty URL.
-  - MUST support an HTTP(s) `GET` to this URL.
+    - If present, MUST be a non-empty URL.
+    - MUST support an HTTP(s) `GET` to this URL.
 - Examples:
-  - `https://example.com/docs/myQueue`
+    - `https://example.com/docs/myQueue`
 
 ##### `labels` Attribute
 
@@ -713,15 +725,15 @@ of the existing entity. Then the existing entity can be deleted.
 - Description: A mechanism in which additional metadata about the entity can
   be stored without changing the schema of the entity.
 - Constraints:
-  - If present, MUST be a map of zero or more name/value string pairs. See
-    [Attributes and Extensions](#attributes-and-extensions) for more
-    information.
-  - Keys MUST be non-empty strings.
-  - Values MAY be empty strings.
+    - If present, MUST be a map of zero or more name/value string pairs. See
+      [Attributes and Extensions](#attributes-and-extensions) for more
+      information.
+    - Keys MUST be non-empty strings.
+    - Values MAY be empty strings.
 - Examples:
-  - `"labels": { "owner": "John", "verified": "" }` when in the HTTP body
-  - `xRegistry-labels-owner: John` <br>
-    `xRegistry-labels-verified:`  when in HTTP headers
+    - `"labels": { "owner": "John", "verified": "" }` when in the HTTP body
+    - `xRegistry-labels-owner: John` <br>
+      `xRegistry-labels-verified:`  when in HTTP headers
 
   Note: HTTP header values can be empty strings but some client-side tooling
   might make it challenging to produce them. For example, `curl` requires
@@ -738,9 +750,9 @@ of the existing entity. Then the existing entity can be deleted.
   is the value of the `self` attribute and in those cases its presence in the
   serialization of the entity is OPTIONAL.
 - Constraints:
-  - OPTIONAL if this Registry is the authority owner.
-  - REQUIRED if this Registry is not the authority owner.
-  - If present, MUST be a non-empty URI.
+    - OPTIONAL if this Registry is the authority owner.
+    - REQUIRED if this Registry is not the authority owner.
+    - If present, MUST be a non-empty URI.
 - Examples:
   - `https://example2.com/myregistry/endpoints/ep1`
 
@@ -749,15 +761,15 @@ of the existing entity. Then the existing entity can be deleted.
 - Type: Timestamp
 - Description: The date/time of when the entity was created.
 - Constraints:
-  - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp.
-  - When present in a write operation request, the value MUST override any
-    existing value, however a value of `null` MUST use the current date/time
-    as the new value.
-  - When absent in a write operation request, any existing value MUST remain
-    unchanged, or if not present, set to the current date/time
-  - In cases where the `createdat` attribute is set to the current date/time
-    on multiple entities within the same operation, the same value MUST be
-    applied to all of the entities.
+    - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp.
+    - When present in a write operation request, the value MUST override any
+      existing value, however a value of `null` MUST use the current date/time
+      as the new value.
+    - When absent in a write operation request, any existing value MUST remain
+      unchanged, or if not present, set to the current date/time
+    - In cases where the `createdat` attribute is set to the current date/time
+      on multiple entities within the same operation, the same value MUST be
+      applied to all of the entities.
 - Examples:
   - `2030-12-19T06:00:00Z`
 
@@ -766,29 +778,29 @@ of the existing entity. Then the existing entity can be deleted.
 - Type: Timestamp
 - Description: The date/time of when the entity was last updated
 - Constraints:
-  - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp
-    representing the time when the entity was last updated.
-  - Any update operation (even one that does not change any attribute, such as
-    a `PATCH` with no attributes provided), MUST update this attribute. This
-    then acts like a `touch` type of operation.
-  - Upon creation of a new entity, this attribute MUST match the `createdat`
-    attribute's value.
-  - Setting an entity's `modifiedat` value MUST NOT update any parent
-    entity's `modifiedat` value.
-  - When present in a write operation request, the following applies:
-    - If the request value is the same as the existing value, then the
-      current date/time MUST be used as its new value.
-    - If the request value is different than the existing value, then the
-      request value MUST be used as its new value.
-    - If the request value is `null` then the current date/time MUST be used
-      as the new value.
-  - When absent in a write operation request, it MUST be set to the current
-    date/time.
-  - In cases where the `modifiedat` attribute is set to the current date/time
-    on multiple entities within the same operation, the same value MUST be
-    applied to all of the entities.
+    - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp
+      representing the time when the entity was last updated.
+    - Any update operation (even one that does not change any attribute, such as
+      a `PATCH` with no attributes provided), MUST update this attribute. This
+      then acts like a `touch` type of operation.
+    - Upon creation of a new entity, this attribute MUST match the `createdat`
+      attribute's value.
+    - Setting an entity's `modifiedat` value MUST NOT update any parent
+      entity's `modifiedat` value.
+    - When present in a write operation request, the following applies:
+        - If the request value is the same as the existing value, then the
+          current date/time MUST be used as its new value.
+        - If the request value is different than the existing value, then the
+          request value MUST be used as its new value.
+        - If the request value is `null` then the current date/time MUST be used
+          as the new value.
+    - When absent in a write operation request, it MUST be set to the current
+      date/time.
+    - In cases where the `modifiedat` attribute is set to the current date/time
+      on multiple entities within the same operation, the same value MUST be
+      applied to all of the entities.
 - Examples:
-  - `2030-12-19T06:00:00Z`
+    - `2030-12-19T06:00:00Z`
 
 ---
 
@@ -2031,31 +2043,31 @@ The following describes the attributes of Registry model:
     extension attributes. As such, it is only for informational purposes for
     clients.
 
-    Once set, any attempt to update the value MUST be silently ignored by
-    the server.
+      Once set, any attempt to update the value MUST be silently ignored by
+      the server.
 
-    When not specified, the default value is `false`.
-  - Type: Boolean.
-  - OPTIONAL.
+      When not specified, the default value is `false`.
+    - Type: Boolean.
+    - OPTIONAL.
 
 - `attributes."STRING".clientrequired`
-  - Indicates whether this attribute is a REQUIRED field for a client when
-    creating or updating an entity. When not specified the default value is
-    `false`. When the attribute name is `*` then `clientrequired` MUST NOT be
-    set to `true`.
+    - Indicates whether this attribute is a REQUIRED field for a client when
+      creating or updating an entity. When not specified the default value is
+      `false`. When the attribute name is `*` then `clientrequired` MUST NOT be
+      set to `true`.
 
-    During creation or update of an entity if this attribute is not
-    specified then an error MUST be generated.
+      During creation or update of an entity if this attribute is not
+      specified then an error MUST be generated.
 
-  - Type: Boolean.
-  - OPTIONAL.
+    - Type: Boolean.
+    - OPTIONAL.
 
 - `attributes."STRING".serverrequired`
-  - Indicates whether this attribute is a REQUIRED field for a server when
-    serializing an entity. When not specified the default value is `false`.
-    When the attribute name is `*` then `serverrequired` MUST NOT be set to
-    `true`. When `clientrequired` is `true` then `serverrequired` MUST also be
-    `true`.
+    - Indicates whether this attribute is a REQUIRED field for a server when
+      serializing an entity. When not specified the default value is `false`.
+      When the attribute name is `*` then `serverrequired` MUST NOT be set to
+      `true`. When `clientrequired` is `true` then `serverrequired` MUST also be
+      `true`.
 
   - Type: Boolean
   - OPTIONAL
@@ -2083,14 +2095,14 @@ The following describes the attributes of Registry model:
   - When not present, the default value is `version`.
 
 - `attributes."STRING".default`
-  - This value MUST be used to populate this attribute's value if one was
-    not provided by a client. An attribute with a default value does not mean
-    that its owning Object is mandated to be present, rather the attribute
-    would only appear when the owning Object is present. By default,
-    attributes have no default values.
-  - Type: MUST be the same type as the `type` of this attribute and MUST
-    only be used for scalar types.
-  - OPTIONAL.
+    - This value MUST be used to populate this attribute's value if one was
+      not provided by a client. An attribute with a default value does not mean
+      that its owning Object is mandated to be present, rather the attribute
+      would only appear when the owning Object is present. By default,
+      attributes have no default values.
+    - Type: MUST be the same type as the `type` of this attribute and MUST
+      only be used for scalar types.
+    - OPTIONAL.
 
 - `attributes."STRING".attributes`
   - This contains the list of attributes defined as part of a nested resource.
@@ -2100,24 +2112,24 @@ The following describes the attributes of Registry model:
     defined attributes for the nested `object`.
 
 - `attributes."STRING".item`
-  - Defines the nested resource that this attribute references. This
-    attribute MUST only be used when the owning attribute's `type` value is
-    `map` or `array`.
-  - Type: Object.
-  - REQUIRED when owning attribute's `type` is `map` or `array`.
+    - Defines the nested resource that this attribute references. This
+      attribute MUST only be used when the owning attribute's `type` value is
+      `map` or `array`.
+    - Type: Object.
+    - REQUIRED when owning attribute's `type` is `map` or `array`.
 
 - `attributes."STRING".item.type`
-  - The "TYPE" of this nested resource.
-  - Type: TYPE.
-  - REQUIRED.
+    - The "TYPE" of this nested resource.
+    - Type: TYPE.
+    - REQUIRED.
 
 - `attributes."STRING".item.attributes`
-  - See `attributes` above.
-  - OPTIONAL, and MUST ONLY be used when `item.type` is `object`.
+    - See `attributes` above.
+    - OPTIONAL, and MUST ONLY be used when `item.type` is `object`.
 
 - `attributes."STRING".item.item`
-  - See `attributes."STRING".item` above.
-  - REQUIRED when `item.type` is `map` or `array`.
+    - See `attributes."STRING".item` above.
+    - REQUIRED when `item.type` is `map` or `array`.
 
 - `attributes."STRING".ifvalues`
   - This map can be used to conditionally include additional
@@ -2126,46 +2138,46 @@ The following describes the attributes of Registry model:
     the `ifvalues` `"VALUE"` (case sensitive) then the `siblingattributes` MUST
     be included in the model as siblings to this attribute.
 
-    If `enum` is not empty and `strict` is `true` then this map MUST NOT
-    contain any value that is not specified in the `enum` array.
+      If `enum` is not empty and `strict` is `true` then this map MUST NOT
+      contain any value that is not specified in the `enum` array.
 
-    This aspect MUST only be used for scalar attributes.
+      This aspect MUST only be used for scalar attributes.
 
-    All attributes defined for this `ifvalues` MUST be unique within the scope
-    of this `ifvalues` and MUST NOT match a named attributed defined at this
-    level of the entity. If multiple `ifvalues` sections, at the same entity
-    level, are active at the same time then there MUST NOT be duplicate
-    `ifvalues` attributes names between those `ifvalues` sections.
-  - `ifvalues` `"VALUE"` MUST NOT be an empty string.
-  - `ifvalues` `siblingattributes` MAY include additional `ifvalues`
-    definitions.
-  - Type: Map where each value of the attribute is the key of the map.
-  - OPTIONAL.
+      All attributes defined for this `ifvalues` MUST be unique within the scope
+      of this `ifvalues` and MUST NOT match a named attributed defined at this
+      level of the entity. If multiple `ifvalues` sections, at the same entity
+      level, are active at the same time then there MUST NOT be duplicate
+      `ifvalues` attributes names between those `ifvalues` sections.
+    - `ifvalues` `"VALUE"` MUST NOT be an empty string.
+    - `ifvalues` `siblingattributes` MAY include additional `ifvalues`
+      definitions.
+    - Type: Map where each value of the attribute is the key of the map.
+    - OPTIONAL.
 
 - `groups`
-  - The set of Group types supported by the Registry.
-  - Type: Map where the key MUST be the plural name (`groups.plural`) of the
-    Group type (`GROUPs`).
-  - REQUIRED if there are any Group types defined for the Registry.
+    - The set of Group types supported by the Registry.
+    - Type: Map where the key MUST be the plural name (`groups.plural`) of the
+      Group type (`GROUPs`).
+    - REQUIRED if there are any Group types defined for the Registry.
 
 - `groups.singular`
-  - The singular name of a Group type e.g. `endpoint` (`GROUP`).
-  - Type: String.
-  - REQUIRED.
-  - MUST be unique across all Group types in the Registry.
-  - MUST be non-empty and MUST be a valid attribute name with the exception
-    that it MUST NOT exceed 58 characters (not 63).
+    - The singular name of a Group type e.g. `endpoint` (`GROUP`).
+    - Type: String.
+    - REQUIRED.
+    - MUST be unique across all Group types in the Registry.
+    - MUST be non-empty and MUST be a valid attribute name with the exception
+      that it MUST NOT exceed 58 characters (not 63).
 
 - `groups.plural`
-  - The plural name of the Group type e.g. `endpoints` (`GROUPs`).
-  - Type: String.
-  - REQUIRED.
-  - MUST be unique across all Group types in the Registry.
-  - MUST be non-empty and MUST be a valid attribute name with the exception
-    that it MUST NOT exceed 58 characters (not 63).
+    - The plural name of the Group type e.g. `endpoints` (`GROUPs`).
+    - Type: String.
+    - REQUIRED.
+    - MUST be unique across all Group types in the Registry.
+    - MUST be non-empty and MUST be a valid attribute name with the exception
+      that it MUST NOT exceed 58 characters (not 63).
 
 - `groups.attributes`
-  - See `attributes` above.
+    - See `attributes` above.
 
 - `groups.resources`
   - The set of Resource types defined for the Group type.
@@ -2190,45 +2202,45 @@ The following describes the attributes of Registry model:
   - MUST be unique within the scope of its owning Group type.
 
 - `groups.resources.maxversions`
-  - Number of Versions that will be stored in the Registry for this Resource
-    type.
-  - Type: Unsigned Integer.
-  - OPTIONAL.
-  - The default value is zero (`0`).
-  - A value of zero (`0`) indicates there is no stated limit, and
-    implementations MAY prune non-default Versions at any time.
-  - When the limit is exceeded, implementations MUST prune Versions by
-    deleting the oldest Version (based on creation times) first, skipping the
-    Version marked as "default". An exception to this pruning rule is if
-    `maxversions` value is one (`1`) then the newest Version of the Resource
-    MUST always be the "default" and the `setdefaultversionsticky` aspect
-    MUST be `false`.
+    - Number of Versions that will be stored in the Registry for this Resource
+      type.
+    - Type: Unsigned Integer.
+    - OPTIONAL.
+    - The default value is zero (`0`).
+    - A value of zero (`0`) indicates there is no stated limit, and
+      implementations MAY prune non-default Versions at any time.
+    - When the limit is exceeded, implementations MUST prune Versions by
+      deleting the oldest Version (based on creation times) first, skipping the
+      Version marked as "default". An exception to this pruning rule is if
+      `maxversions` value is one (`1`) then the newest Version of the Resource
+      MUST always be the "default" and the `setdefaultversionsticky` aspect
+      MUST be `false`.
 
 - `groups.resources.setversionid`
-  - Indicates whether support for client-side setting of a Version's
-    `versionid` is supported.
-  - Type: Boolean (`true` or `false`, case sensitive).
-  - OPTIONAL.
-  - The default value is `true`.
-  - A value of `true` indicates the client MAY specify the `versionid` of a
-    Version during its creation process.
-  - A value of `false` indicates that the server MUST choose an appropriate
-    `versionid` value during creation of the Version.
+    - Indicates whether support for client-side setting of a Version's
+      `versionid` is supported.
+    - Type: Boolean (`true` or `false`, case sensitive).
+    - OPTIONAL.
+    - The default value is `true`.
+    - A value of `true` indicates the client MAY specify the `versionid` of a
+      Version during its creation process.
+    - A value of `false` indicates that the server MUST choose an appropriate
+      `versionid` value during creation of the Version.
 
 - `groups.resources.setdefaultversionsticky`
-  - Indicates whether support for client-side selection of the "default"
-    Version is supported for Resources of this type. Once set, the default
-    Version MUST NOT change unless there is some explicit action by a client
-    to change it - hence the term "sticky".
-  - Type: Boolean (`true` or `false`, case sensitive).
-  - OPTIONAL.
-  - The default value is `true`.
-  - A value of `true` indicates a client MAY select the default Version of
-    a Resource via one of the methods described in this specification rather
-    than the server always choosing the default Version.
-  - A value of `false` indicates the server MUST choose which Version is the
-    default Version.
-  - This attribute MUST NOT be `true` if `maxversions` is one (`1`).
+    - Indicates whether support for client-side selection of the "default"
+      Version is supported for Resources of this type. Once set, the default
+      Version MUST NOT change unless there is some explicit action by a client
+      to change it - hence the term "sticky".
+    - Type: Boolean (`true` or `false`, case sensitive).
+    - OPTIONAL.
+    - The default value is `true`.
+    - A value of `true` indicates a client MAY select the default Version of
+      a Resource via one of the methods described in this specification rather
+      than the server always choosing the default Version.
+    - A value of `false` indicates the server MUST choose which Version is the
+      default Version.
+    - This attribute MUST NOT be `true` if `maxversions` is one (`1`).
 
 - `groups.resources.hasdocument`
   - Indicates whether or not Resources of this type can have a document
@@ -2240,14 +2252,14 @@ The following describes the attributes of Registry model:
     the cases where this attribute is set to `true` - but the output remains
     the same.
 
-    A value of `true` does not mean that these Resources are guaranteed to
-    have a non-empty document, and an HTTP `GET` to the Resource MAY return an
-    empty HTTP body.
-  - Type: Boolean (`true` or `false`, case sensitive).
-  - OPTIONAL.
-  - The default value is `true`.
-  - A value of `true` indicates that Resource of this type supports a separate
-    document to be associated with it.
+      A value of `true` does not mean that these Resources are guaranteed to
+      have a non-empty document, and an HTTP `GET` to the Resource MAY return an
+      empty HTTP body.
+    - Type: Boolean (`true` or `false`, case sensitive).
+    - OPTIONAL.
+    - The default value is `true`.
+    - A value of `true` indicates that Resource of this type supports a separate
+      document to be associated with it.
 
 - `groups.resources.typemap`
   - When a Resource's metadata is serialized in a response and the `inline`
@@ -2266,22 +2278,22 @@ The following describes the attributes of Registry model:
     The `typemap` attribute allows for this by defining a mapping of
     `contenttype` values to well-known xRegistry format types.
 
-    Since the `contenttype` value is a "media-type" per
-    [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type),
-    for purposes of looking it up in the `typemap`, just the `type/subtype`
-    portion of the value (case insensitively) MUST be used. Meaning, any
-    `parameters` MUST be excluded.
+      Since the `contenttype` value is a "media-type" per
+      [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type),
+      for purposes of looking it up in the `typemap`, just the `type/subtype`
+      portion of the value (case insensitively) MUST be used. Meaning, any
+      `parameters` MUST be excluded.
 
-    If more than one entry in the `typemap` matches the `contenttype`, but
-    they all have the same value, then that value MUST be used. If they are
-    not all the same, then `binary` MUST be used.
+      If more than one entry in the `typemap` matches the `contenttype`, but
+      they all have the same value, then that value MUST be used. If they are
+      not all the same, then `binary` MUST be used.
 
-  - This specification defines the following values (case insensitive):
-    - `binary`
-    - `json`
-    - `string`
+    - This specification defines the following values (case insensitive):
+        - `binary`
+        - `json`
+        - `string`
 
-    Implementations MAY define additional values.
+      Implementations MAY define additional values.
 
     A value of `binary` indicates that the Resource's document is to be treated
     as an array of bytes and serialized under the `RESOURCEbase64` attribute,
@@ -2304,33 +2316,33 @@ The following describes the attributes of Registry model:
     Specifying an unknown (or unsupported) value MUST generate an error during
     the update of the xRegistry model.
 
-    By default, the following
-    [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type)
-    `typemap` keys MUST be implicitly defined as follows, unless overridden
-    by an explicit `typemap` entry:
-    - `application/json`: mapped to `json`
-    - `*+json`: mapped to `json`
-    - `text/plain`: mapped to `string`
+      By default, the following
+      [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type)
+      `typemap` keys MUST be implicitly defined as follows, unless overridden
+      by an explicit `typemap` entry:
+        - `application/json`: mapped to `json`
+        - `*+json`: mapped to `json`
+        - `text/plain`: mapped to `string`
 
-  - Type: Map where the keys and values MUST be non-empty strings. The key
-    MAY include at most one `*` to act as a wildcard to mean zero or more
-    instance of any character at that position in the string - similar to a
-    `.*` in a regular expression. The key MUST be a case insensitive string.
+    - Type: Map where the keys and values MUST be non-empty strings. The key
+      MAY include at most one `*` to act as a wildcard to mean zero or more
+      instance of any character at that position in the string - similar to a
+      `.*` in a regular expression. The key MUST be a case insensitive string.
 
-  - OPTIONAL.
-  - Example:<br>
-    ```yaml
-    "typemap": {
-      "text/*": "string",
-      "text/mine": "json"
-    }
-    ```
+    - OPTIONAL.
+    - Example:<br>
+      ```yaml
+      "typemap": {
+        "text/*": "string",
+        "text/mine": "json"
+      }
+      ```
 
 - `groups.resources.attributes`
-  - See `attributes` above.
-  - Note that Resources only have a few attributes, and most of the attributes
-    listed here would be for the Versions. However, they would appear on the
-    Resource when asking for the default Version of the Resource.
+    - See `attributes` above.
+    - Note that Resources only have a few attributes, and most of the attributes
+      listed here would be for the Versions. However, they would appear on the
+      Resource when asking for the default Version of the Resource.
 
 #### Retrieving the Registry Model
 
@@ -2932,16 +2944,17 @@ and the following Group level attributes:
 ##### `authority` Attribute
 
 - Type: String
-- Description: The authority under which this group is defined. If not present, 
-  the according `defaultauthority` will be applied. 
+- Description: The authority under which this group is defined. If not present,
+  the according `defaultauthority` will be applied.
 - Constraints:
-    - OPTIONAL.
-    - If present, MUST be non-empty.
-    - Must be a valid authority as defined under [authority](#authority).
-    - If not present, the `defaultauthority` will be applied, when the group 
-      is exported.
+  - OPTIONAL.
+  - If present, MUST be non-empty.
+  - Must be a valid authority as defined under [authority](#authority).
+  - If not present, the `defaultauthority` will be applied, when the group
+    is exported.
 
 ##### `RESOURCEs` Collections
+
 - Type: Set of [Registry Collections](#registry-collections).
 - Description: A list of Registry collections that contain the set of
   Resources supported by the Group.
@@ -3401,29 +3414,29 @@ and the following Resource level attributes:
   then the Version chosen by the server will be indeterminate.
 
 - Constraints:
-  - When not present, the default value is `false`.
-  - REQUIRED when `true`, otherwise OPTIONAL.
-  - When present, it MUST be a case sensitive `true` or `false`.
-  - If present in a request, a value of `null` has the same meaning as
-    deleting the attribute, implicitly setting it to `false`.
-  - Since this attribute and `defaultversionid` are closely related, the
-    processing of them in a request message MUST adhere to the following:
-    - The `defaultversionsticky` attribute is applied first. As a reminder,
-      in the `PATCH` case, if this attribute is missing in the request then
-      this attribute remains unchanged in the Resource.
-    - If the resulting value of this attribute is `false` then the sticky
-      aspect MUST be turned off, and any `defaultversionid` in the request
-      MUST be ignored. The newest Version MUST be the default Version.
-    - If the resulting value of this attribute is `true` then the sticky
-      aspect MUST be turned on, and any `defaultversionid` attribute from
-      the request is applied - where a value of `null` means "newest".
-      If the request was a `PUT` or `POST` and did not have a
-      `defaultversionid` then the implicit value of `null` MUST be used,
-      resulting in "newest". If the request was a `PATCH` and did not have a
-      `defaultversionid` then the current default Version MUST be used.
-      A reference to a Version that does not exist MUST generate an error.
+    - When not present, the default value is `false`.
+    - REQUIRED when `true`, otherwise OPTIONAL.
+    - When present, it MUST be a case sensitive `true` or `false`.
+    - If present in a request, a value of `null` has the same meaning as
+      deleting the attribute, implicitly setting it to `false`.
+    - Since this attribute and `defaultversionid` are closely related, the
+      processing of them in a request message MUST adhere to the following:
+        - The `defaultversionsticky` attribute is applied first. As a reminder,
+          in the `PATCH` case, if this attribute is missing in the request then
+          this attribute remains unchanged in the Resource.
+        - If the resulting value of this attribute is `false` then the sticky
+          aspect MUST be turned off, and any `defaultversionid` in the request
+          MUST be ignored. The newest Version MUST be the default Version.
+        - If the resulting value of this attribute is `true` then the sticky
+          aspect MUST be turned on, and any `defaultversionid` attribute from
+          the request is applied - where a value of `null` means "newest".
+          If the request was a `PUT` or `POST` and did not have a
+          `defaultversionid` then the implicit value of `null` MUST be used,
+          resulting in "newest". If the request was a `PATCH` and did not have a
+          `defaultversionid` then the current default Version MUST be used.
+          A reference to a Version that does not exist MUST generate an error.
 - Examples:
-  - `true`, `false`
+    - `true`, `false`
 
 ##### `defaultversionid` Attribute
 - Type: String
@@ -3433,11 +3446,11 @@ and the following Resource level attributes:
   is assumed that newer Versions of a Resource will have a "higher"
   value than older Versions.
 - Constraints:
-  - REQUIRED in responses and document view, OPTIONAL in requests.
-  - If present, MUST be non-empty.
-  - MUST be the `versionid` of the default Version of the Resource.
-  - See the `defaultversionsticky` section above for how to process these two
-    attributes.
+    - REQUIRED in responses and document view, OPTIONAL in requests.
+    - If present, MUST be non-empty.
+    - MUST be the `versionid` of the default Version of the Resource.
+    - See the `defaultversionsticky` section above for how to process these two
+      attributes.
 - Examples:
   - `1`, `2.0`, `v3-rc1` (v3's release candidate 1)
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -518,7 +518,23 @@ De-referenced URI: xreg://example.com/messagegroups/group1/messages/message1
 
 ##### Resolving an `xid`
 
+As an `xid` is an abstract identifier of an entity, it is necessary to 
+transform it into URLs or URL references to access the entity.
+
+For the HTTP API, the information from an `xid` can be used to construct a 
+URL like this:
+
+`<Registry-base-URL>/GROUPs/{authority}${gID}/RESOURCEs/{rID}/versions/{vID}`
+
+The authority is OPTIONAL if it is identical to the registry's default 
+authority. For a file-based registry, the URL looks similar but makes use of 
+a URL fragment section: 
+
+`<File-URL>/#GROUPs/{authority}${gID}/RESOURCEs/{rID}/versions/{vID}`
+
 Bindings to HTTP, AMQP, registry as document  etc.
+
+##### Comparing `xid` values
 
 
 
@@ -2811,6 +2827,7 @@ The serialization of a Group entity adheres to this form:
 ```yaml
 {
   "GROUPid": "STRING",
+  "authority": "STRING", ?
   "self": "URL",
   "epoch": UINTEGER,
   "name": "STRING", ?
@@ -2892,6 +2909,7 @@ Link: <URL>;rel=next;count=UINTEGER ?
 {
   "KEY": {                                     # GROUPid
     "GROUPid": "STRING",
+    "authority": "STRING", ?
     "self": "URL",
     "epoch": UINTEGER,
     "name": "STRING", ?

--- a/core/spec.md
+++ b/core/spec.md
@@ -1405,12 +1405,32 @@ JSON object as follows:
 ```yaml
 {
   "xid": "URI",     # The xid to resolve
-  [
-    "url": "URL",   # The URL to access the entity
-    "authoritative": boolean
-  ]
+  "locations": [
+    {
+      "url": "URL",   # The URL to access the entity
+      "authoritative": boolean
+    } *                 
+  ], 
+  "externalids":[ 
+    {
+      "type": "STRING",  # The type of the external ID
+      "id": "STRING"         # External IDs that are equivalent to the xid"
+    } *
+  ] ?
 }
 ```
+
+#### `locations`
+
+The `locations` array contains the URLs to access the entity. In addition to 
+the `url`, the `authoritative` attribute indicates whether the URL points to 
+the registry that is authoritative for the entity.
+
+#### `externalids`
+
+The `externalids` array is optional. If the entity can also be identified by 
+identifiers outside from xRegistry, they can be listed here. The `type` 
+attribute describes the type of the external ID.
 
 ### Registry Entity
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -10,12 +10,12 @@ automation and tooling.
 
 - [Overview](#overview)
 - [Notations and Terminology](#notations-and-terminology)
-    - [Notational Conventions](#notational-conventions)
-    - [Terminology](#terminology)
+  - [Notational Conventions](#notational-conventions)
+  - [Terminology](#terminology)
 - [Registry Attributes and APIs](#registry-attributes-and-apis)
   - [Attributes and Extensions](#attributes-and-extensions)
     - [Common Attributes](#common-attributes)
-    - [`xid` - Referencing xRegistry Entities](#xid---referencing-xregistry-entities)
+    - [`xid`](#xid)
   - [Registry APIs](#registry-apis)
     - [Registry Collections](#registry-collections)
     - [Entity Processing Rules](#entity-processing-rules)
@@ -34,7 +34,7 @@ automation and tooling.
   - [Resources](#resources)
     - [Retrieving a Resource Collection](#retrieving-a-resource-collection)
     - [Creating or Updating Resources and
-       Versions](#creating-or-updating-resources-and-versions)
+      Versions](#creating-or-updating-resources-and-versions)
     - [Retrieving a Resource](#retrieving-a-resource)
     - [Deleting Resources](#deleting-resources)
   - [Versions](#versions)
@@ -452,8 +452,9 @@ the local registry. The `xid` can also be used in other places where it
 is helpful to use a URI, e.g. events or knowledge graphs.
 Each entity has exactly one `xid`. Therefore, comparing two `xid`
 values is possible to determine, if they identify the same or different
-entities. To achieve this, an xRegistry-specific URI scheme `xreg` is defined:
-ABNF https://datatracker.ietf.org/doc/html/rfc5234
+entities. To achieve this, an xRegistry-specific URI scheme `xreg` is defined.
+Below, [ABNF](https://datatracker.ietf.org/doc/html/rfc5234)  notation is used 
+to describe how `xids` are structured:
 
 `xid` = `"xreg://" authority "/" entity-path`
 
@@ -531,13 +532,13 @@ transform it into URLs or URL references to access the entity.
 For the HTTP API, the information from an `xid` can be used to construct a
 URL like this:
 
-`<Registry-base-URL>/GROUPs/{authority}${gID}/RESOURCEs/{rID}/versions/{vID}`
+`<Registry-base-URL>/GROUPs/{gID}@{authority}/RESOURCEs/{rID}/versions/{vID}`
 
 The authority is OPTIONAL if it is identical to the registry's default
 authority. For a file-based registry, the URL looks similar but makes use of
 a URL fragment section:
 
-`<File-URL>/#GROUPs/{authority}${gID}/RESOURCEs/{rID}/versions/{vID}`
+`<File-URL>/#GROUPs/{gID}@{authority}/RESOURCEs/{rID}/versions/{vID}`
 
 Further bindings MAY be defined in the future, e.g. for AMQP or GraphQL.
 
@@ -600,9 +601,9 @@ The definition of each attribute is defined below:
     be generated.
   - MUST be immutable.
 - Examples:
-    - `a183e0a9-abf8-4763-99bc-e6b7fcc9544b`
-    - `myEntity`
-    - `myEntity.example.com`
+  - `a183e0a9-abf8-4763-99bc-e6b7fcc9544b`
+  - `myEntity`
+  - `myEntity.example.com`
 
 While `SINGULARid` can be something like a UUID, when possible, it is
 RECOMMENDED that it be something human friendly as these values will often
@@ -669,10 +670,10 @@ of the existing entity. Then the existing entity can be deleted.
   might result in an epoch validation error for the second update request
   mention above.
 - Constraints:
-    - MUST be an unsigned integer equal to or greater than zero.
-    - MUST increase in value each time the entity is updated.
+  - MUST be an unsigned integer equal to or greater than zero.
+  - MUST increase in value each time the entity is updated.
 - Examples:
-    - `0`, `1`, `2`, `3`
+  - `0`, `1`, `2`, `3`
 
 ##### `name` Attribute
 
@@ -703,9 +704,9 @@ of the existing entity. Then the existing entity can be deleted.
 - Type: String
 - Description: A human readable summary of the purpose of the entity.
 - Constraints:
-    - None
+  - None
 - Examples:
-    - `A queue of the sensor generated messages`
+  - `A queue of the sensor generated messages`
 
 ##### `documentation` Attribute
 
@@ -714,10 +715,10 @@ of the existing entity. Then the existing entity can be deleted.
   This specification does not place any constraints on the data returned from
   an HTTP `GET` to this URL.
 - Constraints:
-    - If present, MUST be a non-empty URL.
-    - MUST support an HTTP(s) `GET` to this URL.
+  - If present, MUST be a non-empty URL.
+  - MUST support an HTTP(s) `GET` to this URL.
 - Examples:
-    - `https://example.com/docs/myQueue`
+  - `https://example.com/docs/myQueue`
 
 ##### `labels` Attribute
 
@@ -725,15 +726,15 @@ of the existing entity. Then the existing entity can be deleted.
 - Description: A mechanism in which additional metadata about the entity can
   be stored without changing the schema of the entity.
 - Constraints:
-    - If present, MUST be a map of zero or more name/value string pairs. See
-      [Attributes and Extensions](#attributes-and-extensions) for more
-      information.
-    - Keys MUST be non-empty strings.
-    - Values MAY be empty strings.
+  - If present, MUST be a map of zero or more name/value string pairs. See
+    [Attributes and Extensions](#attributes-and-extensions) for more
+    information.
+  - Keys MUST be non-empty strings.
+  - Values MAY be empty strings.
 - Examples:
-    - `"labels": { "owner": "John", "verified": "" }` when in the HTTP body
-    - `xRegistry-labels-owner: John` <br>
-      `xRegistry-labels-verified:`  when in HTTP headers
+  - `"labels": { "owner": "John", "verified": "" }` when in the HTTP body
+  - `xRegistry-labels-owner: John` <br>
+    `xRegistry-labels-verified:`  when in HTTP headers
 
   Note: HTTP header values can be empty strings but some client-side tooling
   might make it challenging to produce them. For example, `curl` requires
@@ -750,9 +751,9 @@ of the existing entity. Then the existing entity can be deleted.
   is the value of the `self` attribute and in those cases its presence in the
   serialization of the entity is OPTIONAL.
 - Constraints:
-    - OPTIONAL if this Registry is the authority owner.
-    - REQUIRED if this Registry is not the authority owner.
-    - If present, MUST be a non-empty URI.
+  - OPTIONAL if this Registry is the authority owner.
+  - REQUIRED if this Registry is not the authority owner.
+  - If present, MUST be a non-empty URI.
 - Examples:
   - `https://example2.com/myregistry/endpoints/ep1`
 
@@ -761,15 +762,15 @@ of the existing entity. Then the existing entity can be deleted.
 - Type: Timestamp
 - Description: The date/time of when the entity was created.
 - Constraints:
-    - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp.
-    - When present in a write operation request, the value MUST override any
-      existing value, however a value of `null` MUST use the current date/time
-      as the new value.
-    - When absent in a write operation request, any existing value MUST remain
-      unchanged, or if not present, set to the current date/time
-    - In cases where the `createdat` attribute is set to the current date/time
-      on multiple entities within the same operation, the same value MUST be
-      applied to all of the entities.
+  - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp.
+  - When present in a write operation request, the value MUST override any
+    existing value, however a value of `null` MUST use the current date/time
+    as the new value.
+  - When absent in a write operation request, any existing value MUST remain
+    unchanged, or if not present, set to the current date/time
+  - In cases where the `createdat` attribute is set to the current date/time
+    on multiple entities within the same operation, the same value MUST be
+    applied to all of the entities.
 - Examples:
   - `2030-12-19T06:00:00Z`
 
@@ -778,29 +779,29 @@ of the existing entity. Then the existing entity can be deleted.
 - Type: Timestamp
 - Description: The date/time of when the entity was last updated
 - Constraints:
-    - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp
-      representing the time when the entity was last updated.
-    - Any update operation (even one that does not change any attribute, such as
-      a `PATCH` with no attributes provided), MUST update this attribute. This
-      then acts like a `touch` type of operation.
-    - Upon creation of a new entity, this attribute MUST match the `createdat`
-      attribute's value.
-    - Setting an entity's `modifiedat` value MUST NOT update any parent
-      entity's `modifiedat` value.
-    - When present in a write operation request, the following applies:
-        - If the request value is the same as the existing value, then the
-          current date/time MUST be used as its new value.
-        - If the request value is different than the existing value, then the
-          request value MUST be used as its new value.
-        - If the request value is `null` then the current date/time MUST be used
-          as the new value.
-    - When absent in a write operation request, it MUST be set to the current
-      date/time.
-    - In cases where the `modifiedat` attribute is set to the current date/time
-      on multiple entities within the same operation, the same value MUST be
-      applied to all of the entities.
+  - MUST be a [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp
+    representing the time when the entity was last updated.
+  - Any update operation (even one that does not change any attribute, such as
+    a `PATCH` with no attributes provided), MUST update this attribute. This
+    then acts like a `touch` type of operation.
+  - Upon creation of a new entity, this attribute MUST match the `createdat`
+    attribute's value.
+  - Setting an entity's `modifiedat` value MUST NOT update any parent
+    entity's `modifiedat` value.
+  - When present in a write operation request, the following applies:
+    - If the request value is the same as the existing value, then the
+      current date/time MUST be used as its new value.
+    - If the request value is different than the existing value, then the
+      request value MUST be used as its new value.
+    - If the request value is `null` then the current date/time MUST be used
+      as the new value.
+  - When absent in a write operation request, it MUST be set to the current
+    date/time.
+  - In cases where the `modifiedat` attribute is set to the current date/time
+    on multiple entities within the same operation, the same value MUST be
+    applied to all of the entities.
 - Examples:
-    - `2030-12-19T06:00:00Z`
+  - `2030-12-19T06:00:00Z`
 
 ---
 
@@ -1504,15 +1505,16 @@ and the following Registry level attributes:
 #### `defaultauthority` Attribute
 
 - Type: String
-- Description: The default authority that is applied to groups without 
-  explicit authority. If not present, there is no way to refer to groups 
+- Description: The default authority that is applied to groups without
+  explicit authority. If not present, there is no way to refer to groups
   without authority via an `xid`.
 - Constraints:
-    - OPTIONAL.
-    - If present, MUST be non-empty.
-    - Must be a valid authority as defined under [authority](#authority).
+  - OPTIONAL.
+  - If present, MUST be non-empty.
+  - Must be a valid authority as defined under [authority](#authority).
 
 ##### `model` Attribute
+
 - Type: Registry Model
 - Description: A description of the features, extension attributes, Groups and
   Resources supported by this Registry. See [Registry Model](#registry-model)
@@ -2043,31 +2045,31 @@ The following describes the attributes of Registry model:
     extension attributes. As such, it is only for informational purposes for
     clients.
 
-      Once set, any attempt to update the value MUST be silently ignored by
-      the server.
+    Once set, any attempt to update the value MUST be silently ignored by
+    the server.
 
-      When not specified, the default value is `false`.
-    - Type: Boolean.
-    - OPTIONAL.
+    When not specified, the default value is `false`.
+  - Type: Boolean.
+  - OPTIONAL.
 
 - `attributes."STRING".clientrequired`
-    - Indicates whether this attribute is a REQUIRED field for a client when
-      creating or updating an entity. When not specified the default value is
-      `false`. When the attribute name is `*` then `clientrequired` MUST NOT be
-      set to `true`.
+  - Indicates whether this attribute is a REQUIRED field for a client when
+    creating or updating an entity. When not specified the default value is
+    `false`. When the attribute name is `*` then `clientrequired` MUST NOT be
+    set to `true`.
 
-      During creation or update of an entity if this attribute is not
-      specified then an error MUST be generated.
+    During creation or update of an entity if this attribute is not
+    specified then an error MUST be generated.
 
-    - Type: Boolean.
-    - OPTIONAL.
+  - Type: Boolean.
+  - OPTIONAL.
 
 - `attributes."STRING".serverrequired`
-    - Indicates whether this attribute is a REQUIRED field for a server when
-      serializing an entity. When not specified the default value is `false`.
-      When the attribute name is `*` then `serverrequired` MUST NOT be set to
-      `true`. When `clientrequired` is `true` then `serverrequired` MUST also be
-      `true`.
+  - Indicates whether this attribute is a REQUIRED field for a server when
+    serializing an entity. When not specified the default value is `false`.
+    When the attribute name is `*` then `serverrequired` MUST NOT be set to
+    `true`. When `clientrequired` is `true` then `serverrequired` MUST also be
+    `true`.
 
   - Type: Boolean
   - OPTIONAL
@@ -2095,14 +2097,14 @@ The following describes the attributes of Registry model:
   - When not present, the default value is `version`.
 
 - `attributes."STRING".default`
-    - This value MUST be used to populate this attribute's value if one was
-      not provided by a client. An attribute with a default value does not mean
-      that its owning Object is mandated to be present, rather the attribute
-      would only appear when the owning Object is present. By default,
-      attributes have no default values.
-    - Type: MUST be the same type as the `type` of this attribute and MUST
-      only be used for scalar types.
-    - OPTIONAL.
+  - This value MUST be used to populate this attribute's value if one was
+    not provided by a client. An attribute with a default value does not mean
+    that its owning Object is mandated to be present, rather the attribute
+    would only appear when the owning Object is present. By default,
+    attributes have no default values.
+  - Type: MUST be the same type as the `type` of this attribute and MUST
+    only be used for scalar types.
+  - OPTIONAL.
 
 - `attributes."STRING".attributes`
   - This contains the list of attributes defined as part of a nested resource.
@@ -2112,24 +2114,24 @@ The following describes the attributes of Registry model:
     defined attributes for the nested `object`.
 
 - `attributes."STRING".item`
-    - Defines the nested resource that this attribute references. This
-      attribute MUST only be used when the owning attribute's `type` value is
-      `map` or `array`.
-    - Type: Object.
-    - REQUIRED when owning attribute's `type` is `map` or `array`.
+  - Defines the nested resource that this attribute references. This
+    attribute MUST only be used when the owning attribute's `type` value is
+    `map` or `array`.
+  - Type: Object.
+  - REQUIRED when owning attribute's `type` is `map` or `array`.
 
 - `attributes."STRING".item.type`
-    - The "TYPE" of this nested resource.
-    - Type: TYPE.
-    - REQUIRED.
+  - The "TYPE" of this nested resource.
+  - Type: TYPE.
+  - REQUIRED.
 
 - `attributes."STRING".item.attributes`
-    - See `attributes` above.
-    - OPTIONAL, and MUST ONLY be used when `item.type` is `object`.
+  - See `attributes` above.
+  - OPTIONAL, and MUST ONLY be used when `item.type` is `object`.
 
 - `attributes."STRING".item.item`
-    - See `attributes."STRING".item` above.
-    - REQUIRED when `item.type` is `map` or `array`.
+  - See `attributes."STRING".item` above.
+  - REQUIRED when `item.type` is `map` or `array`.
 
 - `attributes."STRING".ifvalues`
   - This map can be used to conditionally include additional
@@ -2138,46 +2140,46 @@ The following describes the attributes of Registry model:
     the `ifvalues` `"VALUE"` (case sensitive) then the `siblingattributes` MUST
     be included in the model as siblings to this attribute.
 
-      If `enum` is not empty and `strict` is `true` then this map MUST NOT
-      contain any value that is not specified in the `enum` array.
+    If `enum` is not empty and `strict` is `true` then this map MUST NOT
+    contain any value that is not specified in the `enum` array.
 
-      This aspect MUST only be used for scalar attributes.
+    This aspect MUST only be used for scalar attributes.
 
-      All attributes defined for this `ifvalues` MUST be unique within the scope
-      of this `ifvalues` and MUST NOT match a named attributed defined at this
-      level of the entity. If multiple `ifvalues` sections, at the same entity
-      level, are active at the same time then there MUST NOT be duplicate
-      `ifvalues` attributes names between those `ifvalues` sections.
-    - `ifvalues` `"VALUE"` MUST NOT be an empty string.
-    - `ifvalues` `siblingattributes` MAY include additional `ifvalues`
-      definitions.
-    - Type: Map where each value of the attribute is the key of the map.
-    - OPTIONAL.
+    All attributes defined for this `ifvalues` MUST be unique within the scope
+    of this `ifvalues` and MUST NOT match a named attributed defined at this
+    level of the entity. If multiple `ifvalues` sections, at the same entity
+    level, are active at the same time then there MUST NOT be duplicate
+    `ifvalues` attributes names between those `ifvalues` sections.
+  - `ifvalues` `"VALUE"` MUST NOT be an empty string.
+  - `ifvalues` `siblingattributes` MAY include additional `ifvalues`
+    definitions.
+  - Type: Map where each value of the attribute is the key of the map.
+  - OPTIONAL.
 
 - `groups`
-    - The set of Group types supported by the Registry.
-    - Type: Map where the key MUST be the plural name (`groups.plural`) of the
-      Group type (`GROUPs`).
-    - REQUIRED if there are any Group types defined for the Registry.
+  - The set of Group types supported by the Registry.
+  - Type: Map where the key MUST be the plural name (`groups.plural`) of the
+    Group type (`GROUPs`).
+  - REQUIRED if there are any Group types defined for the Registry.
 
 - `groups.singular`
-    - The singular name of a Group type e.g. `endpoint` (`GROUP`).
-    - Type: String.
-    - REQUIRED.
-    - MUST be unique across all Group types in the Registry.
-    - MUST be non-empty and MUST be a valid attribute name with the exception
-      that it MUST NOT exceed 58 characters (not 63).
+  - The singular name of a Group type e.g. `endpoint` (`GROUP`).
+  - Type: String.
+  - REQUIRED.
+  - MUST be unique across all Group types in the Registry.
+  - MUST be non-empty and MUST be a valid attribute name with the exception
+    that it MUST NOT exceed 58 characters (not 63).
 
 - `groups.plural`
-    - The plural name of the Group type e.g. `endpoints` (`GROUPs`).
-    - Type: String.
-    - REQUIRED.
-    - MUST be unique across all Group types in the Registry.
-    - MUST be non-empty and MUST be a valid attribute name with the exception
-      that it MUST NOT exceed 58 characters (not 63).
+  - The plural name of the Group type e.g. `endpoints` (`GROUPs`).
+  - Type: String.
+  - REQUIRED.
+  - MUST be unique across all Group types in the Registry.
+  - MUST be non-empty and MUST be a valid attribute name with the exception
+    that it MUST NOT exceed 58 characters (not 63).
 
 - `groups.attributes`
-    - See `attributes` above.
+  - See `attributes` above.
 
 - `groups.resources`
   - The set of Resource types defined for the Group type.
@@ -2202,45 +2204,45 @@ The following describes the attributes of Registry model:
   - MUST be unique within the scope of its owning Group type.
 
 - `groups.resources.maxversions`
-    - Number of Versions that will be stored in the Registry for this Resource
-      type.
-    - Type: Unsigned Integer.
-    - OPTIONAL.
-    - The default value is zero (`0`).
-    - A value of zero (`0`) indicates there is no stated limit, and
-      implementations MAY prune non-default Versions at any time.
-    - When the limit is exceeded, implementations MUST prune Versions by
-      deleting the oldest Version (based on creation times) first, skipping the
-      Version marked as "default". An exception to this pruning rule is if
-      `maxversions` value is one (`1`) then the newest Version of the Resource
-      MUST always be the "default" and the `setdefaultversionsticky` aspect
-      MUST be `false`.
+  - Number of Versions that will be stored in the Registry for this Resource
+    type.
+  - Type: Unsigned Integer.
+  - OPTIONAL.
+  - The default value is zero (`0`).
+  - A value of zero (`0`) indicates there is no stated limit, and
+    implementations MAY prune non-default Versions at any time.
+  - When the limit is exceeded, implementations MUST prune Versions by
+    deleting the oldest Version (based on creation times) first, skipping the
+    Version marked as "default". An exception to this pruning rule is if
+    `maxversions` value is one (`1`) then the newest Version of the Resource
+    MUST always be the "default" and the `setdefaultversionsticky` aspect
+    MUST be `false`.
 
 - `groups.resources.setversionid`
-    - Indicates whether support for client-side setting of a Version's
-      `versionid` is supported.
-    - Type: Boolean (`true` or `false`, case sensitive).
-    - OPTIONAL.
-    - The default value is `true`.
-    - A value of `true` indicates the client MAY specify the `versionid` of a
-      Version during its creation process.
-    - A value of `false` indicates that the server MUST choose an appropriate
-      `versionid` value during creation of the Version.
+  - Indicates whether support for client-side setting of a Version's
+    `versionid` is supported.
+  - Type: Boolean (`true` or `false`, case sensitive).
+  - OPTIONAL.
+  - The default value is `true`.
+  - A value of `true` indicates the client MAY specify the `versionid` of a
+    Version during its creation process.
+  - A value of `false` indicates that the server MUST choose an appropriate
+    `versionid` value during creation of the Version.
 
 - `groups.resources.setdefaultversionsticky`
-    - Indicates whether support for client-side selection of the "default"
-      Version is supported for Resources of this type. Once set, the default
-      Version MUST NOT change unless there is some explicit action by a client
-      to change it - hence the term "sticky".
-    - Type: Boolean (`true` or `false`, case sensitive).
-    - OPTIONAL.
-    - The default value is `true`.
-    - A value of `true` indicates a client MAY select the default Version of
-      a Resource via one of the methods described in this specification rather
-      than the server always choosing the default Version.
-    - A value of `false` indicates the server MUST choose which Version is the
-      default Version.
-    - This attribute MUST NOT be `true` if `maxversions` is one (`1`).
+  - Indicates whether support for client-side selection of the "default"
+    Version is supported for Resources of this type. Once set, the default
+    Version MUST NOT change unless there is some explicit action by a client
+    to change it - hence the term "sticky".
+  - Type: Boolean (`true` or `false`, case sensitive).
+  - OPTIONAL.
+  - The default value is `true`.
+  - A value of `true` indicates a client MAY select the default Version of
+    a Resource via one of the methods described in this specification rather
+    than the server always choosing the default Version.
+  - A value of `false` indicates the server MUST choose which Version is the
+    default Version.
+  - This attribute MUST NOT be `true` if `maxversions` is one (`1`).
 
 - `groups.resources.hasdocument`
   - Indicates whether or not Resources of this type can have a document
@@ -2252,14 +2254,14 @@ The following describes the attributes of Registry model:
     the cases where this attribute is set to `true` - but the output remains
     the same.
 
-      A value of `true` does not mean that these Resources are guaranteed to
-      have a non-empty document, and an HTTP `GET` to the Resource MAY return an
-      empty HTTP body.
-    - Type: Boolean (`true` or `false`, case sensitive).
-    - OPTIONAL.
-    - The default value is `true`.
-    - A value of `true` indicates that Resource of this type supports a separate
-      document to be associated with it.
+    A value of `true` does not mean that these Resources are guaranteed to
+    have a non-empty document, and an HTTP `GET` to the Resource MAY return an
+    empty HTTP body.
+  - Type: Boolean (`true` or `false`, case sensitive).
+  - OPTIONAL.
+  - The default value is `true`.
+  - A value of `true` indicates that Resource of this type supports a separate
+    document to be associated with it.
 
 - `groups.resources.typemap`
   - When a Resource's metadata is serialized in a response and the `inline`
@@ -2278,22 +2280,22 @@ The following describes the attributes of Registry model:
     The `typemap` attribute allows for this by defining a mapping of
     `contenttype` values to well-known xRegistry format types.
 
-      Since the `contenttype` value is a "media-type" per
-      [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type),
-      for purposes of looking it up in the `typemap`, just the `type/subtype`
-      portion of the value (case insensitively) MUST be used. Meaning, any
-      `parameters` MUST be excluded.
+    Since the `contenttype` value is a "media-type" per
+    [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type),
+    for purposes of looking it up in the `typemap`, just the `type/subtype`
+    portion of the value (case insensitively) MUST be used. Meaning, any
+    `parameters` MUST be excluded.
 
-      If more than one entry in the `typemap` matches the `contenttype`, but
-      they all have the same value, then that value MUST be used. If they are
-      not all the same, then `binary` MUST be used.
+    If more than one entry in the `typemap` matches the `contenttype`, but
+    they all have the same value, then that value MUST be used. If they are
+    not all the same, then `binary` MUST be used.
 
-    - This specification defines the following values (case insensitive):
-        - `binary`
-        - `json`
-        - `string`
+  - This specification defines the following values (case insensitive):
+    - `binary`
+    - `json`
+    - `string`
 
-      Implementations MAY define additional values.
+    Implementations MAY define additional values.
 
     A value of `binary` indicates that the Resource's document is to be treated
     as an array of bytes and serialized under the `RESOURCEbase64` attribute,
@@ -2316,33 +2318,33 @@ The following describes the attributes of Registry model:
     Specifying an unknown (or unsupported) value MUST generate an error during
     the update of the xRegistry model.
 
-      By default, the following
-      [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type)
-      `typemap` keys MUST be implicitly defined as follows, unless overridden
-      by an explicit `typemap` entry:
-        - `application/json`: mapped to `json`
-        - `*+json`: mapped to `json`
-        - `text/plain`: mapped to `string`
+    By default, the following
+    [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110#media.type)
+    `typemap` keys MUST be implicitly defined as follows, unless overridden
+    by an explicit `typemap` entry:
+    - `application/json`: mapped to `json`
+    - `*+json`: mapped to `json`
+    - `text/plain`: mapped to `string`
 
-    - Type: Map where the keys and values MUST be non-empty strings. The key
-      MAY include at most one `*` to act as a wildcard to mean zero or more
-      instance of any character at that position in the string - similar to a
-      `.*` in a regular expression. The key MUST be a case insensitive string.
+  - Type: Map where the keys and values MUST be non-empty strings. The key
+    MAY include at most one `*` to act as a wildcard to mean zero or more
+    instance of any character at that position in the string - similar to a
+    `.*` in a regular expression. The key MUST be a case insensitive string.
 
-    - OPTIONAL.
-    - Example:<br>
-      ```yaml
-      "typemap": {
-        "text/*": "string",
-        "text/mine": "json"
-      }
-      ```
+  - OPTIONAL.
+  - Example:<br>
+    ```yaml
+    "typemap": {
+      "text/*": "string",
+      "text/mine": "json"
+    }
+    ```
 
 - `groups.resources.attributes`
-    - See `attributes` above.
-    - Note that Resources only have a few attributes, and most of the attributes
-      listed here would be for the Versions. However, they would appear on the
-      Resource when asking for the default Version of the Resource.
+  - See `attributes` above.
+  - Note that Resources only have a few attributes, and most of the attributes
+    listed here would be for the Versions. However, they would appear on the
+    Resource when asking for the default Version of the Resource.
 
 #### Retrieving the Registry Model
 
@@ -2735,8 +2737,8 @@ When a Resource type definition is to be shared between Groups, rather than
 creating a duplicate Resource definition, the `ximport` mechanism MAY be used
 instead. When defining the Resources of a Group, a special Resource "plural"
 name MAY be used to reference other Resource definitions from within the same
-Registry. For example the following abbreviated model definition defines
-one Resource type (`definitions`) under the `messagegroups` Group, that is
+Registry. For example, the following abbreviated model definition defines
+one Resource type (`messages`) under the `messagegroups` Group, that is
 also used by the `endpoints` Group.
 
 ```yaml
@@ -2746,9 +2748,9 @@ also used by the `endpoints` Group.
       "plural": "messagegroups",
       "singular": "messagegroup",
       "resources": {
-        "definitions": {
-          "plural": "definitions",
-          "singular": "definition"
+        "messages": {
+          "plural": "messages",
+          "singular": "message"
         }
       }
     },
@@ -2756,7 +2758,7 @@ also used by the `endpoints` Group.
       "plural": "endpoints",
       "singular": "endpoint",
       "resources": {
-        "ximport": [ "messagegroups/definitions" ]
+        "ximport": [ "messagegroups/messages" ]
       }
     }
   }
@@ -2770,9 +2772,10 @@ The format of the `ximport` specification is:
 ```
 
 where:
+
 - Each array value MUST be a reference to another Group/Resource plural
-combination defined within the same Registry. It MUST NOT reference the
-same Group under which the `ximport` resides.
+  combination defined within the same Registry. It MUST NOT reference the
+  same Group under which the `ximport` resides.
 - An empty array MAY be specified, implying no Resources are imported.
 
 Use of the `ximport` feature MUST only be used once per Group definition.
@@ -3414,31 +3417,32 @@ and the following Resource level attributes:
   then the Version chosen by the server will be indeterminate.
 
 - Constraints:
-    - When not present, the default value is `false`.
-    - REQUIRED when `true`, otherwise OPTIONAL.
-    - When present, it MUST be a case sensitive `true` or `false`.
-    - If present in a request, a value of `null` has the same meaning as
-      deleting the attribute, implicitly setting it to `false`.
-    - Since this attribute and `defaultversionid` are closely related, the
-      processing of them in a request message MUST adhere to the following:
-        - The `defaultversionsticky` attribute is applied first. As a reminder,
-          in the `PATCH` case, if this attribute is missing in the request then
-          this attribute remains unchanged in the Resource.
-        - If the resulting value of this attribute is `false` then the sticky
-          aspect MUST be turned off, and any `defaultversionid` in the request
-          MUST be ignored. The newest Version MUST be the default Version.
-        - If the resulting value of this attribute is `true` then the sticky
-          aspect MUST be turned on, and any `defaultversionid` attribute from
-          the request is applied - where a value of `null` means "newest".
-          If the request was a `PUT` or `POST` and did not have a
-          `defaultversionid` then the implicit value of `null` MUST be used,
-          resulting in "newest". If the request was a `PATCH` and did not have a
-          `defaultversionid` then the current default Version MUST be used.
-          A reference to a Version that does not exist MUST generate an error.
+  - When not present, the default value is `false`.
+  - REQUIRED when `true`, otherwise OPTIONAL.
+  - When present, it MUST be a case sensitive `true` or `false`.
+  - If present in a request, a value of `null` has the same meaning as
+    deleting the attribute, implicitly setting it to `false`.
+  - Since this attribute and `defaultversionid` are closely related, the
+    processing of them in a request message MUST adhere to the following:
+    - The `defaultversionsticky` attribute is applied first. As a reminder,
+      in the `PATCH` case, if this attribute is missing in the request then
+      this attribute remains unchanged in the Resource.
+    - If the resulting value of this attribute is `false` then the sticky
+      aspect MUST be turned off, and any `defaultversionid` in the request
+      MUST be ignored. The newest Version MUST be the default Version.
+    - If the resulting value of this attribute is `true` then the sticky
+      aspect MUST be turned on, and any `defaultversionid` attribute from
+      the request is applied - where a value of `null` means "newest".
+      If the request was a `PUT` or `POST` and did not have a
+      `defaultversionid` then the implicit value of `null` MUST be used,
+      resulting in "newest". If the request was a `PATCH` and did not have a
+      `defaultversionid` then the current default Version MUST be used.
+      A reference to a Version that does not exist MUST generate an error.
 - Examples:
-    - `true`, `false`
+  - `true`, `false`
 
 ##### `defaultversionid` Attribute
+
 - Type: String
 - Description: the `versionid` of the default Version of the Resource.
   This specification makes no statement as to the format of this string or
@@ -3446,11 +3450,11 @@ and the following Resource level attributes:
   is assumed that newer Versions of a Resource will have a "higher"
   value than older Versions.
 - Constraints:
-    - REQUIRED in responses and document view, OPTIONAL in requests.
-    - If present, MUST be non-empty.
-    - MUST be the `versionid` of the default Version of the Resource.
-    - See the `defaultversionsticky` section above for how to process these two
-      attributes.
+  - REQUIRED in responses and document view, OPTIONAL in requests.
+  - If present, MUST be non-empty.
+  - MUST be the `versionid` of the default Version of the Resource.
+  - See the `defaultversionsticky` section above for how to process these two
+    attributes.
 - Examples:
   - `1`, `2.0`, `v3-rc1` (v3's release candidate 1)
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -372,6 +372,7 @@ be one of the following data types:
   [RFC 6570 Section 3.2.1](https://tools.ietf.org/html/rfc6570#section-3.2.1).
 - `url` - URL as defined in
   [RFC 1738](https://datatracker.ietf.org/doc/html/rfc1738).
+- `xregid` - as defined in [Referencing xRegistry Entities](#xregid---referencing-xregistry-entities).
 
 The "scalar" data types are: `boolean`, `decimal`, `integer`, `string`,
 `timestamp`, `uinteger`, `uri`, `urireference`, `uritemplate`, `url`.
@@ -435,6 +436,93 @@ attributes. However they MUST adhere to the following rules:
   potential conflicts with future Registry level attributes. For
   example, use of a model (or domain) specific prefix could be used to help
   avoid possible future conflicts.
+
+#### `xregid` - Referencing xRegistry Entities
+
+An `xregid` is a URI according to
+[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) that
+uniquely identifies an entity within an xRegistry. Its purpose is to
+reference the entity and express a relation to it, even if it is not stored in
+the local registry. The `xregid` can also be used in other places where it
+is helpful to use a URI, e.g. events or knowledge graphs.
+Each entity has exactly one `xregid`. Therefore, comparing two `xregid`
+values is possible to determine, if they identify the same or different
+entities. To achieve this, an xRegistry-specific URI scheme `xreg` is defined:
+
+`regid` = `"xreg://" authority "/" entity-path "/" entity-id`
+
+`entity-path` = `group-path` / `resource-path` / `version-path`
+
+`group-path`= `GROUPs "/" gID`
+
+`resource-path`= `group-path "/" RESOURCEs "/" rID`
+
+`version-path`= `resource-path "/" versions "/" vID`
+
+Where:
+
+- `GROUPs` is a Group type name (plural). e.g. `endpoints`.
+- `GROUP`, not shown, is the singular name of a Group type.
+- `gID` is the `id` of a single Group.
+- `RESOURCEs` is a Resource type name (plural). e.g. `definitions`.
+- `RESOURCE`, not shown, is the singular name of a Resource type.
+- `rID` is the `id` of a single Resource.
+- `vID` is the `id` of a single Version of a Resource.
+
+##### `authority`
+
+The `authority` is a string that uniquely identifies the entity's authority.
+It could be regarded as a namespace and SHOULD be based on a domain name that is
+under the control of the entity's publisher.
+
+##### `entity-path`
+
+As xRegistry entities are organized in a hierarchy, the `entity-path`
+outlines the entity's position in the hierarchy. As the ABNF above shows,
+there can be paths for groups, resources, and versions.
+
+##### `entity-id`
+
+##### De-referencing a relative URI reference
+
+A relative URI reference can only be de-referenced if the base URI is known
+from the context. 
+
+If the relative URI reference consists of a relative path segment, i.e. it 
+does not begin with a slash, then the base URI is the URI of the surrounding 
+entity.
+
+__Example:__
+```
+xregid of surrounding entity: xreg://example.
+com/messagegroups/group2
+
+Reference: messages/message1
+
+De-referenced URI: xreg://example.com/messagegroups/group2/messages/message1
+```
+
+If the relative URI reference consists of an absolute path segment, i.e. it 
+begins with a slash, then the base URI is the authority of the surrounding 
+group.
+
+__Example:__ 
+```
+xregid of surrounding group: xreg://example.com/messagegroups/group2
+
+Reference: /messagegroups/group1/messages/message1
+
+De-referenced URI: xreg://example.com/messagegroups/group1/messages/message1
+
+
+```
+
+##### Resolving an `xregid`
+
+
+Bindings to HTTP, AMQP, registry as document  etc.
+
+
 
 #### Common Attributes
 
@@ -1319,6 +1407,17 @@ and the following Registry level attributes:
   - If present, MUST be non-empty.
 - Examples:
   - `1.0`
+
+#### `defaultauthority` Attribute
+
+- Type: String
+- Description: The default authority that is applied to groups without 
+  explicit authority. If not present, there is no way to refer to groups 
+  without authority via an `xregid`.
+- Constraints:
+    - OPTIONAL.
+    - If present, MUST be non-empty.
+    - Must be a valid authority as defined under [authority](#authority).
 
 ##### `model` Attribute
 - Type: Registry Model
@@ -2747,6 +2846,18 @@ Groups include the following common attributes:
   OPTIONAL.
 
 and the following Group level attributes:
+
+##### `authority` Attribute
+
+- Type: String
+- Description: The authority under which this group is defined. If not present, 
+  the according `defaultauthority` will be applied. 
+- Constraints:
+    - OPTIONAL.
+    - If present, MUST be non-empty.
+    - Must be a valid authority as defined under [authority](#authority).
+    - If not present, the `defaultauthority` will be applied, when the group 
+      is exported.
 
 ##### `RESOURCEs` Collections
 - Type: Set of [Registry Collections](#registry-collections).

--- a/core/spec.md
+++ b/core/spec.md
@@ -372,7 +372,7 @@ be one of the following data types:
   [RFC 6570 Section 3.2.1](https://tools.ietf.org/html/rfc6570#section-3.2.1).
 - `url` - URL as defined in
   [RFC 1738](https://datatracker.ietf.org/doc/html/rfc1738).
-- `xregid` - as defined in [Referencing xRegistry Entities](#xregid---referencing-xregistry-entities).
+- `xid` - as defined in [Referencing xRegistry Entities](#xid---referencing-xregistry-entities).
 
 The "scalar" data types are: `boolean`, `decimal`, `integer`, `string`,
 `timestamp`, `uinteger`, `uri`, `urireference`, `uritemplate`, `url`.
@@ -437,19 +437,19 @@ attributes. However they MUST adhere to the following rules:
   example, use of a model (or domain) specific prefix could be used to help
   avoid possible future conflicts.
 
-#### `xregid` - Referencing xRegistry Entities
+#### `xid` - Referencing xRegistry Entities
 
-An `xregid` is a URI according to
+An `xid` is a URI according to
 [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) that
 uniquely identifies an entity within an xRegistry. Its purpose is to
 reference the entity and express a relation to it, even if it is not stored in
-the local registry. The `xregid` can also be used in other places where it
+the local registry. The `xid` can also be used in other places where it
 is helpful to use a URI, e.g. events or knowledge graphs.
-Each entity has exactly one `xregid`. Therefore, comparing two `xregid`
+Each entity has exactly one `xid`. Therefore, comparing two `xid`
 values is possible to determine, if they identify the same or different
 entities. To achieve this, an xRegistry-specific URI scheme `xreg` is defined:
 
-`regid` = `"xreg://" authority "/" entity-path "/" entity-id`
+`xid` = `"xreg://" authority "/" entity-path "/" entity-id`
 
 `entity-path` = `group-path` / `resource-path` / `version-path`
 
@@ -494,8 +494,7 @@ entity.
 
 __Example:__
 ```
-xregid of surrounding entity: xreg://example.
-com/messagegroups/group2
+xid of surrounding entity: xreg://example.com/messagegroups/group2
 
 Reference: messages/message1
 
@@ -508,7 +507,7 @@ group.
 
 __Example:__ 
 ```
-xregid of surrounding group: xreg://example.com/messagegroups/group2
+xid of surrounding group: xreg://example.com/messagegroups/group2
 
 Reference: /messagegroups/group1/messages/message1
 
@@ -517,8 +516,7 @@ De-referenced URI: xreg://example.com/messagegroups/group1/messages/message1
 
 ```
 
-##### Resolving an `xregid`
-
+##### Resolving an `xid`
 
 Bindings to HTTP, AMQP, registry as document  etc.
 
@@ -1413,7 +1411,7 @@ and the following Registry level attributes:
 - Type: String
 - Description: The default authority that is applied to groups without 
   explicit authority. If not present, there is no way to refer to groups 
-  without authority via an `xregid`.
+  without authority via an `xid`.
 - Constraints:
     - OPTIONAL.
     - If present, MUST be non-empty.

--- a/core/spec.md
+++ b/core/spec.md
@@ -375,7 +375,7 @@ be one of the following data types:
   [RFC 6570 Section 3.2.1](https://tools.ietf.org/html/rfc6570#section-3.2.1).
 - `url` - URL as defined in
   [RFC 1738](https://datatracker.ietf.org/doc/html/rfc1738).
-- `xid` - as defined in [Referencing xRegistry Entities](#xid---referencing-xregistry-entities).
+- `xid` - as defined in [Referencing xRegistry Entities](#xid).
 
 The "scalar" data types are: `boolean`, `decimal`, `integer`, `string`,
 `timestamp`, `uinteger`, `uri`, `urireference`, `uritemplate`, `url`.
@@ -453,7 +453,7 @@ is helpful to use a URI, e.g. events or knowledge graphs.
 Each entity has exactly one `xid`. Therefore, comparing two `xid`
 values is possible to determine, if they identify the same or different
 entities. To achieve this, an xRegistry-specific URI scheme `xreg` is defined.
-Below, [ABNF](https://datatracker.ietf.org/doc/html/rfc5234)  notation is used 
+Below, [ABNF](https://datatracker.ietf.org/doc/html/rfc5234)  notation is used
 to describe how `xids` are structured:
 
 `xid` = `"xreg://" authority "/" entity-path`
@@ -548,7 +548,7 @@ A key feature of the `xid` is that it is a URI and can be efficiently compared
 with other `xids`:
 
 __Two `xids` are equal if and only if their authority, their group type name,
-their resource type name (if applicable), and all ID fields they contain are 
+their resource type name (if applicable), and all ID fields they contain are
 equal.__
 
 #### Common Attributes
@@ -1405,11 +1405,11 @@ For `GET` and `HEAD` requests, the server MUST respond as follows:
   server MUST respond with an HTTP `300 Multiple Choices` where the choices
   are listed as `Link` headers. Each `Link` header MUST contain a
   `rel="alternate"`as specified
-  in [RFC5988](https://tools.ietf.org/html/rfc5988), 
+  in [RFC5988](https://tools.ietf.org/html/rfc5988),
 [RFC8288](https://tools.ietf.org/html/rfc8288)
   and
-  [RFC7231](https://tools.ietf.org/rfc/rfc7231#section-6.4.1). If the server 
-  has a preferred URL, e.g. the authoritative URL, it SHOULD be returned as 
+  [RFC7231](https://tools.ietf.org/rfc/rfc7231#section-6.4.1). If the server
+  has a preferred URL, e.g. the authoritative URL, it SHOULD be returned as
   `Location` header.
 
 If the applied request method is `GET`, the body of the response MUST be a
@@ -1422,9 +1422,9 @@ JSON object as follows:
     {
       "url": "URL",   # The URL to access the entity
       "authoritative": boolean
-    } *                 
-  ], 
-  "externalids":[ 
+    } *
+  ],
+  "externalids":[
     {
       "type": "STRING",  # The type of the external ID
       "id": "STRING"         # External IDs that are equivalent to the xid"
@@ -1435,14 +1435,14 @@ JSON object as follows:
 
 #### `locations`
 
-The `locations` array contains the URLs to access the entity. In addition to 
-the `url`, the `authoritative` attribute indicates whether the URL points to 
+The `locations` array contains the URLs to access the entity. In addition to
+the `url`, the `authoritative` attribute indicates whether the URL points to
 the registry that is authoritative for the entity.
 
 #### `externalids`
 
-The `externalids` array is optional. If the entity can also be identified by 
-identifiers outside from xRegistry, they can be listed here. The `type` 
+The `externalids` array is OPTIONAL. If the entity can also be identified by
+identifiers outside from xRegistry, they can be listed here. The `type`
 attribute describes the type of the external ID.
 
 ### Registry Entity
@@ -1511,7 +1511,7 @@ and the following Registry level attributes:
 - Constraints:
   - OPTIONAL.
   - If present, MUST be non-empty.
-  - Must be a valid authority as defined under [authority](#authority).
+  - MUST be a valid authority as defined under [authority](#authority).
 
 ##### `model` Attribute
 
@@ -2952,7 +2952,7 @@ and the following Group level attributes:
 - Constraints:
   - OPTIONAL.
   - If present, MUST be non-empty.
-  - Must be a valid authority as defined under [authority](#authority).
+  - MUST be a valid authority as defined under [authority](#authority).
   - If not present, the `defaultauthority` will be applied, when the group
     is exported.
 

--- a/tools/dict
+++ b/tools/dict
@@ -1,3 +1,4 @@
+abnf
 acks
 amqp
 amqps
@@ -38,6 +39,7 @@ dataschema
 datastore
 datatracker
 datetime
+defaultauthority
 defaultversion
 defaultversionid
 defaultversionsticky
@@ -50,6 +52,7 @@ definitionsurl
 deploymentid
 deviceid
 distributionmode
+dns
 emoji
 endpointid
 endpointscount
@@ -59,11 +62,13 @@ envelopemetadata
 envelopeoptions
 etag
 eventing
+externalids
 filesystem
 gid
 github
 gmt
 gotchas
+graphql
 groupid
 groupscount
 groupsurl
@@ -130,6 +135,7 @@ myspec
 mysubject
 mytopic
 mywillmessage
+namespace
 nats
 nbsp
 nginx
@@ -228,6 +234,8 @@ willtopic
 wip
 wss
 www
+xid
+xids
 xml
 xmlschema
 xpath


### PR DESCRIPTION
These changes introduce a URI scheme `xreg` that can be used to identify xRegistry entities independent from their storage location. 
