### PR TITLE
Changes for week of Sep 16

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -88,16 +88,6 @@
             },
             {
               "type": "string",
-              "name": "format",
-              "doc": "Endpoint metadata format identifier. If set, all definitions MUST use this format value"
-            },
-            {
-              "type": "string",
-              "name": "binding",
-              "doc": "Endpoint message binding identifier. If set, all definitions MUST use this binding value"
-            },
-            {
-              "type": "string",
               "name": "channel",
               "doc": "tbd"
             },
@@ -107,9 +97,93 @@
               "doc": "tbd"
             },
             {
-              "type": "GenericRecord",
-              "name": "config",
-              "doc": "Configuration information for this endpoint"
+              "name": "envelope",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "EnvelopeCloudevents10Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "envelopeoptions",
+                      "doc": "Envelope metadata constraints"
+                    }
+                  ]
+                }
+              ],
+              "doc": "Envelope metadata format identifier. If set, all definitions MUST use this format value"
+            },
+            {
+              "name": "protocol",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "ProtocolAmqp10Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolMqtt50Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolMqtt311Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolHTTPType",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolKAFKAType",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolNATSType",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                }
+              ],
+              "doc": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value"
             },
             {
               "type": {
@@ -215,16 +289,16 @@
                       "doc": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
                     },
                     {
-                      "name": "format",
+                      "name": "envelope",
                       "type": [
                         {
                           "type": "record",
-                          "name": "FormatNoneType",
+                          "name": "EnvelopeNoneType",
                           "fields": []
                         },
                         {
                           "type": "record",
-                          "name": "FormatCloudevents10Type",
+                          "name": "EnvelopeCloudevents10Type",
                           "fields": [
                             {
                               "type": {
@@ -264,99 +338,132 @@
                                   }
                                 ]
                               },
-                              "name": "metadata",
+                              "name": "envelopemetadata",
                               "doc": "CloudEvents metadata constraints"
+                            },
+                            {
+                              "type": "GenericRecord",
+                              "name": "envelopeoptions",
+                              "doc": "Envelope metadata constraints"
                             }
                           ]
                         }
                       ],
-                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+                      "doc": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
                     },
                     {
-                      "name": "binding",
+                      "name": "protocol",
                       "type": [
                         {
                           "type": "record",
-                          "name": "BindingNoneType",
+                          "name": "ProtocolNoneType",
                           "fields": []
                         },
                         {
                           "type": "record",
-                          "name": "BindingAmqp10Type",
+                          "name": "ProtocolAmqp10Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "AMQP message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingMqtt311Type",
+                          "name": "ProtocolMqtt311Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "MQTT message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingMqtt50Type",
+                          "name": "ProtocolMqtt50Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "MQTT message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingKAFKAType",
+                          "name": "ProtocolKAFKAType",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "The Apache Kafka message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingHTTPType",
+                          "name": "ProtocolHTTPType",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "The HTTP message metadata constraints"
                             }
                           ]
                         }
                       ],
-                      "doc": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+                      "doc": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
                     },
                     {
                       "type": "string",
                       "name": "schemaformat",
-                      "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+                      "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
                     },
                     {
-                      "type": "string",
+                      "type": "record",
                       "name": "schema",
+                      "fields": [
+                        {
+                          "name": "object",
+                          "type": {
+                            "type": "map",
+                            "values": [
+                              "null",
+                              "boolean",
+                              "int",
+                              "long",
+                              "float",
+                              "double",
+                              "bytes",
+                              "string",
+                              {
+                                "type": "array",
+                                "items": [
+                                  "null",
+                                  "boolean",
+                                  "int",
+                                  "long",
+                                  "float",
+                                  "double",
+                                  "bytes",
+                                  "string",
+                                  "GenericRecord"
+                                ]
+                              },
+                              "GenericRecord"
+                            ]
+                          }
+                        }
+                      ],
                       "doc": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
                     },
                     {
-                      "type": "GenericRecord",
-                      "name": "schemaobject",
-                      "doc": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry"
-                    },
-                    {
                       "type": "string",
-                      "name": "schemaurl",
-                      "doc": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+                      "name": "schemauri",
+                      "doc": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
                     }
                   ]
                 }
@@ -446,13 +553,13 @@
             },
             {
               "type": "string",
-              "name": "format",
-              "doc": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+              "name": "envelope",
+              "doc": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted"
             },
             {
               "type": "string",
-              "name": "binding",
-              "doc": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted"
+              "name": "protocol",
+              "doc": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted"
             },
             {
               "name": "Extensions",
@@ -643,6 +750,11 @@
                       "type": "string",
                       "name": "format",
                       "doc": "Schema format identifier for this schema version"
+                    },
+                    {
+                      "type": "boolean",
+                      "name": "validation",
+                      "doc": "Verify compliance with specified schema 'format'"
                     },
                     {
                       "name": "Extensions",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -67,21 +67,16 @@
         },
         "schemaformat": {
           "type": "string",
-          "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+          "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
         },
         "schema": {
-          "type": "string",
+          "type": "object",
           "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
         },
-        "schemaobject": {
-          "type": "object",
-          "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry",
-          "properties": {}
-        },
-        "schemaurl": {
+        "schemauri": {
           "type": "string",
           "format": "uri",
-          "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+          "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
         }
       },
       "required": [
@@ -92,9 +87,9 @@
           "oneOf": [
             {
               "properties": {
-                "format": {
+                "envelope": {
                   "type": "string",
-                  "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "None"
                   ],
@@ -104,14 +99,14 @@
             },
             {
               "properties": {
-                "format": {
+                "envelope": {
                   "type": "string",
-                  "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "CloudEvents/1.0"
                   ]
                 },
-                "metadata": {
+                "envelopemetadata": {
                   "type": "object",
                   "description": "CloudEvents metadata constraints",
                   "properties": {
@@ -229,10 +224,24 @@
                       }
                     }
                   }
+                },
+                "envelopeoptions": {
+                  "type": "object",
+                  "description": "Envelope metadata constraints",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "description": "Whether CloudEvents 'binary' or 'structure' mode will be used"
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+                    }
+                  }
                 }
               },
               "required": [
-                "format"
+                "envelope"
               ]
             }
           ]
@@ -241,9 +250,9 @@
           "oneOf": [
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "None"
                   ],
@@ -253,14 +262,14 @@
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "AMQP/1.0"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "AMQP message metadata constraints",
                   "properties": {
@@ -541,19 +550,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "MQTT/3.1.1"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "MQTT message metadata constraints",
                   "properties": {
@@ -591,19 +600,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "MQTT/5.0"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "MQTT message metadata constraints",
                   "properties": {
@@ -698,19 +707,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "KAFKA"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "The Apache Kafka message metadata constraints",
                   "properties": {
@@ -751,19 +760,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "HTTP"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "The HTTP message metadata constraints",
                   "properties": {
@@ -801,7 +810,7 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             }
           ]
@@ -850,14 +859,6 @@
           "type": "string",
           "description": "Client's expected usage of this endpoint"
         },
-        "format": {
-          "type": "string",
-          "description": "Endpoint metadata format identifier. If set, all definitions MUST use this format value"
-        },
-        "binding": {
-          "type": "string",
-          "description": "Endpoint message binding identifier. If set, all definitions MUST use this binding value"
-        },
         "channel": {
           "type": "string",
           "description": "tbd"
@@ -888,73 +889,118 @@
             }
           }
         },
-        "config": {
+        "messagegroups": {
+          "type": "array",
+          "description": "The message groups that are supported by this endpoint",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "messages": {
           "type": "object",
-          "description": "Configuration information for this endpoint",
-          "properties": {
-            "endpoints": {
-              "type": "array",
-              "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "uri": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "Network accessible location"
-                  }
-                }
-              }
-            },
-            "authorization": {
-              "type": "array",
-              "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
-                  },
-                  "resourceurl": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The resource uri for which authorization shall be granted (if applicable)"
-                  },
-                  "authorityuri": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authority uri where authorization shall be requested (if applicable)"
-                  },
-                  "granttypes": {
-                    "type": "array",
-                    "description": "The grant types that can be requested (if applicable)",
-                    "items": {
+          "additionalProperties": {
+            "$ref": "#/definitions/message"
+          }
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "envelope": {
+                  "type": "string",
+                  "description": "Envelope metadata format identifier. If set, all definitions MUST use this format value",
+                  "enum": [
+                    "CloudEvents/1.0"
+                  ]
+                },
+                "envelopeoptions": {
+                  "type": "object",
+                  "description": "Envelope metadata constraints",
+                  "properties": {
+                    "mode": {
+                      "type": "string"
+                    },
+                    "format": {
                       "type": "string"
                     }
                   }
                 }
-              }
-            },
-            "deployed": {
-              "type": "boolean",
-              "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+              },
+              "required": [
+                "envelope"
+              ]
             }
