### PR TITLE
Changes for the week of Aug 26

### DIFF
--- a/core/sample-model.json
+++ b/core/sample-model.json
@@ -218,7 +218,7 @@
             }
 
             "defaultversionsticky": {
-              "name": "stickydefaultversion",
+              "name": "defaultversionsticky",
               "type": "boolean",
               "readonly": true,
               "serverrequired": true,

--- a/message/model.json
+++ b/message/model.json
@@ -27,7 +27,7 @@
           "singular": "message",
           "plural": "messages",
           "maxversions": 1,
-          "setstickydefaultversion": false,
+          "setdefaultversionsticky": false,
           "hasdocument": false,
           "attributes": {
             "basemessageurl": {

--- a/tools/dict
+++ b/tools/dict
@@ -11,6 +11,7 @@ createdby
 crlf
 datastore
 datatracker
+defaultversion
 defaultversionid
 defaultversionsticky
 defaultversionurl
@@ -26,6 +27,7 @@ gid
 gotchas
 groupscount
 groupsurl
+hasdoc
 hasdocument
 html
 http

--- a/tools/schema-generator.py
+++ b/tools/schema-generator.py
@@ -800,12 +800,12 @@ model_definition = {
 
 
 def resolve_imports(basedir, node):
-    """ recursively resolve all $imports in the model definition """
+    """ recursively resolve all $includes in the model definition """
     
     if isinstance(node, dict):
-        if "$import" in node:
+        if "$include" in node:
             obj_ref = ''
-            file_ref = node["$import"]
+            file_ref = node["$include"]
             # strip # anchor portion from the file reference
             if "#" in file_ref:
                 fr = file_ref.split("#")
@@ -815,7 +815,7 @@ def resolve_imports(basedir, node):
             import_file = os.path.join(basedir, file_ref)
             with open(import_file) as file:
                 import_definition = json.load(file)
-            del node["$import"]
+            del node["$include"]
             if obj_ref:
                 node.update(resolve_pointer(import_definition, obj_ref))
             else:


### PR DESCRIPTION
- make `epoch` global to the Resource
- check `versionid` on update when updating the Resource's default Version props
- add `location` to Resource model attributes (resource, version, both)
- removed `exportrequired`
- added back in `$import` (as `$include`)
- added `?resource` to exclude the default Version attributes on a Resource
- added `/export` - same as `/?export` - for static file server cases
