### PR TITLE
Changes for the week of Sept 9

### DIFF
--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -98,7 +98,7 @@ schema for its payload.
 {
   "$schema": "https://cloudevents.io/schemas/registry",
   "specversion": "0.5-wip",
-  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "registryid": "Example Registry",
   "self": "http://example.com",
   "epoch": 4,
   "createdat": "2024-04-30T12:00:00Z",
@@ -108,7 +108,7 @@ schema for its payload.
   "endpointscount": 1,
   "endpoints": {
     "com.example.telemetry": {
-      "id": "com.example.telemetry",
+      "endpointid": "com.example.telemetry",
       "self": "https://example.com/endpoints/com.example.telemetry",
       "epoch": 5,
       "createdat": "2024-04-30T12:00:00Z",
@@ -131,12 +131,10 @@ schema for its payload.
       "messagescount": 1,
       "messages": {
         "com.example.telemetry": {
-          "id": "com.example.telemetry",
+          "messageid": "com.example.telemetry",
           "self": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry",
           "epoch": 5,
 
-          "versionid": "1.0",
-          "isdefault": true,
           "description": "device telemetry event",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
@@ -186,7 +184,7 @@ scenarios:
 {
   "$schema": "https://cloudevents.io/schemas/registry",
   "specversion": "0.5-wip",
-  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "registryid": "Example Registry",
   "self": "http://example.com",
   "epoch": 4,
   "createdat": "2024-04-30T12:00:00Z",
@@ -196,7 +194,7 @@ scenarios:
   "endpointscount": 1,
   "endpoints": {
     "com.example.telemetry": {
-      "id": "com.example.telemetry",
+      "endpointid": "com.example.telemetry",
       "self": "https://example.com/endpoints/com.example.telemetry",
       "epoch": 5,
       "createdat": "2024-04-30T12:00:00Z",
@@ -226,7 +224,7 @@ scenarios:
   "messagegroupscount": 1,
   "messagegroups": {
     "com.example.telemetryEvents": {
-      "id": "com.example.telemetryEvents",
+      "messageid": "com.example.telemetryEvents",
       "self": "https://example.com/messagegroups/com.example.telemetryEvents",
       "epoch": 3,
       "createdat": "2024-04-30T12:00:00Z",
@@ -236,13 +234,11 @@ scenarios:
       "messagescount": 1,
       "messages": {
         "com.example.telemetry": {
-          "id": "com.example.telemetry",
+          "messageid": "com.example.telemetry",
           "self": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry",
           "epoch": 5,
           "description": "device telemetry event",
 
-          "versionid": "1.0",
-          "isdefault": true,
           "description": "device telemetry event",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
@@ -285,7 +281,7 @@ scenarios:
   "schemagroupscount": 1,
   "schemagroups": {
     "com.example.telemetry": {
-      "id": "com.example.telemetry",
+      "schemagroupid": "com.example.telemetry",
       "self": "https://example.com/schemagroups/com.example.telemetry",
       "epoch": 5,
       "createdat": "2024-04-30T12:00:00Z",
@@ -294,12 +290,10 @@ scenarios:
       "schemascount": 1,
       "schemas": {
         "com.example.telemetrydata": {
-          "id": "com.example.telemetrydata",
+          "schemaid": "com.example.telemetrydata",
           "self": "https://example.com/schemagroups/com.example.telemetry/schemas",
           "epoch": 5,
 
-          "versionid": "1.0",
-          "isdefault": true,
           "description": "device telemetry event data",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
@@ -314,11 +308,11 @@ scenarios:
           "versionsurl": "https://example.com/schemagroups/com.example.telemetry/schemas/versions",
           "versions": {
             "1.0": {
-              "id": "com.example.telemetrydata",
+              "resourceid": "com.example.telemetrydata",
+              "versionid": "1.0",
               "self": "https://example.com/schemagroups/com.example.telemetry/schemas/versions/1.0",
               "epoch": 5,
 
-              "versionid": "1.0",
               "isdefault": true,
               "description": "device telemetry event data",
               "createdat": "2024-04-30T12:00:00Z",
@@ -343,13 +337,13 @@ group with a deep link to the respective object in the service:
 {
   "$schema": "https://cloudevents.io/schemas/registry",
   "specversion": "0.5-wip",
-  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "registryid": "Example Registry",
 
   "endpointsurl": "https://example.com/endpoints",
   "endpointscount": 1,
   "endpoints": {
     "com.example.telemetry": {
-      "id": "com.example.telemetry",
+      "endpointid": "com.example.telemetry",
       "self": "https://example.com/endpoints/com.example.telemetry",
       "epoch": 5,
       "createdat": "2024-04-30T12:00:00Z",
@@ -377,13 +371,13 @@ link will first reference the file and then the object within the file, using
 {
   "$schema": "https://cloudevents.io/schemas/registry",
   "specversion": "0.5-wip",
-  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "registryid": "Example Registry",
 
   "endpointsurl": "https://example.com/endpoints",
   "endpointscount": 1,
   "endpoints": {
     "com.example.telemetry": {
-      "id": "com.example.telemetry",
+      "endpointid": "com.example.telemetry",
       "self": "https://example.com/endpoints/com.example.telemetry",
       "epoch": 5,
       "createdat": "2024-04-30T12:00:00Z",
@@ -446,7 +440,7 @@ embedded or referenced. Any of the three sub-registries MAY be omitted.
 {
   "$schema": "https://cloudevents.io/schemas/registry",
   "specversion": "0.5-wip",
-  "id": "STRING",
+  "registryid": "STRING",
 
   "endpointsurl": "URL",
   "endpointscount": INT,

--- a/core/model.json
+++ b/core/model.json
@@ -10,19 +10,10 @@
       "immutable": true,
       "serverrequired": true
     },
-    "id": {
-      "name": "id",
+    "registryid": {
+      "name": "registryid",
       "type": "string",
       "immutable": true,
-      "serverrequired": true
-    },
-    "name": {
-      "name": "name",
-      "type": "string"
-    },
-    "epoch": {
-      "name": "epoch",
-      "type": "uinteger",
       "serverrequired": true
     },
     "self": {
@@ -30,6 +21,15 @@
       "type": "url",
       "readonly": true,
       "serverrequired": true
+    },
+    "epoch": {
+      "name": "epoch",
+      "type": "uinteger",
+      "serverrequired": true
+    },
+    "name": {
+      "name": "name",
+      "type": "string"
     },
     "description": {
       "name": "description",
@@ -46,18 +46,8 @@
         "type": "string"
       }
     },
-    "createdby": {
-      "name": "createdby",
-      "type": "string",
-      "readonly": true
-    },
     "createdat": {
       "name": "createdat",
-      "type": "timestamp",
-      "readonly": true
-    },
-    "modifiedby": {
-      "name": "modifiedby",
       "type": "timestamp",
       "readonly": true
     },

--- a/core/sample-model.json
+++ b/core/sample-model.json
@@ -10,19 +10,10 @@
       "immutable": true,
       "serverrequired": true
     },
-    "id": {
+    "registryid": {
       "name": "id",
       "type": "string",
       "immutable": true,
-      "serverrequired": true
-    },
-    "name": {
-      "name": "name",
-      "type": "string"
-    },
-    "epoch": {
-      "name": "epoch",
-      "type": "uinteger",
       "serverrequired": true
     },
     "self": {
@@ -30,6 +21,15 @@
       "type": "url",
       "readonly": true,
       "serverrequired": true
+    },
+    "epoch": {
+      "name": "epoch",
+      "type": "uinteger",
+      "serverrequired": true
+    },
+    "name": {
+      "name": "name",
+      "type": "string"
     },
     "description": {
       "name": "description",
@@ -46,19 +46,9 @@
         "type": "string"
       }
     },
-    "createdby": {
-      "name": "createdby",
-      "type": "string",
-      "readonly": true
-    },
     "createdat": {
       "name": "createdat",
       "type": "timestamp",
-      "readonly": true
-    },
-    "modifiedby": {
-      "name": "modifiedby",
-      "type": "string",
       "readonly": true
     },
     "modifiedat": {
@@ -73,19 +63,10 @@
       "plural": "sample_groups",
       "singular": "sample_group",
       "attributes": {
-        "id": {
-          "name": "id",
+        "sample_groupid": {
+          "name": "sample_groupid",
           "type": "string",
           "immutable": true,
-          "serverrequired": true
-        },
-        "name": {
-          "name": "name",
-          "type": "string"
-        },
-        "epoch": {
-          "name": "epoch",
-          "type": "uinteger",
           "serverrequired": true
         },
         "self": {
@@ -93,6 +74,15 @@
           "type": "url",
           "readonly": true,
           "serverrequired": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uinteger",
+          "serverrequired": true
+        },
+        "name": {
+          "name": "name",
+          "type": "string"
         },
         "description": {
           "name": "description",
@@ -113,25 +103,17 @@
           "name": "origin",
           "type": "uri"
         },
-        "createdby": {
-          "name": "createdby",
-          "type": "string",
-          "readonly": true
-        },
         "createdat": {
           "name": "createdat",
           "type": "timestamp",
-          "readonly": true
-        },
-        "modifiedby": {
-          "name": "modifiedby",
-          "type": "string",
-          "readonly": true
+          "readonly": true,
+          "serverrequired": true
         },
         "modifiedat": {
           "name": "modifiedat",
           "type": "timestamp",
-          "readonly": true
+          "readonly": true,
+          "serverrequired": true
         }
       },
       "resources": {
@@ -139,39 +121,35 @@
           "plural": "sample_resources",
           "singular": "sample_resource",
           "attributes": {
-            "id": {
+            "sample_resourceid": {
               "name": "id",
               "type": "string",
               "immutable": true,
-              "serverrequired": true,
-              "exportrequired": true
+              "serverrequired": true
             },
             "self": {
               "name": "self",
               "type": "url",
               "readonly": true,
-              "serverrequired": true,
-              "exportrequired": true
-            },
-            "name": {
-              "name": "name",
-              "type": "string"
-            },
-            "versionid": {
-              "name": "versionid",
-              "type": "string",
-              "immutable": true,
               "serverrequired": true
+            },
+            "xref": {
+              "name": "xref",
+              "type": "url"
             },
             "epoch": {
               "name": "epoch",
               "type": "uinteger",
               "serverrequired": true
             },
-            "isdefault": {
-              "name": "isdefault",
+            "readonly": {
+              "name": "readonly",
               "type": "boolean",
               "readonly": true
+            },
+            "name": {
+              "name": "name",
+              "type": "string"
             },
             "description": {
               "name": "description",
@@ -192,25 +170,17 @@
               "name": "origin",
               "type": "uri"
             },
-            "createdby": {
-              "name": "createdby",
-              "type": "string",
-              "readonly": true
-            },
             "createdat": {
               "name": "createdat",
               "type": "timestamp",
-              "readonly": true
-            },
-            "modifiedby": {
-              "name": "modifiedby",
-              "type": "string",
-              "readonly": true
+              "readonly": true,
+              "serverrequired": true
             },
             "modifiedat": {
               "name": "modifiedat",
               "type": "timestamp",
-              "readonly": true
+              "readonly": true,
+              "serverrequired": true
             },
             "contenttype": {
               "name": "contenttype",
@@ -220,24 +190,19 @@
             "defaultversionsticky": {
               "name": "defaultversionsticky",
               "type": "boolean",
-              "readonly": true,
-              "serverrequired": true,
-              "exportrequired": true
+              "serverrequired": true
             },
             "defaultversionid": {
               "name": "defaultversionid",
               "type": "string",
-              "readonly": true,
-              "serverrequired": true,
-              "exportrequired": true
+              "serverrequired": true
             },
             "defaultversionurl": {
               "name": "defaultversionurl",
               "type": "url",
               "readonly": true,
-              "serverrequired": true,
-              "exportrequired": true
-            },
+              "serverrequired": true
+            }
           }
         }
       }

--- a/core/spec.md
+++ b/core/spec.md
@@ -66,7 +66,7 @@ can choose to define (or enforce) any pattern they wish. In this sense, a
 Group is similar to a "directory" on a filesystem.
 
 Resources represent the main data of interest for the Registry. In the
-filesystem analogy, these would be the "files". All Resource exists under a
+filesystem analogy, these would be the "files". All Resources exists under a
 single Group and, similar to Groups, has a set of Registry metadata.
 However, unlike a Group which only has Registry metadata, each Resource can
 have a "document" associated with it. For example, a "schema" Resource might
@@ -460,10 +460,11 @@ The definition of each attribute is defined below:
 ##### `SINGULARid` (`id`) Attribute
 
 - Type: String
-- Description: An immutable unique identifier of the Registry, Group or
-  Resource. The actual name of this attribute will vary based on the entity it
+- Description: An immutable unique identifier of the Registry, Group, Resource
+  or Version. The actual name of this attribute will vary based on the entity it
   identifies. For example, a `schema` Resource would use an attribute name of
-  `schemaid`. This attribute MUST be `registryid` for the Registry itself.
+  `schemaid`. This attribute MUST be named `registryid` for the Registry
+  itself, and MUST be named `versionid` for all Version entities.
 - Constraints:
   - MUST be a non-empty string consisting of [RFC3986 `unreserved`
     characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3)
@@ -471,8 +472,8 @@ The definition of each attribute is defined below:
   - MUST be case insensitive unique within the scope of the entity's parent.
     In the case of the `registryid` for the Registry itself, the uniqueness
     scope will be based on where the Registry is used. For example, a publicly
-    accessible Registry might want to consider using a UUID, while a private
-    Registry does not need to be so widely unique.
+    accessible Registry might want to consider using a globally unique value,
+    while a private Registry does not need to be so widely unique.
   - This attribute MUST be treated as case sensitive for look-up purposes.
     This means that an HTTP request to an entity with the wrong case for its
     `SINGULARid` MUST be treated as "not found".
@@ -490,10 +491,10 @@ The definition of each attribute is defined below:
   - `myEntity.example.com`
 
 While `SINGULARid` can be something like a UUID, when possible, it is
-RECOMMENDED that it be something human friendly as these value will often appear
-in user-facing situations such as URLs or as command-line parameters. And,
-in cases where [`name`](#name-attribute) is absent, it might be used as the
-display name.
+RECOMMENDED that it be something human friendly as these values will often
+appear in user-facing situations such as URLs or as command-line parameters.
+And, in cases where [`name`](#name-attribute) is absent, it might be used as
+the display name.
 
 Note, since `SINGULARid` is immutable, in order to change its value a new
 entity would need to be created with the new `SINGULARid` that is a deep-copy
@@ -785,7 +786,7 @@ Note that simple file servers SHOULD support exposing Resources where the HTTP
 body response contains the Resource's associated "document" as well as the
 case where the HTTP response body contains a JSON serialization of the
 Resource via the `$meta` suffix on the URL path. This can be achieved by
-created a secondary sibling file on disk with `$meta` at the end of its
+creating a secondary sibling file on disk with `$meta` at the end of its
 filename.
 
 ---
@@ -1035,7 +1036,7 @@ following exceptions:
     This is because when it is absent, the processing of the HTTP `xRegistry-`
     headers are already defined with "patch" semantics so a normal `PUT` or
     `POST` can be used instead. Using `PATCH` in this case would mean that the
-    request is also trying to "patch" the Resources's "document", which this
+    request is also trying to "patch" the Resource's "document", which this
     specification does not support at this time.
   - `PATCH` MAY be used to create new entities, but as with any of the create
     operations, any missing REQUIRED attributes MUST generate an error.
@@ -1284,7 +1285,7 @@ The serialization of the Registry entity adheres to this form:
 ```
 
 The Registry entity includes the following common attributes:
-- [`SINGULARid`](#singularid-id-attribute) - REQUIRED in responses and document
+- [`registryid`](#singularid-id-attribute) - REQUIRED in responses and document
   view, otherwise OPTIONAL
 - [`self`](#self-attribute) - REQUIRED in responses, otherwise OPTIONAL
 - [`epoch`](#epoch-attribute) - REQUIRED in responses, otherwise OPTIONAL
@@ -4236,8 +4237,7 @@ Versions include the following common attributes:
 - [`RESOURCEid`](#singularid-id-attribute) - REQUIRED in responses and document
   view, otherwise OPTIONAL. MUST be the `RESOURCEid` of the owning Resource.
 - [`versionid`](#versionid-attribute) - REQUIRED in responses and document view,
-  otherwise OPTIONAL. MUST be the unique (within the scope of the owning
-  Resource) identifier of this Version.
+  otherwise OPTIONAL.
 - [`self`](#self-attribute) - REQUIRED in responses, otherwise OPTIONAL - URL
   to this Version, not the Resource.
 - [`epoch`](#epoch-attribute) - REQUIRED in responses, otherwise OPTIONAL. MUST

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -27,7 +27,7 @@ this form:
 ```yaml
 {
   "specversion": "STRING",
-  "id": "STRING",
+  "registryid": "STRING",
   "self": "URL",
   "epoch": UINTEGER,
   "name": "STRING", ?
@@ -42,8 +42,8 @@ this form:
   "endpointsurl": "URL",
   "endpointscount": UINTEGER,
   "endpoints": {
-    "ID": {
-      "id": "STRING",                           # xRegistry core attributes
+    "KEY": {
+      "endpointid": "STRING",                   # xRegistry core attributes
       "self": "URL",
       "epoch": UINTEGER,
       "name": "STRING", ?
@@ -129,7 +129,7 @@ this form:
       "messagesurl": "URL", ?
       "messagescount": UINTEGER, ?
       "messages": {
-        "ID": {
+        "KEY": {                                         # messageid
           # See Message Definition spec for details
         }, *
       } ?

--- a/message/spec.md
+++ b/message/spec.md
@@ -32,7 +32,7 @@ this form:
 ```yaml
 {
   "specversion": "STRING",
-  "id": "STRING",
+  "registryid": "STRING",
   "self": "URL",
   "epoch": UINTEGER,
   "name": "STRING", ?
@@ -47,8 +47,8 @@ this form:
   "messagegroupsurl": "URL",
   "messagegroupscount": UINTEGER,
   "messagegroups": {
-    "ID": {
-      "id": "STRING",                           # xRegistry core attributes
+    "KEY": {                                    # messagegroupid
+      "messagegroupid": "STRING",               # xRegistry core attributes
       "self": "URL",
       "epoch": UINTEGER,
       "name": "STRING", ?
@@ -65,16 +65,14 @@ this form:
       "messagesurl": "URL",
       "messagescount": UINTEGER,
       "messages" : {
-        "ID": {
-          "id": "STRING",                      # xRegistry core attributes
+        "KEY": {                               # messageid
+          "messageid": "STRING",               # xRegistry core attributes
           "self": "URL",
           "xref": "URL", ?
           "epoch": UINTEGER,
           "readonly": BOOLEAN, ?
 
-          "versionid": "STRING",
           "name": "STRING", ?
-          "isdefault": true,
           "description": "STRING", ?
           "documentation": "URL", ?
           "labels": { "STRING": "STRING" * }, ?
@@ -265,26 +263,26 @@ Illustrating example:
 "messagegroupscount": 2,
 "messagegroups": {
   "com.example.abc": {
-    "id": "com.example.abc",
+    "messagegroupid": "com.example.abc",
     "format": "CloudEvents/1.0",
 
     "messagesurl": "...",
     "messagescount": 2,
     "messages": {
       "com.example.abc.event1": {
-        "id": "com.example.abc.event1",
+        "messageid": "com.example.abc.event1",
         "format": "CloudEvents/1.0",
          # ... details ...
         }
       },
       "com.example.abc.event2": {
-        "id": "com.example.abc.event1",
+        "messageid": "com.example.abc.event1",
         "format": "CloudEvents/1.0",
         # ... details ...
       }
   },
   "com.example.def": {
-    "id": "com.example.def",
+    "messagegroupid": "com.example.def",
     "format": "CloudEvents/1.0",
 
     "messagesurl": "...",

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -27,7 +27,7 @@ this form:
 ```yaml
 {
   "specversion": "STRING",                         # xRegistry core attributes
-  "id": "STRING",
+  "registryid": "STRING",
   "self": "URL",
   "epoch": UINTEGER,
   "name": "STRING", ?
@@ -42,8 +42,8 @@ this form:
   "schemagroupsurl": "URL",                        # SchemaGroups collection
   "schemagroupscount": UINTEGER,
   "schemagroups": {
-    "ID": {
-      "id": "STRING",                              # xRegistry core attributes
+    "KEY": {                                       # schemagroupid
+      "schemagroupid": "STRING",                   # xRegistry core attributes
       "self": "URL",
       "epoch": UINTEGER,
       "name": "STRING", ?
@@ -57,16 +57,14 @@ this form:
       "schemasurl": "URL",                         # Schemas collection
       "schemascount": UINTEGER,
       "schemas": {
-        "ID": {
-          "id": "STRING",                          # xRegistry core attributes
+        "KEY": {                                   # schemaid
+          "schemaid": "STRING",                    # xRegistry core attributes
           "self": "URL",
           "xreg": "URL", ?
           "epoch": UINTEGER,
           "readonly": BOOLEAN, ?
 
-          "versionid": "STRING",
           "name": "STRING", ?
-          "isdefault": true,
           "description": "STRING", ?
           "documentation": "URL", ?
           "labels": { "STRING": "STRING" * }, ?
@@ -221,7 +219,7 @@ containing 5 schemas.
   "schemagroupscount": 1,
   "schemagroups": {
     "com.example.schemas": {
-      "id": "com.example.schemas",
+      "schemagroupid": "com.example.schemas",
       # Other xRegistry group-level attributes excluded for brevity
 
       "schemasurl": "https://example.com/schemagroups/com.example.schemas/schemas",
@@ -296,14 +294,14 @@ Versions for a schema named `com.example.telemetrydata`:
   "schemagroupscount": 1,
   "schemagroups": {
     "com.example.telemetry": {
-      "id": "com.example.telemetry",
+      "schemagroupid": "com.example.telemetry",
       # other xRegistry group-level attributes excluded for brevity
 
       "schemasurl": "http://example.com/schemagroups/com.example.telemetry/schemas",
       "schemascount": 1,
       "schemas": {
         "com.example.telemetrydata": {
-          "id": "com.example.telemetrydata",
+          "schemaid": "com.example.telemetrydata",
           "defaultversionurl": "http://example.com/schemagroups/com.example.telemetry/schemas/com.example.telemetrydata/versions/3",
           "defaultversionid": "3",
           "description": "device telemetry event data",
@@ -316,7 +314,8 @@ Versions for a schema named `com.example.telemetrydata`:
           "versionscount": 3,
           "versions": {
             "1": {
-              "id": "1",
+              "schemaid": "com.example.telemetrydata",
+              "versionid": "1",
               "description": "device telemetry event data",
               "format": "Protobuf/3",
               # other xRegistry resource-level attributes excluded for brevity
@@ -324,7 +323,8 @@ Versions for a schema named `com.example.telemetrydata`:
               "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; } }"
             },
             "2": {
-              "id": "2",
+              "schemaid": "com.example.telemetrydata",
+              "versionid": "2",
               "description": "device telemetry event data",
               "format": "Protobuf/3",
               # other xRegistry resource-level attributes excluded for brevity
@@ -332,7 +332,8 @@ Versions for a schema named `com.example.telemetrydata`:
               "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; string unit = 2; } }"
             },
             "3": {
-              "id": "3",
+              "schemaid": "com.example.telemetrydata",
+              "versionid": "3",
               "description": "device telemetry event data",
               "format": "Protobuf/3",
               # other xRegistry resource-level attributes excluded for brevity

--- a/tools/dict
+++ b/tools/dict
@@ -5,6 +5,7 @@ api
 apicurio
 apikey
 asyncapi
+attribs
 attributename
 authorityuri
 avro
@@ -49,6 +50,7 @@ deploymentid
 deviceid
 distributionmode
 emoji
+endpointid
 endpointscount
 endpointsurl
 enum
@@ -59,6 +61,7 @@ gid
 github
 gmt
 gotchas
+groupid
 groupscount
 groupsurl
 hasdoc
@@ -84,9 +87,11 @@ jsonschema
 keyname
 linkproperties
 maxversions
+messagegroupid
 messagegroupscount
 messagegroupsurl
 messagegroupurl
+messageid
 messagepack
 messagescount
 messagesurl
@@ -138,7 +143,9 @@ qos
 rawdata
 readonly
 redis
+registryid
 repos
+resourceid
 resourcescount
 resourcesurl
 resourceuri
@@ -148,9 +155,11 @@ rfc
 rid
 schemaformat
 schemagroup
+schemagroupid
 schemagroups
 schemagroupscount
 schemagroupsurl
+schemaid
 schemaobject
 schemascount
 schemasurl
@@ -162,6 +171,7 @@ setdefaultversionid
 setdefaultversionsticky
 setversionid
 siblingattributes
+singularid
 someattribute
 someattributes
 specurl

--- a/tools/words
+++ b/tools/words
@@ -107794,7 +107794,6 @@ exported
 exporter
 exporters
 exporting
-exportrequired
 exports
 expos
 exposable


### PR DESCRIPTION
- s/id/SINGULARid/g  (e.g. registryid, schemagroupid, schemaid, versionid)
- remove "versionid" from Resources
- keep "RESOURCEid" on Versions
- filtering on strings: = is now exact match, add support for wildcards(*)
- SHOULD include Content-Disposition http header for Resources and Versions(rID)
- s/definition/message/g in core spec (typo/old name)
- Provide recommendation that IDs be human readable as they often will appear in human readable locations - like URLs, CLIs and even as the display name in a UI when "name" isn't provided
- Recommend that static file servers also expose "rID$meta" secondary files
- Explain why PATCH+rID w/o $meta when hasdoc=true is banned
- s/?resource/?attribs/g - process just Resource level attributes, not Version

Fixes: #165 