-          },
+          ]
+        },
+        {
           "oneOf": [
             {
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "AMQP/1.0"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "AMQP 1.0 connection options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "node": {
                       "type": "string",
                       "description": "The AMQP node name. Commonly the name of a queue or a topic"
@@ -992,15 +1038,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "MQTT/5.0"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "MQTT 5.0 connection options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "topic": {
                       "type": "string",
                       "description": "The MQTT topic path"
@@ -1037,15 +1131,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "MQTT/3.1.1"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "MQTT 3.1.1 connection options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "topic": {
                       "type": "string",
                       "description": "MQTT topic path"
@@ -1082,15 +1224,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "HTTP"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "method": {
                       "type": "string",
                       "description": "The HTTP method name"
@@ -1130,15 +1320,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "KAFKA"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "Apache Kafka options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "topic": {
                       "type": "string",
                       "description": "Apache Kafka topic name"
@@ -1177,15 +1415,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "NATS"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "NATS options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "subject": {
                       "type": "string",
                       "description": "The NATS subject"
@@ -1198,24 +1484,7 @@
               ]
             }
           ]
-        },
-        "messagegroups": {
-          "type": "array",
-          "description": "The message groups that are supported by this endpoint",
-          "items": {
-            "type": "string",
-            "format": "uri"
-          }
-        },
-        "messages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/message"
-          }
         }
-      },
-      "required": [
-        "id"
       ]
     },
     "messagegroup": {
@@ -1256,13 +1525,13 @@
           "type": "string",
           "format": "date-time"
         },
-        "format": {
+        "envelope": {
           "type": "string",
-          "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+          "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted"
         },
-        "binding": {
+        "protocol": {
           "type": "string",
-          "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted"
+          "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted"
         },
         "messages": {
           "type": "object",
@@ -1316,6 +1585,10 @@
         "format": {
           "type": "string",
           "description": "Schema format identifier for this schema version"
+        },
+        "validation": {
+          "type": "boolean",
+          "description": "Verify compliance with specified schema 'format'"
         }
       },
       "oneOf": [

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -2522,11 +2522,11 @@
           }
         }
       },
-      "format_None": {
+      "envelope_None": {
         "properties": {
-          "format": {
+          "envelope": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "None"
             ],
@@ -2534,16 +2534,16 @@
           }
         }
       },
-      "format_CloudEvents_1_0": {
+      "envelope_CloudEvents_1_0": {
         "properties": {
-          "format": {
+          "envelope": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "CloudEvents/1.0"
             ]
           },
-          "metadata": {
+          "envelopemetadata": {
             "type": "object",
             "description": "CloudEvents metadata constraints",
             "properties": {
@@ -2661,17 +2661,31 @@
                 }
               }
             }
+          },
+          "envelopeoptions": {
+            "type": "object",
+            "description": "Envelope metadata constraints",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "description": "Whether CloudEvents 'binary' or 'structure' mode will be used"
+              },
+              "format": {
+                "type": "string",
+                "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+              }
+            }
           }
         },
         "required": [
-          "format"
+          "envelope"
         ]
       },
-      "binding_None": {
+      "protocol_None": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "None"
             ],
@@ -2679,16 +2693,16 @@
           }
         }
       },
