### PR TITLE
Updates for week of Oct 7

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -747,6 +747,10 @@
                       ]
                     },
                     {
+                      "type": "string",
+                      "name": "compatibility"
+                    },
+                    {
                       "type": "boolean",
                       "name": "validation",
                       "doc": "Verify compliance with specified schema 'format'"

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -1582,6 +1582,9 @@
           "type": "string",
           "format": "date-time"
         },
+        "compatibility": {
+          "type": "string"
+        },
         "validation": {
           "type": "boolean",
           "description": "Verify compliance with specified schema 'format'"

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -3587,6 +3587,9 @@
             "type": "string",
             "format": "date-time"
           },
+          "compatibility": {
+            "type": "string"
+          },
           "validation": {
             "type": "boolean",
             "description": "Verify compliance with specified schema 'format'"

--- a/core/sample-model.json
+++ b/core/sample-model.json
@@ -158,6 +158,13 @@
               "readonly": true,
               "location": "resource"
             },
+            "compatibility": {
+              "name": "compatibility",
+              "type": "string",
+              "enum": [ "none", "backward", "backward_transitive", "forward",
+                        "forward_transitive", "full", "full_transitive" ],
+              "location": "resource"
+            },
             "name": {
               "name": "name",
               "type": "string"
@@ -196,7 +203,7 @@
             "contenttype": {
               "name": "contenttype",
               "type": "string"
-            }
+            },
 
             "defaultversionsticky": {
               "name": "defaultversionsticky",

--- a/schema/model.json
+++ b/schema/model.json
@@ -20,6 +20,14 @@
           "plural": "schemas",
 
           "attributes": {
+            "compatibility": {
+              "name": "compatibility",
+              "type": "string",
+              "enum": [ "none", "backward", "backward_transitive", "forward",
+                        "forward_transitive", "full", "full_transitive" ],
+              "default": "backwards",
+              "location": "resource"
+            },
             "validation": {
               "name": "validation",
               "type": "boolean",

--- a/schema/schemas/document-schema.avsc
+++ b/schema/schemas/document-schema.avsc
@@ -169,6 +169,10 @@
                       ]
                     },
                     {
+                      "type": "string",
+                      "name": "compatibility"
+                    },
+                    {
                       "type": "boolean",
                       "name": "validation",
                       "doc": "Verify compliance with specified schema 'format'"

--- a/schema/schemas/document-schema.json
+++ b/schema/schemas/document-schema.json
@@ -48,6 +48,9 @@
           "type": "string",
           "format": "date-time"
         },
+        "compatibility": {
+          "type": "string"
+        },
         "validation": {
           "type": "boolean",
           "description": "Verify compliance with specified schema 'format'"

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -1142,6 +1142,9 @@
             "type": "string",
             "format": "date-time"
           },
+          "compatibility": {
+            "type": "string"
+          },
           "validation": {
             "type": "boolean",
             "description": "Verify compliance with specified schema 'format'"

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -135,10 +135,11 @@ is needed to decode the structured data from its serialized, binary form.
 We use the term **schema** (or schema Resource) in this specification as a
 logical grouping of **schema Versions**. A **schema Version** is a concrete
 document. The **schema** Resource is a semantic umbrella formed around one or
-more concrete schema Version documents. The semantic condition for **schema
-Versions** to coexist in the same **schema** is that any new schema Version
-MUST be backwards compatible with all previous versions of the same **schema**.
-Any breaking change MUST result in a new **schema** Resource.
+more concrete schema Version documents. Per the definition of the
+[`compatibility`](../core/spec.md#compatibility-attribute) attribute, all
+Versions of a single **schema** MUST adhere to the rules defined by the
+`compatibility` attribute. Any breaking change MUST result in a new **schema**
+being created.
 
 In "semantic Versioning" terms, you can think of a **schema** as a "major
 version" and the **schema Versions** as "minor versions".
@@ -242,26 +243,34 @@ The type of the resource is `schema`. Any single `schema` is a container for
 one or more `Versions`, which hold the concrete schema documents or schema
 document references.
 
-Any new schema Version that is added to a schema definition SHOULD be backwards
-compatible with all previous Versions of the schema, meaning that a consumer
-using the new schema would be able to understand data encoded using a prior
-Version of the schema. If a new Version introduces a breaking change, it SHOULD
-be registered as a new schema with a new name.
+All Versions of a schema MUST adhere to the semantic rules of the schema's
+`compatibility` attribute. This specification defines "compatibility" for
+schemas as follows; version B of a schema is said to be compatible with
+version A of a schema if all of the following are true:
+- Any document that adheres to the rules specified by schema A also adheres to
+  rules specified by schema B.
+- Any processing rules defined for schema A also apply for schema B.
+- Any processing rules defined for schema B, that are not defined for schema
+  A, do not conflict with the processing rules for schema A.
+
+Implementations of this specification MAY choose to support any of the
+[`compatibility`](../core/spec.md#compatibility-attribute) values defined in
+the core xRegistry specification.
 
 Implementations of this specification SHOULD use the xRegistry default
-algorithm for generating new `id` values and for determining which is the
-latest Version. See [Version IDs](../core/spec.md#version-ids) for more
+algorithm for generating new `versionid` values and for determining which is
+the latest Version. See [Version IDs](../core/spec.md#version-ids) for more
 information, but in summary it means:
-- `id`s are unsigned integers starting with `1`
+- `versionid`s are unsigned integers starting with `1`
 - They monotomically increase by `1` with each new Version
-- The latest is the Version with the lexically largest `id` value after all
-  Version's `id`s have been left-padded with spaces to the same length
+- The latest is the Version with the lexically largest `versionid` value after
+  all `versionid`s have been left-padded with spaces to the same length
 
 When semantic versioning is used in a solution, it is RECOMMENDED to include a
-major version identifier in the schema `id`, like `"com.example.event.v1"` or
+major version identifier in the `schemaid`, like `"com.example.event.v1"` or
 `"com.example.event.2024-02"`, so that incompatible, but historically related
 schemas can be more easily identified by users and developers. The schema
-Version `id` then functions as the semantic minor version identifier.
+`versionid` then functions as the semantic minor version identifier.
 
 The following extensions are defined for the `schema` Resource in addition to
 the core xRegistry Resource

--- a/tools/tabcheck
+++ b/tools/tabcheck
@@ -5,13 +5,12 @@ set -e
 for f in $* ; do
   echo Checking for tabs: $f
 
-  if grep -P '\t' $f > /dev/null ; then
-    echo "$f contains tabs" 
+  if grep -nP '\t' $f ; then
     exit 1
   fi
 
-  if grep "  *$" $f > /dev/null ; then 
-    echo "$f contains lines with extra spaces at the end" 
+  echo Checking for trailing spaces: $f
+  if grep -n "  *$" $f ; then
     exit 1
   fi
 


### PR DESCRIPTION
- minor wording tweak w.r.t. epoch value
- 'location' is only allowed to appear in the model for Resource attributes
- define a 'compatibility' attribute for Resources. Define just some abstract
  values that people MAY use. Domain specific specs will narrow/expand the list
  and define what each value means for their domain/docs.
- define what "compatibility" means for schemas and make "compatibility"
  default to "backward". Remove the requirement that all versions are backwards
  compatible.
- new code gen files
- show line numbers of offending lines in some of the spec checking tools

Fixes: https://github.com/xregistry/spec/issues/145