-      "binding_AMQP_1_0": {
+      "protocol_AMQP_1_0": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "AMQP/1.0"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "AMQP message metadata constraints",
             "properties": {
@@ -2969,19 +2983,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_MQTT_3_1_1": {
+      "protocol_MQTT_3_1_1": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "MQTT/3.1.1"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "MQTT message metadata constraints",
             "properties": {
@@ -3019,19 +3033,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_MQTT_5_0": {
+      "protocol_MQTT_5_0": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "MQTT/5.0"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "MQTT message metadata constraints",
             "properties": {
@@ -3126,19 +3140,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_KAFKA": {
+      "protocol_KAFKA": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "KAFKA"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "The Apache Kafka message metadata constraints",
             "properties": {
@@ -3179,19 +3193,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_HTTP": {
+      "protocol_HTTP": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "HTTP"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "The HTTP message metadata constraints",
             "properties": {
@@ -3229,7 +3243,7 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
       "message": {
@@ -3277,282 +3291,94 @@
           },
           "schemaformat": {
             "type": "string",
-            "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+            "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
           },
           "schema": {
-            "type": "string",
+            "type": "object",
             "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
           },
-          "schemaobject": {
-            "type": "object",
-            "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry",
-            "properties": {}
-          },
-          "schemaurl": {
+          "schemauri": {
             "type": "string",
             "format": "uri",
-            "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+            "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
           }
         },
         "required": [
           "id"
         ],
         "discriminator": {
-          "propertyName": "binding",
+          "propertyName": "protocol",
           "mapping": {
-            "None": "#/components/schemas/binding_None",
-            "AMQP/1.0": "#/components/schemas/binding_AMQP_1_0",
-            "MQTT/3.1.1": "#/components/schemas/binding_MQTT_3_1_1",
-            "MQTT/5.0": "#/components/schemas/binding_MQTT_5_0",
-            "KAFKA": "#/components/schemas/binding_KAFKA",
-            "HTTP": "#/components/schemas/binding_HTTP"
+            "None": "#/components/schemas/protocol_None",
+            "AMQP/1.0": "#/components/schemas/protocol_AMQP_1_0",
+            "MQTT/3.1.1": "#/components/schemas/protocol_MQTT_3_1_1",
+            "MQTT/5.0": "#/components/schemas/protocol_MQTT_5_0",
+            "KAFKA": "#/components/schemas/protocol_KAFKA",
+            "HTTP": "#/components/schemas/protocol_HTTP"
           }
         }
-      },
-      "protocol_AMQP_1_0": {
-        "properties": {
-          "protocol": {
-            "type": "string",
-            "description": "endpoint protocol identifier",
-            "enum": [
-              "AMQP/1.0"
-            ]
-          },
-          "options": {
-            "type": "object",
-            "description": "AMQP 1.0 connection options",
-            "properties": {
-              "node": {
-                "type": "string",
-                "description": "The AMQP node name. Commonly the name of a queue or a topic"
-              },
-              "durable": {
-                "type": "boolean",
-                "description": "The AMQP durable flag. Whether the node is durable or transient"
-              },
-              "linkproperties": {
-                "type": "object",
-                "description": "An optional map of AMQP link properties to use with the endpoint",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
-              "connectionproperties": {
-                "type": "object",
-                "description": "An optional map of AMQP connection properties to use with the endpoint",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
-              "distributionmode": {
-                "type": "string",
-                "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message"
-              }
-            }
-          }
-        },
-        "required": [
-          "protocol"
-        ]
-      },
-      "protocol_MQTT_5_0": {
-        "properties": {
-          "protocol": {
-            "type": "string",
-            "description": "endpoint protocol identifier",
-            "enum": [
-              "MQTT/5.0"
-            ]
-          },
-          "options": {
-            "type": "object",
-            "description": "MQTT 5.0 connection options",
-            "properties": {
-              "topic": {
-                "type": "string",
-                "description": "The MQTT topic path"
-              },
-              "qos": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "The MQTT QoS level. May be 0, 1, or 2"
-              },
-              "retain": {
-                "type": "boolean",
-                "description": "The MQTT retain flag to use for publishers on ths endpoint"
-              },
-              "cleansession": {
-                "type": "boolean",
-                "description": "The MQTT clean session flag to use for publishers on this endpoint"
-              },
-              "willtopic": {
-                "type": "string",
-                "description": "The MQTT will topic to configure for publishers on this endpoint"
-              },
-              "willmessage": {
-                "type": "string",
-                "description": "The MQTT will message definition to configure for publishers on this endpoint"
-              }
-            }
-          }
-        },
-        "required": [
-          "protocol"
-        ]
-      },
-      "protocol_MQTT_3_1_1": {
-        "properties": {
-          "protocol": {
-            "type": "string",
-            "description": "endpoint protocol identifier",
-            "enum": [
-              "MQTT/3.1.1"
-            ]
-          },
-          "options": {
-            "type": "object",
-            "description": "MQTT 3.1.1 connection options",
-            "properties": {
-              "topic": {
-                "type": "string",
-                "description": "MQTT topic path"
-              },
-              "qos": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "The MQTT QoS level\u00f6. May be 0, 1, or 2"
-              },
-              "retain": {
-                "type": "boolean",
-                "description": "The MQTT retain flag to use for publishers on ths endpoint"
-              },
-              "cleansession": {
-                "type": "boolean",
-                "description": "The MQTT clean session flag to use for publishers on this endpoint"
-              },
-              "willtopic": {
-                "type": "string",
-                "description": "The MQTT will topic to configure for publishers on this endpoint"
-              },
-              "willmessage": {
-                "type": "string",
-                "description": "The MQTT will message definition to configure for publishers on this endpoint"
-              }
-            }
-          }
-        },
-        "required": [
-          "protocol"
-        ]
-      },
-      "protocol_HTTP": {
-        "properties": {
-          "protocol": {
-            "type": "string",
-            "description": "endpoint protocol identifier",
-            "enum": [
-              "HTTP"
-            ]
-          },
-          "options": {
-            "type": "object",
-            "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions",
-            "properties": {
-              "method": {
-                "type": "string",
-                "description": "The HTTP method name"
-              },
-              "headers": {
-                "type": "array",
-                "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "HTTP header name"
-                    },
-                    "value": {
-                      "type": "string",
-                      "description": "HTTP header value"
-                    }
-                  }
-                }
-              },
-              "query": {
-                "type": "object",
-                "description": "HTTP query parameters",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "required": [
-          "protocol"
-        ]
-      },
-      "protocol_KAFKA": {
-        "properties": {
-          "protocol": {
-            "type": "string",
-            "description": "endpoint protocol identifier",
-            "enum": [
-              "KAFKA"
-            ]
-          },
-          "options": {
-            "type": "object",
-            "description": "Apache Kafka options",
-            "properties": {
-              "topic": {
-                "type": "string",
-                "description": "Apache Kafka topic name"
-              },
-              "acks": {
-                "type": "integer",
-                "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
-              },
-              "key": {
-                "type": "string",
-                "description": "The Apache Kafka record key"
-              },
-              "partition": {
-                "type": "integer",
-                "description": "The Apache Kafka partition number to use when writing to or receiving from Apache Kafka"
-              },
-              "consumergroup": {
-                "type": "string",
-                "description": "The Apache Kafka consumer group name to use for consumers"
-              },
-              "headers": {
-                "type": "object",
-                "description": "The Apache Kafka headers for publishers on this endpoint",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "required": [
-          "protocol"
-        ]
       },
       "protocol_NATS": {
         "properties": {
           "protocol": {
             "type": "string",
-            "description": "endpoint protocol identifier",
+            "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
             "enum": [
               "NATS"
             ]
           },
-          "options": {
+          "protocoloptions": {
             "type": "object",
-            "description": "NATS options",
+            "description": "Configuration information for this endpoint",
             "properties": {
+              "endpoints": {
+                "type": "array",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "uri": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Network accessible location"
+                    }
+                  }
+                }
+              },
+              "authorization": {
+                "type": "array",
+                "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                    },
+                    "resourceurl": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The resource uri for which authorization shall be granted (if applicable)"
+                    },
+                    "authorityuri": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "The authority uri where authorization shall be requested (if applicable)"
+                    },
+                    "granttypes": {
+                      "type": "array",
+                      "description": "The grant types that can be requested (if applicable)",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "deployed": {
+                "type": "boolean",
+                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+              },
               "subject": {
                 "type": "string",
                 "description": "The NATS subject"
@@ -3606,14 +3432,6 @@
             "type": "string",
             "description": "Client's expected usage of this endpoint"
           },
-          "format": {
-            "type": "string",
-            "description": "Endpoint metadata format identifier. If set, all definitions MUST use this format value"
-          },
-          "binding": {
-            "type": "string",
-            "description": "Endpoint message binding identifier. If set, all definitions MUST use this binding value"
-          },
           "channel": {
             "type": "string",
             "description": "tbd"
@@ -3644,71 +3462,6 @@
               }
             }
           },
-          "config": {
-            "type": "object",
-            "description": "Configuration information for this endpoint",
-            "properties": {
-              "endpoints": {
-                "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "uri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "Network accessible location"
-                    }
-                  }
-                }
-              },
-              "authorization": {
-                "type": "array",
-                "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
-                    },
-                    "resourceurl": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "The resource uri for which authorization shall be granted (if applicable)"
-                    },
-                    "authorityuri": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              "deployed": {
-                "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
-              }
-            },
-            "discriminator": {
-              "propertyName": "protocol",
-              "mapping": {
-                "AMQP/1.0": "#/components/schemas/protocol_AMQP_1_0",
-                "MQTT/5.0": "#/components/schemas/protocol_MQTT_5_0",
-                "MQTT/3.1.1": "#/components/schemas/protocol_MQTT_3_1_1",
-                "HTTP": "#/components/schemas/protocol_HTTP",
-                "KAFKA": "#/components/schemas/protocol_KAFKA",
-                "NATS": "#/components/schemas/protocol_NATS"
-              }
-            }
-          },
           "messagegroups": {
             "type": "array",
             "description": "The message groups that are supported by this endpoint",
@@ -3726,7 +3479,18 @@
         },
         "required": [
           "id"
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "protocol",
+          "mapping": {
+            "AMQP/1.0": "#/components/schemas/protocol_AMQP_1_0",
+            "MQTT/5.0": "#/components/schemas/protocol_MQTT_5_0",
+            "MQTT/3.1.1": "#/components/schemas/protocol_MQTT_3_1_1",
+            "HTTP": "#/components/schemas/protocol_HTTP",
+            "KAFKA": "#/components/schemas/protocol_KAFKA",
+            "NATS": "#/components/schemas/protocol_NATS"
+          }
+        }
       },
       "messagegroup": {
         "type": "object",
@@ -3766,13 +3530,13 @@
             "type": "string",
             "format": "date-time"
           },
-          "format": {
+          "envelope": {
             "type": "string",
-            "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+            "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted"
           },
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted"
+            "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted"
           },
           "messages": {
             "type": "object",
@@ -3826,6 +3590,10 @@
           "format": {
             "type": "string",
             "description": "Schema format identifier for this schema version"
+          },
+          "validation": {
+            "type": "boolean",
+            "description": "Verify compliance with specified schema 'format'"
           }
         },
         "oneOf": [

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -403,7 +403,7 @@ While the CloudEvents Registry is primarily motivated by enabling development of
 CloudEvents-based event flows, the registry is not limited to CloudEvents. It
 can be used to describe any asynchronous messaging or eventing endpoint and its
 messages, including endpoints that do not use CloudEvents at all. The [Message
-Formats](../message/spec.md#metadata-formats-and-message-bindings) section
+Formats](../message/spec.md#metadata-envelopes-and-message-protocols) section
 therefore not only describes the attribute meta-schema for CloudEvents, but also
 meta-schemas for the native message envelopes of MQTT, AMQP, and other messaging
 protocols.

--- a/core/sample-model.json
+++ b/core/sample-model.json
@@ -122,7 +122,14 @@
           "singular": "sample_resource",
           "attributes": {
             "sample_resourceid": {
-              "name": "id",
+              "name": "sample_resourceid",
+              "type": "string",
+              "immutable": true,
+              "serverrequired": true,
+              "location": "resource"
+            },
+            "versionid": {
+              "name": "versionid",
               "type": "string",
               "immutable": true,
               "serverrequired": true
@@ -131,21 +138,25 @@
               "name": "self",
               "type": "url",
               "readonly": true,
-              "serverrequired": true
+              "serverrequired": true,
+              "location": "both"
             },
             "xref": {
               "name": "xref",
-              "type": "url"
+              "type": "url",
+              "location": "resource"
             },
             "epoch": {
               "name": "epoch",
               "type": "uinteger",
-              "serverrequired": true
+              "serverrequired": true,
+              "location": "resource"
             },
             "readonly": {
               "name": "readonly",
               "type": "boolean",
-              "readonly": true
+              "readonly": true,
+              "location": "resource"
             },
             "name": {
               "name": "name",
@@ -190,18 +201,21 @@
             "defaultversionsticky": {
               "name": "defaultversionsticky",
               "type": "boolean",
-              "serverrequired": true
+              "serverrequired": true,
+              "location": "resource"
             },
             "defaultversionid": {
               "name": "defaultversionid",
               "type": "string",
-              "serverrequired": true
+              "serverrequired": true,
+              "location": "resource"
             },
             "defaultversionurl": {
               "name": "defaultversionurl",
               "type": "url",
               "readonly": true,
-              "serverrequired": true
+              "serverrequired": true,
+              "location": "resource"
             }
           }
         }

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -20,20 +20,6 @@
           "clientrequired": true,
           "serverrequired": true
         },
-        "format": {
-          "name": "format",
-          "type": "string",
-          "description": "Endpoint metadata format identifier. If set, all definitions MUST use this format value",
-          "clientrequired": false,
-          "serverrequired": false
-        },
-        "binding": {
-          "name": "binding",
-          "type": "string",
-          "description": "Endpoint message binding identifier. If set, all definitions MUST use this binding value",
-          "clientrequired": false,
-          "serverrequired": false
-        },
         "channel": {
           "name": "channel",
           "type": "string",
@@ -70,355 +56,710 @@
             }
           }
         },
-        "config": {
-          "name": "config",
-          "type": "object",
-          "description": "Configuration information for this endpoint",
-          "attributes": {
-            "protocol": {
-              "name": "protocol",
-              "type": "string",
-              "description": "endpoint protocol identifier",
-              "clientrequired": true,
-              "serverrequired": true,
-              "ifvalues": {
-                "AMQP/1.0": {
-                  "siblingattributes": {
-                    "options": {
-                      "name": "options",
-                      "type": "object",
-                      "description": "AMQP 1.0 connection options",
-                      "attributes": {
-                        "node": {
-                          "name": "node",
-                          "type": "string",
-                          "description": "The AMQP node name. Commonly the name of a queue or a topic"
-                        },
-                        "durable": {
-                          "name": "durable",
-                          "type": "boolean",
-                          "description": "The AMQP durable flag. Whether the node is durable or transient"
-                        },
-                        "linkproperties": {
-                          "name": "linkproperties",
-                          "type": "map",
-                          "description": "An optional map of AMQP link properties to use with the endpoint",
-                          "item": {
-                            "type": "string"
-                          }
-                        },
-                        "connectionproperties": {
-                          "name": "connectionproperties",
-                          "type": "map",
-                          "description": "An optional map of AMQP connection properties to use with the endpoint",
-                          "item": {
-                            "type": "string"
-                          }
-                        },
-                        "distributionmode": {
-                          "name": "distributionmode",
-                          "type": "string",
-                          "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
-                          "enum": [
-                            "move",
-                            "copy"
-                          ]
-                        },
-                        "*": {
-                          "name": "*",
-                          "type": "any"
-                        }
-                      }
-                    }
-                  }
-                },
-                "MQTT/5.0": {
-                  "siblingattributes": {
-                    "options": {
-                      "name": "options",
-                      "type": "object",
-                      "description": "MQTT 5.0 connection options",
-                      "attributes": {
-                        "topic": {
-                          "name": "topic",
-                          "type": "string",
-                          "description": "The MQTT topic path"
-                        },
-                        "qos": {
-                          "name": "qos",
-                          "type": "uinteger",
-                          "description": "The MQTT QoS level. May be 0, 1, or 2"
-                        },
-                        "retain": {
-                          "name": "retain",
-                          "type": "boolean",
-                          "description": "The MQTT retain flag to use for publishers on ths endpoint"
-                        },
-                        "cleansession": {
-                          "name": "cleansession",
-                          "type": "boolean",
-                          "description": "The MQTT clean session flag to use for publishers on this endpoint"
-                        },
-                        "willtopic": {
-                          "name": "willtopic",
-                          "type": "string",
-                          "description": "The MQTT will topic to configure for publishers on this endpoint"
-                        },
-                        "willmessage": {
-                          "name": "willmessage",
-                          "type": "string",
-                          "description": "The MQTT will message definition to configure for publishers on this endpoint"
-                        },
-                        "*": {
-                          "name": "*",
-                          "type": "any"
-                        }
-                      }
-                    }
-                  }
-                },
-                "MQTT/3.1.1": {
-                  "siblingattributes": {
-                    "options": {
-                      "name": "options",
-                      "type": "object",
-                      "description": "MQTT 3.1.1 connection options",
-                      "attributes": {
-                        "topic": {
-                          "name": "topic",
-                          "type": "string",
-                          "description": "MQTT topic path"
-                        },
-                        "qos": {
-                          "name": "qos",
-                          "type": "uinteger",
-                          "description": "The MQTT QoS levelö. May be 0, 1, or 2"
-                        },
-                        "retain": {
-                          "name": "retain",
-                          "type": "boolean",
-                          "description": "The MQTT retain flag to use for publishers on ths endpoint"
-                        },
-                        "cleansession": {
-                          "name": "cleansession",
-                          "type": "boolean",
-                          "description": "The MQTT clean session flag to use for publishers on this endpoint"
-                        },
-                        "willtopic": {
-                          "name": "willtopic",
-                          "type": "string",
-                          "description": "The MQTT will topic to configure for publishers on this endpoint"
-                        },
-                        "willmessage": {
-                          "name": "willmessage",
-                          "type": "string",
-                          "description": "The MQTT will message definition to configure for publishers on this endpoint"
-                        },
-                        "*": {
-                          "name": "*",
-                          "type": "any"
-                        }
-                      }
-                    }
-                  }
-                },
-                "HTTP": {
-                  "siblingattributes": {
-                    "options": {
-                      "name": "options",
-                      "type": "object",
-                      "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions",
-                      "attributes": {
-                        "method": {
-                          "name": "method",
-                          "type": "string",
-                          "description": "The HTTP method name"
-                        },
-                        "headers": {
-                          "name": "headers",
-                          "type": "array",
-                          "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive",
-                          "item": {
-                            "type": "object",
-                            "attributes": {
-                              "name": {
-                                "name": "name",
-                                "type": "string",
-                                "description": "HTTP header name",
-                                "clientrequired": true,
-                                "serverrequired": true
-                              },
-                              "value": {
-                                "name": "value",
-                                "type": "string",
-                                "description": "HTTP header value",
-                                "clientrequired": true,
-                                "serverrequired": true
-                              }
-                            }
-                          }
-                        },
-                        "query": {
-                          "name": "query",
-                          "type": "map",
-                          "description": "HTTP query parameters",
-                          "item": {
-                            "type": "string"
-                          }
-                        },
-                        "*": {
-                          "name": "*",
-                          "type": "any"
-                        }
-                      }
-                    }
-                  }
-                },
-                "KAFKA": {
-                  "siblingattributes": {
-                    "options": {
-                      "name": "options",
-                      "type": "object",
-                      "description": "Apache Kafka options",
-                      "attributes": {
-                        "topic": {
-                          "name": "topic",
-                          "type": "string",
-                          "description": "Apache Kafka topic name",
-                          "clientrequired": true,
-                          "serverrequired": true
-                        },
-                        "acks": {
-                          "name": "acks",
-                          "type": "integer",
-                          "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
-                        },
-                        "key": {
-                          "name": "key",
-                          "type": "string",
-                          "description": "The Apache Kafka record key"
-                        },
-                        "partition": {
-                          "name": "partition",
-                          "type": "integer",
-                          "description": "The Apache Kafka partition number to use when writing to or receiving from Apache Kafka"
-                        },
-                        "consumergroup": {
-                          "name": "consumergroup",
-                          "type": "string",
-                          "description": "The Apache Kafka consumer group name to use for consumers"
-                        },
-                        "headers": {
-                          "name": "headers",
-                          "type": "map",
-                          "description": "The Apache Kafka headers for publishers on this endpoint",
-                          "item": {
-                            "type": "string"
-                          }
-                        },
-                        "*": {
-                          "name": "*",
-                          "type": "any"
-                        }
-                      }
-                    }
-                  }
-                },
-                "NATS": {
-                  "siblingattributes": {
-                    "options": {
-                      "name": "options",
-                      "type": "object",
-                      "description": "NATS options",
-                      "attributes": {
-                        "subject": {
-                          "name": "subject",
-                          "type": "string",
-                          "description": "The NATS subject",
-                          "clientrequired": true,
-                          "serverrequired": true
-                        },
-                        "*": {
-                          "name": "*",
-                          "type": "any"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "endpoints": {
-              "name": "endpoints",
-              "type": "array",
-              "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
-              "item": {
-                "type": "object",
-                "attributes": {
-                  "uri": {
-                    "name": "uri",
-                    "type": "uri",
-                    "description": "Network accessible location",
-                    "clientrequired": true,
-                    "serverrequired": true
-                  },
-                  "*": {
-                    "name": "*",
-                    "type": "any"
-                  }
-                }
-              }
-            },
-            "authorization": {
-              "name": "authorization",
-              "type": "array",
-              "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
-              "item": {
-                "type": "object",
-                "attributes": {
-                  "type": {
-                    "name": "type",
-                    "type": "string",
-                    "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                    "clientrequired": true,
-                    "serverrequired": true
-                  },
-                  "resourceurl": {
-                    "name": "resourceurl",
-                    "type": "url",
-                    "description": "The resource uri for which authorization shall be granted (if applicable)"
-                  },
-                  "authorityuri": {
-                    "name": "authorityuri",
-                    "type": "uri",
-                    "description": "The authority uri where authorization shall be requested (if applicable)"
-                  },
-                  "granttypes": {
-                    "name": "granttypes",
-                    "type": "array",
-                    "description": "The grant types that can be requested (if applicable)",
-                    "item": {
+        "envelope": {
+          "name": "envelope",
+          "type": "string",
+          "description": "Envelope metadata format identifier. If set, all definitions MUST use this format value",
+          "clientrequired": false,
+          "serverrequired": false,
+          "ifvalues": {
+            "CloudEvents/1.0": {
+              "siblingattributes": {
+                "envelopeoptions": {
+                  "name": "envelopeoptions",
+                  "type": "object",
+                  "description": "Envelope metadata constraints",
+                  "attributes": {
+                    "mode": {
+                      "name": "mode",
+                      "type": "string",
+                      "enum": [ "binary", "structured" ]
+                    },
+                    "format": {
+                      "name": "format",
                       "type": "string"
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
                     }
-                  },
-                  "*": {
-                    "name": "*",
-                    "type": "any"
                   }
                 }
               }
-            },
-            "deployed": {
-              "name": "deployed",
-              "type": "boolean",
-              "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
-            },
-            "*": {
-              "name": "*",
-              "type": "any"
             }
           }
         },
+        "protocol": {
+          "name": "protocol",
+          "type": "string",
+          "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
+          "clientrequired": false,
+          "serverrequired": false,
+
+          "ifvalues": {
+            "AMQP/1.0": {
+              "siblingattributes": {
+                "protocoloptions": {
+                  "name": "protocoloptions",
+                  "type": "object",
+                  "description": "Configuration information for this endpoint",
+                  "attributes": {
+                    "endpoints": {
+                      "name": "endpoints",
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "Network accessible location",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "name": "authorization",
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "type": {
+                            "name": "type",
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "resourceurl": {
+                            "name": "resourceurl",
+                            "type": "url",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "name": "authorityuri",
+                            "type": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "name": "granttypes",
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "item": {
+                              "type": "string"
+                            }
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "name": "deployed",
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
+
+                    "node": {
+                      "name": "node",
+                      "type": "string",
+                      "description": "The AMQP node name. Commonly the name of a queue or a topic"
+                    },
+                    "durable": {
+                      "name": "durable",
+                      "type": "boolean",
+                      "description": "The AMQP durable flag. Whether the node is durable or transient"
+                    },
+                    "linkproperties": {
+                      "name": "linkproperties",
+                      "type": "map",
+                      "description": "An optional map of AMQP link properties to use with the endpoint",
+                      "item": {
+                        "type": "string"
+                      }
+                    },
+                    "connectionproperties": {
+                      "name": "connectionproperties",
+                      "type": "map",
+                      "description": "An optional map of AMQP connection properties to use with the endpoint",
+                      "item": {
+                        "type": "string"
+                      }
+                    },
+                    "distributionmode": {
+                      "name": "distributionmode",
+                      "type": "string",
+                      "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
+                      "enum": [
+                        "move",
+                        "copy"
+                      ]
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }  
+              }
+            },
+            "MQTT/5.0": {
+              "siblingattributes": {
+                "protocoloptions": {
+                  "name": "protocoloptions",
+                  "type": "object",
+                  "description": "Configuration information for this endpoint",
+                  "attributes": {
+                    "endpoints": {
+                      "name": "endpoints",
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "Network accessible location",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "name": "authorization",
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "type": {
+                            "name": "type",
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "resourceurl": {
+                            "name": "resourceurl",
+                            "type": "url",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "name": "authorityuri",
+                            "type": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "name": "granttypes",
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "item": {
+                              "type": "string"
+                            }
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "name": "deployed",
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
+
+                    "topic": {
+                      "name": "topic",
+                      "type": "string",
+                      "description": "The MQTT topic path"
+                    },
+                    "qos": {
+                      "name": "qos",
+                      "type": "uinteger",
+                      "description": "The MQTT QoS level. May be 0, 1, or 2"
+                    },
+                    "retain": {
+                      "name": "retain",
+                      "type": "boolean",
+                      "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                    },
+                    "cleansession": {
+                      "name": "cleansession",
+                      "type": "boolean",
+                      "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                    },
+                    "willtopic": {
+                      "name": "willtopic",
+                      "type": "string",
+                      "description": "The MQTT will topic to configure for publishers on this endpoint"
+                    },
+                    "willmessage": {
+                      "name": "willmessage",
+                      "type": "string",
+                      "description": "The MQTT will message definition to configure for publishers on this endpoint"
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }
+              }
+            },
+            "MQTT/3.1.1": {
+              "siblingattributes": {
+                "protocoloptions": {
+                  "name": "protocoloptions",
+                  "type": "object",
+                  "description": "Configuration information for this endpoint",
+                  "attributes": {
+                    "endpoints": {
+                      "name": "endpoints",
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "Network accessible location",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "name": "authorization",
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "type": {
+                            "name": "type",
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "resourceurl": {
+                            "name": "resourceurl",
+                            "type": "url",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "name": "authorityuri",
+                            "type": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "name": "granttypes",
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "item": {
+                              "type": "string"
+                            }
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "name": "deployed",
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
+
+                    "topic": {
+                      "name": "topic",
+                      "type": "string",
+                      "description": "MQTT topic path"
+                    },
+                    "qos": {
+                      "name": "qos",
+                      "type": "uinteger",
+                      "description": "The MQTT QoS levelö. May be 0, 1, or 2"
+                    },
+                    "retain": {
+                      "name": "retain",
+                      "type": "boolean",
+                      "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                    },
+                    "cleansession": {
+                      "name": "cleansession",
+                      "type": "boolean",
+                      "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                    },
+                    "willtopic": {
+                      "name": "willtopic",
+                      "type": "string",
+                      "description": "The MQTT will topic to configure for publishers on this endpoint"
+                    },
+                    "willmessage": {
+                      "name": "willmessage",
+                      "type": "string",
+                      "description": "The MQTT will message definition to configure for publishers on this endpoint"
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }
+              }
+            },
+            "HTTP": {
+              "siblingattributes": {
+                "protocoloptions": {
+                  "name": "protocoloptions",
+                  "type": "object",
+                  "description": "Configuration information for this endpoint",
+                  "attributes": {
+                    "endpoints": {
+                      "name": "endpoints",
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "Network accessible location",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "name": "authorization",
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "type": {
+                            "name": "type",
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "resourceurl": {
+                            "name": "resourceurl",
+                            "type": "url",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "name": "authorityuri",
+                            "type": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "name": "granttypes",
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "item": {
+                              "type": "string"
+                            }
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "name": "deployed",
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
+
+                    "method": {
+                      "name": "method",
+                      "type": "string",
+                      "description": "The HTTP method name"
+                    },
+                    "headers": {
+                      "name": "headers",
+                      "type": "array",
+                      "description": "HTTP headers to use with the endpoint. The same header may be specified multiple times with different values. The HTTP header names are case insensitive",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "name": {
+                            "name": "name",
+                            "type": "string",
+                            "description": "HTTP header name",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "value": {
+                            "name": "value",
+                            "type": "string",
+                            "description": "HTTP header value",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          }
+                        }
+                      }
+                    },
+                    "query": {
+                      "name": "query",
+                      "type": "map",
+                      "description": "HTTP query parameters",
+                      "item": {
+                        "type": "string"
+                      }
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }
+              }
+            },
+            "KAFKA": {
+              "siblingattributes": {
+                "protocoloptions": {
+                  "name": "protocoloptions",
+                  "type": "object",
+                  "description": "Configuration information for this endpoint",
+                  "attributes": {
+                    "endpoints": {
+                      "name": "endpoints",
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "Network accessible location",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "name": "authorization",
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "type": {
+                            "name": "type",
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "resourceurl": {
+                            "name": "resourceurl",
+                            "type": "url",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "name": "authorityuri",
+                            "type": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "name": "granttypes",
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "item": {
+                              "type": "string"
+                            }
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "name": "deployed",
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
+
+                    "topic": {
+                      "name": "topic",
+                      "type": "string",
+                      "description": "Apache Kafka topic name",
+                      "clientrequired": true,
+                      "serverrequired": true
+                    },
+                    "acks": {
+                      "name": "acks",
+                      "type": "integer",
+                      "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                    },
+                    "key": {
+                      "name": "key",
+                      "type": "string",
+                      "description": "The Apache Kafka record key"
+                    },
+                    "partition": {
+                      "name": "partition",
+                      "type": "integer",
+                      "description": "The Apache Kafka partition number to use when writing to or receiving from Apache Kafka"
+                    },
+                    "consumergroup": {
+                      "name": "consumergroup",
+                      "type": "string",
+                      "description": "The Apache Kafka consumer group name to use for consumers"
+                    },
+                    "headers": {
+                      "name": "headers",
+                      "type": "map",
+                      "description": "The Apache Kafka headers for publishers on this endpoint",
+                      "item": {
+                        "type": "string"
+                      }
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }
+              }
+            },
+            "NATS": {
+              "siblingattributes": {
+                "protocoloptions": {
+                  "name": "protocoloptions",
+                  "type": "object",
+                  "description": "Configuration information for this endpoint",
+                  "attributes": {
+                    "endpoints": {
+                      "name": "endpoints",
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "Network accessible location",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "name": "authorization",
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "item": {
+                        "type": "object",
+                        "attributes": {
+                          "type": {
+                            "name": "type",
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
+                            "clientrequired": true,
+                            "serverrequired": true
+                          },
+                          "resourceurl": {
+                            "name": "resourceurl",
+                            "type": "url",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "name": "authorityuri",
+                            "type": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "name": "granttypes",
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "item": {
+                              "type": "string"
+                            }
+                          },
+                          "*": {
+                            "name": "*",
+                            "type": "any"
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "name": "deployed",
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
+
+                    "subject": {
+                      "name": "subject",
+                      "type": "string",
+                      "description": "The NATS subject",
+                      "clientrequired": true,
+                      "serverrequired": true
+                    },
+                    "*": {
+                      "name": "*",
+                      "type": "any"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+
         "messagegroups": {
           "name": "messagegroups",
           "type": "array",

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -88,16 +88,6 @@
             },
             {
               "type": "string",
-              "name": "format",
-              "doc": "Endpoint metadata format identifier. If set, all definitions MUST use this format value"
-            },
-            {
-              "type": "string",
-              "name": "binding",
-              "doc": "Endpoint message binding identifier. If set, all definitions MUST use this binding value"
-            },
-            {
-              "type": "string",
               "name": "channel",
               "doc": "tbd"
             },
@@ -107,9 +97,93 @@
               "doc": "tbd"
             },
             {
-              "type": "GenericRecord",
-              "name": "config",
-              "doc": "Configuration information for this endpoint"
+              "name": "envelope",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "EnvelopeCloudevents10Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "envelopeoptions",
+                      "doc": "Envelope metadata constraints"
+                    }
+                  ]
+                }
+              ],
+              "doc": "Envelope metadata format identifier. If set, all definitions MUST use this format value"
+            },
+            {
+              "name": "protocol",
+              "type": [
+                {
+                  "type": "record",
+                  "name": "ProtocolAmqp10Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolMqtt50Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolMqtt311Type",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolHTTPType",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolKAFKAType",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                },
+                {
+                  "type": "record",
+                  "name": "ProtocolNATSType",
+                  "fields": [
+                    {
+                      "type": "GenericRecord",
+                      "name": "protocoloptions",
+                      "doc": "Configuration information for this endpoint"
+                    }
+                  ]
+                }
+              ],
+              "doc": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value"
             },
             {
               "type": {
@@ -215,16 +289,16 @@
                       "doc": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
                     },
                     {
-                      "name": "format",
+                      "name": "envelope",
                       "type": [
                         {
                           "type": "record",
-                          "name": "FormatNoneType",
+                          "name": "EnvelopeNoneType",
                           "fields": []
                         },
                         {
                           "type": "record",
-                          "name": "FormatCloudevents10Type",
+                          "name": "EnvelopeCloudevents10Type",
                           "fields": [
                             {
                               "type": {
@@ -264,99 +338,132 @@
                                   }
                                 ]
                               },
-                              "name": "metadata",
+                              "name": "envelopemetadata",
                               "doc": "CloudEvents metadata constraints"
+                            },
+                            {
+                              "type": "GenericRecord",
+                              "name": "envelopeoptions",
+                              "doc": "Envelope metadata constraints"
                             }
                           ]
                         }
                       ],
-                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+                      "doc": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
                     },
                     {
-                      "name": "binding",
+                      "name": "protocol",
                       "type": [
                         {
                           "type": "record",
-                          "name": "BindingNoneType",
+                          "name": "ProtocolNoneType",
                           "fields": []
                         },
                         {
                           "type": "record",
-                          "name": "BindingAmqp10Type",
+                          "name": "ProtocolAmqp10Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "AMQP message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingMqtt311Type",
+                          "name": "ProtocolMqtt311Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "MQTT message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingMqtt50Type",
+                          "name": "ProtocolMqtt50Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "MQTT message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingKAFKAType",
+                          "name": "ProtocolKAFKAType",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "The Apache Kafka message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingHTTPType",
+                          "name": "ProtocolHTTPType",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "The HTTP message metadata constraints"
                             }
                           ]
                         }
                       ],
-                      "doc": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+                      "doc": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
                     },
                     {
                       "type": "string",
                       "name": "schemaformat",
-                      "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+                      "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
                     },
                     {
-                      "type": "string",
+                      "type": "record",
                       "name": "schema",
+                      "fields": [
+                        {
+                          "name": "object",
+                          "type": {
+                            "type": "map",
+                            "values": [
+                              "null",
+                              "boolean",
+                              "int",
+                              "long",
+                              "float",
+                              "double",
+                              "bytes",
+                              "string",
+                              {
+                                "type": "array",
+                                "items": [
+                                  "null",
+                                  "boolean",
+                                  "int",
+                                  "long",
+                                  "float",
+                                  "double",
+                                  "bytes",
+                                  "string",
+                                  "GenericRecord"
+                                ]
+                              },
+                              "GenericRecord"
+                            ]
+                          }
+                        }
+                      ],
                       "doc": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
                     },
                     {
-                      "type": "GenericRecord",
-                      "name": "schemaobject",
-                      "doc": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry"
-                    },
-                    {
                       "type": "string",
-                      "name": "schemaurl",
-                      "doc": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+                      "name": "schemauri",
+                      "doc": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
                     }
                   ]
                 }

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -55,21 +55,16 @@
         },
         "schemaformat": {
           "type": "string",
-          "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+          "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
         },
         "schema": {
-          "type": "string",
+          "type": "object",
           "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
         },
-        "schemaobject": {
-          "type": "object",
-          "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry",
-          "properties": {}
-        },
-        "schemaurl": {
+        "schemauri": {
           "type": "string",
           "format": "uri",
-          "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+          "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
         }
       },
       "required": [
@@ -80,9 +75,9 @@
           "oneOf": [
             {
               "properties": {
-                "format": {
+                "envelope": {
                   "type": "string",
-                  "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "None"
                   ],
@@ -92,14 +87,14 @@
             },
             {
               "properties": {
-                "format": {
+                "envelope": {
                   "type": "string",
-                  "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "CloudEvents/1.0"
                   ]
                 },
-                "metadata": {
+                "envelopemetadata": {
                   "type": "object",
                   "description": "CloudEvents metadata constraints",
                   "properties": {
@@ -217,10 +212,24 @@
                       }
                     }
                   }
+                },
+                "envelopeoptions": {
+                  "type": "object",
+                  "description": "Envelope metadata constraints",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "description": "Whether CloudEvents 'binary' or 'structure' mode will be used"
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+                    }
+                  }
                 }
               },
               "required": [
-                "format"
+                "envelope"
               ]
             }
           ]
@@ -229,9 +238,9 @@
           "oneOf": [
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "None"
                   ],
@@ -241,14 +250,14 @@
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "AMQP/1.0"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "AMQP message metadata constraints",
                   "properties": {
@@ -529,19 +538,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "MQTT/3.1.1"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "MQTT message metadata constraints",
                   "properties": {
@@ -579,19 +588,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "MQTT/5.0"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "MQTT message metadata constraints",
                   "properties": {
@@ -686,19 +695,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "KAFKA"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "The Apache Kafka message metadata constraints",
                   "properties": {
@@ -739,19 +748,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "HTTP"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "The HTTP message metadata constraints",
                   "properties": {
@@ -789,7 +798,7 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             }
           ]
@@ -838,14 +847,6 @@
           "type": "string",
           "description": "Client's expected usage of this endpoint"
         },
-        "format": {
-          "type": "string",
-          "description": "Endpoint metadata format identifier. If set, all definitions MUST use this format value"
-        },
-        "binding": {
-          "type": "string",
-          "description": "Endpoint message binding identifier. If set, all definitions MUST use this binding value"
-        },
         "channel": {
           "type": "string",
           "description": "tbd"
@@ -876,73 +877,118 @@
             }
           }
         },
-        "config": {
+        "messagegroups": {
+          "type": "array",
+          "description": "The message groups that are supported by this endpoint",
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "messages": {
           "type": "object",
-          "description": "Configuration information for this endpoint",
-          "properties": {
-            "endpoints": {
-              "type": "array",
-              "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "uri": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "Network accessible location"
-                  }
-                }
-              }
-            },
-            "authorization": {
-              "type": "array",
-              "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
-                  },
-                  "resourceurl": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The resource uri for which authorization shall be granted (if applicable)"
-                  },
-                  "authorityuri": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "The authority uri where authorization shall be requested (if applicable)"
-                  },
-                  "granttypes": {
-                    "type": "array",
-                    "description": "The grant types that can be requested (if applicable)",
-                    "items": {
+          "additionalProperties": {
+            "$ref": "#/definitions/message"
+          }
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "envelope": {
+                  "type": "string",
+                  "description": "Envelope metadata format identifier. If set, all definitions MUST use this format value",
+                  "enum": [
+                    "CloudEvents/1.0"
+                  ]
+                },
+                "envelopeoptions": {
+                  "type": "object",
+                  "description": "Envelope metadata constraints",
+                  "properties": {
+                    "mode": {
+                      "type": "string"
+                    },
+                    "format": {
                       "type": "string"
                     }
                   }
                 }
-              }
-            },
-            "deployed": {
-              "type": "boolean",
-              "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+              },
+              "required": [
+                "envelope"
+              ]
             }
-          },
+          ]
+        },
+        {
           "oneOf": [
             {
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "AMQP/1.0"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "AMQP 1.0 connection options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "node": {
                       "type": "string",
                       "description": "The AMQP node name. Commonly the name of a queue or a topic"
@@ -980,15 +1026,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "MQTT/5.0"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "MQTT 5.0 connection options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "topic": {
                       "type": "string",
                       "description": "The MQTT topic path"
@@ -1025,15 +1119,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "MQTT/3.1.1"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "MQTT 3.1.1 connection options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "topic": {
                       "type": "string",
                       "description": "MQTT topic path"
@@ -1070,15 +1212,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "HTTP"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "HTTP options. These apply to all HTTP versions since the application model is the same across versions",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "method": {
                       "type": "string",
                       "description": "The HTTP method name"
@@ -1118,15 +1308,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "KAFKA"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "Apache Kafka options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "topic": {
                       "type": "string",
                       "description": "Apache Kafka topic name"
@@ -1165,15 +1403,63 @@
               "properties": {
                 "protocol": {
                   "type": "string",
-                  "description": "endpoint protocol identifier",
+                  "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
                   "enum": [
                     "NATS"
                   ]
                 },
-                "options": {
+                "protocoloptions": {
                   "type": "object",
-                  "description": "NATS options",
+                  "description": "Configuration information for this endpoint",
                   "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "Network accessible location"
+                          }
+                        }
+                      }
+                    },
+                    "authorization": {
+                      "type": "array",
+                      "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                          },
+                          "resourceurl": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The resource uri for which authorization shall be granted (if applicable)"
+                          },
+                          "authorityuri": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "The authority uri where authorization shall be requested (if applicable)"
+                          },
+                          "granttypes": {
+                            "type": "array",
+                            "description": "The grant types that can be requested (if applicable)",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "deployed": {
+                      "type": "boolean",
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                    },
                     "subject": {
                       "type": "string",
                       "description": "The NATS subject"
@@ -1186,24 +1472,7 @@
               ]
             }
           ]
-        },
-        "messagegroups": {
-          "type": "array",
-          "description": "The message groups that are supported by this endpoint",
-          "items": {
-            "type": "string",
-            "format": "uri"
-          }
-        },
-        "messages": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/message"
-          }
         }
-      },
-      "required": [
-        "id"
       ]
     }
   }

--- a/message/model.json
+++ b/message/model.json
@@ -7,15 +7,15 @@
       "singular": "messagegroup",
       "plural": "messagegroups",
       "attributes": {
-        "format": {
-          "name": "format",
+        "envelope": {
+          "name": "envelope",
           "type": "string",
-          "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+          "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted"
         },
-        "binding": {
-          "name": "binding",
+        "protocol": {
+          "name": "protocol",
           "type": "string",
-          "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted"
+          "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted"
         },
         "*": {
           "name": "*",
@@ -35,16 +35,16 @@
               "type": "uri",
               "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
             },
-            "format": {
-              "name": "format",
+            "envelope": {
+              "name": "envelope",
               "type": "string",
-              "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+              "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
               "ifvalues": {
                 "None": {},
                 "CloudEvents/1.0": {
                   "siblingattributes": {
-                    "metadata": {
-                      "name": "metadata",
+                    "envelopemetadata": {
+                      "name": "envelopemetadata",
                       "type": "object",
                       "description": "CloudEvents metadata constraints",
                       "attributes": {
@@ -206,21 +206,43 @@
                           }
                         }
                       }
+                    },
+                    "envelopeoptions": {
+                      "name": "envelopeoptions",
+                      "type": "object",
+                      "description": "Envelope metadata constraints",
+                      "attributes": {
+                        "mode": {
+                          "name": "mode",
+                          "type": "string",
+                          "enum": [ "binary", "structured" ],
+                          "description": "Whether CloudEvents 'binary' or 'structure' mode will be used"
+                        },
+                        "format": {
+                          "name": "format",
+                          "type": "string",
+                          "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+                        },
+                        "*": {
+                          "name": "*",
+                          "type": "any"
+                        }
+                      }
                     }
                   }
                 }
               }
             },
-            "binding": {
-              "name": "binding",
-              "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "protocol": {
+              "name": "protocol",
+              "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
               "type": "string",
               "ifvalues": {
                 "None": {},
                 "AMQP/1.0": {
                   "siblingattributes": {
-                    "message": {
-                      "name": "message",
+                    "protocoloptions": {
+                      "name": "protocoloptions",
                       "description": "AMQP message metadata constraints",
                       "type": "object",
                       "attributes": {
@@ -560,8 +582,8 @@
                 },
                 "MQTT/3.1.1": {
                   "siblingattributes": {
-                    "message": {
-                      "name": "message",
+                    "protocoloptions": {
+                      "name": "protocoloptions",
                       "description": "MQTT message metadata constraints",
                       "type": "object",
                       "attributes": {
@@ -607,8 +629,8 @@
                 },
                 "MQTT/5.0": {
                   "siblingattributes": {
-                    "message": {
-                      "name": "message",
+                    "protocoloptions": {
+                      "name": "protocoloptions",
                       "description": "MQTT message metadata constraints",
                       "type": "object",
                       "attributes": {
@@ -722,8 +744,8 @@
                 },
                 "KAFKA": {
                   "siblingattributes": {
-                    "message": {
-                      "name": "message",
+                    "protocoloptions": {
+                      "name": "protocoloptions",
                       "description": "The Apache Kafka message metadata constraints",
                       "type": "object",
                       "attributes": {
@@ -773,8 +795,8 @@
                 },
                 "HTTP": {
                   "siblingattributes": {
-                    "message": {
-                      "name": "message",
+                    "protocoloptions": {
+                      "name": "protocoloptions",
                       "description": "The HTTP message metadata constraints",
                       "type": "object",
                       "attributes": {
@@ -821,22 +843,17 @@
             },
             "schemaformat": {
               "name": "schemaformat",
-              "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry",
+              "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry",
               "type": "string"
             },
             "schema": {
               "name": "schema",
               "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry",
-              "type": "string"
+              "type": "any"
             },
-            "schemaobject": {
-              "name": "schemaobject",
-              "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry",
-              "type": "object"
-            },
-            "schemaurl": {
-              "name": "schemaurl",
-              "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry",
+            "schemauri": {
+              "name": "schemauri",
+              "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry",
               "type": "uri"
             }
           }

--- a/message/schemas/document-schema.avsc
+++ b/message/schemas/document-schema.avsc
@@ -83,13 +83,13 @@
             },
             {
               "type": "string",
-              "name": "format",
-              "doc": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+              "name": "envelope",
+              "doc": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted"
             },
             {
               "type": "string",
-              "name": "binding",
-              "doc": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted"
+              "name": "protocol",
+              "doc": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted"
             },
             {
               "name": "Extensions",
@@ -184,16 +184,16 @@
                       "doc": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
                     },
                     {
-                      "name": "format",
+                      "name": "envelope",
                       "type": [
                         {
                           "type": "record",
-                          "name": "FormatNoneType",
+                          "name": "EnvelopeNoneType",
                           "fields": []
                         },
                         {
                           "type": "record",
-                          "name": "FormatCloudevents10Type",
+                          "name": "EnvelopeCloudevents10Type",
                           "fields": [
                             {
                               "type": {
@@ -233,99 +233,132 @@
                                   }
                                 ]
                               },
-                              "name": "metadata",
+                              "name": "envelopemetadata",
                               "doc": "CloudEvents metadata constraints"
+                            },
+                            {
+                              "type": "GenericRecord",
+                              "name": "envelopeoptions",
+                              "doc": "Envelope metadata constraints"
                             }
                           ]
                         }
                       ],
-                      "doc": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+                      "doc": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
                     },
                     {
-                      "name": "binding",
+                      "name": "protocol",
                       "type": [
                         {
                           "type": "record",
-                          "name": "BindingNoneType",
+                          "name": "ProtocolNoneType",
                           "fields": []
                         },
                         {
                           "type": "record",
-                          "name": "BindingAmqp10Type",
+                          "name": "ProtocolAmqp10Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "AMQP message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingMqtt311Type",
+                          "name": "ProtocolMqtt311Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "MQTT message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingMqtt50Type",
+                          "name": "ProtocolMqtt50Type",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "MQTT message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingKAFKAType",
+                          "name": "ProtocolKAFKAType",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "The Apache Kafka message metadata constraints"
                             }
                           ]
                         },
                         {
                           "type": "record",
-                          "name": "BindingHTTPType",
+                          "name": "ProtocolHTTPType",
                           "fields": [
                             {
                               "type": "GenericRecord",
-                              "name": "message",
+                              "name": "protocoloptions",
                               "doc": "The HTTP message metadata constraints"
                             }
                           ]
                         }
                       ],
-                      "doc": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+                      "doc": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
                     },
                     {
                       "type": "string",
                       "name": "schemaformat",
-                      "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+                      "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
                     },
                     {
-                      "type": "string",
+                      "type": "record",
                       "name": "schema",
+                      "fields": [
+                        {
+                          "name": "object",
+                          "type": {
+                            "type": "map",
+                            "values": [
+                              "null",
+                              "boolean",
+                              "int",
+                              "long",
+                              "float",
+                              "double",
+                              "bytes",
+                              "string",
+                              {
+                                "type": "array",
+                                "items": [
+                                  "null",
+                                  "boolean",
+                                  "int",
+                                  "long",
+                                  "float",
+                                  "double",
+                                  "bytes",
+                                  "string",
+                                  "GenericRecord"
+                                ]
+                              },
+                              "GenericRecord"
+                            ]
+                          }
+                        }
+                      ],
                       "doc": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
                     },
                     {
-                      "type": "GenericRecord",
-                      "name": "schemaobject",
-                      "doc": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry"
-                    },
-                    {
                       "type": "string",
-                      "name": "schemaurl",
-                      "doc": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+                      "name": "schemauri",
+                      "doc": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
                     }
                   ]
                 }

--- a/message/schemas/document-schema.json
+++ b/message/schemas/document-schema.json
@@ -55,21 +55,16 @@
         },
         "schemaformat": {
           "type": "string",
-          "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+          "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
         },
         "schema": {
-          "type": "string",
+          "type": "object",
           "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
         },
-        "schemaobject": {
-          "type": "object",
-          "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry",
-          "properties": {}
-        },
-        "schemaurl": {
+        "schemauri": {
           "type": "string",
           "format": "uri",
-          "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+          "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
         }
       },
       "required": [
@@ -80,9 +75,9 @@
           "oneOf": [
             {
               "properties": {
-                "format": {
+                "envelope": {
                   "type": "string",
-                  "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "None"
                   ],
@@ -92,14 +87,14 @@
             },
             {
               "properties": {
-                "format": {
+                "envelope": {
                   "type": "string",
-                  "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "CloudEvents/1.0"
                   ]
                 },
-                "metadata": {
+                "envelopemetadata": {
                   "type": "object",
                   "description": "CloudEvents metadata constraints",
                   "properties": {
@@ -217,10 +212,24 @@
                       }
                     }
                   }
+                },
+                "envelopeoptions": {
+                  "type": "object",
+                  "description": "Envelope metadata constraints",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "description": "Whether CloudEvents 'binary' or 'structure' mode will be used"
+                    },
+                    "format": {
+                      "type": "string",
+                      "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+                    }
+                  }
                 }
               },
               "required": [
-                "format"
+                "envelope"
               ]
             }
           ]
@@ -229,9 +238,9 @@
           "oneOf": [
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "None"
                   ],
@@ -241,14 +250,14 @@
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "AMQP/1.0"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "AMQP message metadata constraints",
                   "properties": {
@@ -529,19 +538,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "MQTT/3.1.1"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "MQTT message metadata constraints",
                   "properties": {
@@ -579,19 +588,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "MQTT/5.0"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "MQTT message metadata constraints",
                   "properties": {
@@ -686,19 +695,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "KAFKA"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "The Apache Kafka message metadata constraints",
                   "properties": {
@@ -739,19 +748,19 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             },
             {
               "properties": {
-                "binding": {
+                "protocol": {
                   "type": "string",
-                  "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+                  "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
                   "enum": [
                     "HTTP"
                   ]
                 },
-                "message": {
+                "protocoloptions": {
                   "type": "object",
                   "description": "The HTTP message metadata constraints",
                   "properties": {
@@ -789,7 +798,7 @@
                 }
               },
               "required": [
-                "binding"
+                "protocol"
               ]
             }
           ]
@@ -834,13 +843,13 @@
           "type": "string",
           "format": "date-time"
         },
-        "format": {
+        "envelope": {
           "type": "string",
-          "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+          "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted"
         },
-        "binding": {
+        "protocol": {
           "type": "string",
-          "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted"
+          "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted"
         },
         "messages": {
           "type": "object",

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -1104,11 +1104,11 @@
           }
         }
       },
-      "format_None": {
+      "envelope_None": {
         "properties": {
-          "format": {
+          "envelope": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "None"
             ],
@@ -1116,16 +1116,16 @@
           }
         }
       },
-      "format_CloudEvents_1_0": {
+      "envelope_CloudEvents_1_0": {
         "properties": {
-          "format": {
+          "envelope": {
             "type": "string",
-            "description": "Message format identifier. This attribute MUST be the same as the 'format' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "CloudEvents/1.0"
             ]
           },
-          "metadata": {
+          "envelopemetadata": {
             "type": "object",
             "description": "CloudEvents metadata constraints",
             "properties": {
@@ -1243,17 +1243,31 @@
                 }
               }
             }
+          },
+          "envelopeoptions": {
+            "type": "object",
+            "description": "Envelope metadata constraints",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "description": "Whether CloudEvents 'binary' or 'structure' mode will be used"
+              },
+              "format": {
+                "type": "string",
+                "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+              }
+            }
           }
         },
         "required": [
-          "format"
+          "envelope"
         ]
       },
-      "binding_None": {
+      "protocol_None": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "None"
             ],
@@ -1261,16 +1275,16 @@
           }
         }
       },
-      "binding_AMQP_1_0": {
+      "protocol_AMQP_1_0": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "AMQP/1.0"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "AMQP message metadata constraints",
             "properties": {
@@ -1551,19 +1565,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_MQTT_3_1_1": {
+      "protocol_MQTT_3_1_1": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "MQTT/3.1.1"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "MQTT message metadata constraints",
             "properties": {
@@ -1601,19 +1615,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_MQTT_5_0": {
+      "protocol_MQTT_5_0": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "MQTT/5.0"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "MQTT message metadata constraints",
             "properties": {
@@ -1708,19 +1722,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_KAFKA": {
+      "protocol_KAFKA": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "KAFKA"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "The Apache Kafka message metadata constraints",
             "properties": {
@@ -1761,19 +1775,19 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
-      "binding_HTTP": {
+      "protocol_HTTP": {
         "properties": {
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier. This attribute MUST be the same as the 'binding' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups",
             "enum": [
               "HTTP"
             ]
           },
-          "message": {
+          "protocoloptions": {
             "type": "object",
             "description": "The HTTP message metadata constraints",
             "properties": {
@@ -1811,7 +1825,7 @@
           }
         },
         "required": [
-          "binding"
+          "protocol"
         ]
       },
       "message": {
@@ -1859,35 +1873,30 @@
           },
           "schemaformat": {
             "type": "string",
-            "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute attribute of the schema registry"
+            "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
           },
           "schema": {
-            "type": "string",
+            "type": "object",
             "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
           },
-          "schemaobject": {
-            "type": "object",
-            "description": "The inline schema object for the message payload, equivalent to the 'schemaobject' attribute of the schema registry",
-            "properties": {}
-          },
-          "schemaurl": {
+          "schemauri": {
             "type": "string",
             "format": "uri",
-            "description": "The URL of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+            "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
           }
         },
         "required": [
           "id"
         ],
         "discriminator": {
-          "propertyName": "binding",
+          "propertyName": "protocol",
           "mapping": {
-            "None": "#/components/schemas/binding_None",
-            "AMQP/1.0": "#/components/schemas/binding_AMQP_1_0",
-            "MQTT/3.1.1": "#/components/schemas/binding_MQTT_3_1_1",
-            "MQTT/5.0": "#/components/schemas/binding_MQTT_5_0",
-            "KAFKA": "#/components/schemas/binding_KAFKA",
-            "HTTP": "#/components/schemas/binding_HTTP"
+            "None": "#/components/schemas/protocol_None",
+            "AMQP/1.0": "#/components/schemas/protocol_AMQP_1_0",
+            "MQTT/3.1.1": "#/components/schemas/protocol_MQTT_3_1_1",
+            "MQTT/5.0": "#/components/schemas/protocol_MQTT_5_0",
+            "KAFKA": "#/components/schemas/protocol_KAFKA",
+            "HTTP": "#/components/schemas/protocol_HTTP"
           }
         }
       },
@@ -1929,13 +1938,13 @@
             "type": "string",
             "format": "date-time"
           },
-          "format": {
+          "envelope": {
             "type": "string",
-            "description": "Format identifier that defines the common metadata information for the message. All definitions in this group share this format. Mixed-format groups are not permitted"
+            "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted"
           },
-          "binding": {
+          "protocol": {
             "type": "string",
-            "description": "Binding identifier that defines the transport message binding. All definitions in this group share this binding type. Mixed-binding groups are not permitted"
+            "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted"
           },
           "messages": {
             "type": "object",

--- a/schema/model.json
+++ b/schema/model.json
@@ -23,9 +23,13 @@
             "format": {
               "name": "format",
               "type": "string",
-              "description": "Schema format identifier for this schema version",
-              "clientrequired": true,
-              "serverrequired": true
+              "description": "Schema format identifier for this schema version"
+            },
+            "validation": {
+              "name": "validation",
+              "type": "boolean",
+              "description": "Verify compliance with specified schema 'format'",
+              "location": "resource"
             },
             "*": {
               "name": "*",

--- a/schema/schemas/document-schema.avsc
+++ b/schema/schemas/document-schema.avsc
@@ -174,6 +174,11 @@
                       "doc": "Schema format identifier for this schema version"
                     },
                     {
+                      "type": "boolean",
+                      "name": "validation",
+                      "doc": "Verify compliance with specified schema 'format'"
+                    },
+                    {
                       "name": "Extensions",
                       "type": {
                         "type": "map",

--- a/schema/schemas/document-schema.json
+++ b/schema/schemas/document-schema.json
@@ -51,6 +51,10 @@
         "format": {
           "type": "string",
           "description": "Schema format identifier for this schema version"
+        },
+        "validation": {
+          "type": "boolean",
+          "description": "Verify compliance with specified schema 'format'"
         }
       },
       "oneOf": [

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -1145,6 +1145,10 @@
           "format": {
             "type": "string",
             "description": "Schema format identifier for this schema version"
+          },
+          "validation": {
+            "type": "boolean",
+            "description": "Verify compliance with specified schema 'format'"
           }
         },
         "oneOf": [

--- a/tools/dict
+++ b/tools/dict
@@ -7,6 +7,7 @@ apikey
 asyncapi
 attribs
 attributename
+attrs
 authorityuri
 avro
 avsc
@@ -54,6 +55,8 @@ endpointid
 endpointscount
 endpointsurl
 enum
+envelopemetadata
+envelopeoptions
 etag
 eventing
 filesystem
@@ -109,6 +112,7 @@ myendpoint
 myentity
 myevent
 mygroup
+mygroupid
 mygroups
 mykey
 mylinkproperty
@@ -118,6 +122,8 @@ myorg
 myproject
 myqueue
 myregistry
+myresourceid
+myresources
 myschema
 myschemas
 myspec
@@ -138,6 +144,8 @@ png
 pov
 producerrecord
 protobuf
+protocoloptions
+protocoloptionsendpoints
 ptr
 qos
 rawdata
@@ -163,6 +171,7 @@ schemaid
 schemaobject
 schemascount
 schemasurl
+schemauri
 schemaurl
 schemaversion
 serverless


### PR DESCRIPTION
- s/format/envelope/g    - e.g. CE
- add envelopeoptions
- add envelopemetadata
- s/binding/protocol/g   - e.g. HTTP
- s/message/protocoloptions/g
- allow $meta on Resources with hasdoc=false
- make "format" optional on Resources in schema spec
- add an optional "validation" attribute to Schema Resources
- clarify how filters + inlining work (only children of leaves can be added)
- require ?nested when child/nested collections are present on write ops
    
Fixes: #153
Fixes: #154
Fixes: #151
Fixes: #164
Fixes: #132
Fixes: #168
Fixes: #159