### PR TITLE
Schema generator update for new identifier model

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -12,40 +12,46 @@
           "name": "EndpointType",
           "fields": [
             {
-              "name": "id",
-              "type": "string"
+              "name": "endpointid",
+              "type": "string",
+              "description": "ID of the endpoint object"
             },
             {
               "name": "name",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Name of the object"
             },
             {
               "name": "epoch",
               "type": [
                 "int",
                 "null"
-              ]
+              ],
+              "doc": "Epoch time of the object creation"
             },
             {
               "name": "self",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object"
             },
             {
               "name": "description",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Description of the object"
             },
             {
               "name": "documentation",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "URI of the documentation of the object"
             },
             {
               "name": "labels",
@@ -55,11 +61,13 @@
                   "string",
                   "null"
                 ]
-              }
+              },
+              "doc": "Labels for the object"
             },
             {
               "name": "origin",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object origin"
             },
             {
               "name": "createdat",
@@ -69,7 +77,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object creation"
             },
             {
               "name": "modifiedat",
@@ -79,7 +88,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object modification"
             },
             {
               "type": "string",
@@ -214,40 +224,46 @@
                   "name": "MessageType",
                   "fields": [
                     {
-                      "name": "id",
-                      "type": "string"
+                      "name": "messageid",
+                      "type": "string",
+                      "description": "ID of the message object"
                     },
                     {
                       "name": "name",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Name of the object"
                     },
                     {
                       "name": "epoch",
                       "type": [
                         "int",
                         "null"
-                      ]
+                      ],
+                      "doc": "Epoch time of the object creation"
                     },
                     {
                       "name": "self",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object"
                     },
                     {
                       "name": "description",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Description of the object"
                     },
                     {
                       "name": "documentation",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "URI of the documentation of the object"
                     },
                     {
                       "name": "labels",
@@ -257,11 +273,13 @@
                           "string",
                           "null"
                         ]
-                      }
+                      },
+                      "doc": "Labels for the object"
                     },
                     {
                       "name": "origin",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object origin"
                     },
                     {
                       "name": "createdat",
@@ -271,7 +289,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object creation"
                     },
                     {
                       "name": "modifiedat",
@@ -281,7 +300,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object modification"
                     },
                     {
                       "type": "string",
@@ -482,40 +502,46 @@
           "name": "MessagegroupType",
           "fields": [
             {
-              "name": "id",
-              "type": "string"
+              "name": "messagegroupid",
+              "type": "string",
+              "description": "ID of the messagegroup object"
             },
             {
               "name": "name",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Name of the object"
             },
             {
               "name": "epoch",
               "type": [
                 "int",
                 "null"
-              ]
+              ],
+              "doc": "Epoch time of the object creation"
             },
             {
               "name": "self",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object"
             },
             {
               "name": "description",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Description of the object"
             },
             {
               "name": "documentation",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "URI of the documentation of the object"
             },
             {
               "name": "labels",
@@ -525,11 +551,13 @@
                   "string",
                   "null"
                 ]
-              }
+              },
+              "doc": "Labels for the object"
             },
             {
               "name": "origin",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object origin"
             },
             {
               "name": "createdat",
@@ -539,7 +567,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object creation"
             },
             {
               "name": "modifiedat",
@@ -549,7 +578,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object modification"
             },
             {
               "type": "string",
@@ -590,40 +620,46 @@
           "name": "SchemagroupType",
           "fields": [
             {
-              "name": "id",
-              "type": "string"
+              "name": "schemagroupid",
+              "type": "string",
+              "description": "ID of the schemagroup object"
             },
             {
               "name": "name",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Name of the object"
             },
             {
               "name": "epoch",
               "type": [
                 "int",
                 "null"
-              ]
+              ],
+              "doc": "Epoch time of the object creation"
             },
             {
               "name": "self",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object"
             },
             {
               "name": "description",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Description of the object"
             },
             {
               "name": "documentation",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "URI of the documentation of the object"
             },
             {
               "name": "labels",
@@ -633,11 +669,13 @@
                   "string",
                   "null"
                 ]
-              }
+              },
+              "doc": "Labels for the object"
             },
             {
               "name": "origin",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object origin"
             },
             {
               "name": "createdat",
@@ -647,7 +685,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object creation"
             },
             {
               "name": "modifiedat",
@@ -657,7 +696,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object modification"
             },
             {
               "name": "Extensions",
@@ -677,40 +717,46 @@
                   "name": "SchemaType",
                   "fields": [
                     {
-                      "name": "id",
-                      "type": "string"
+                      "name": "schemaid",
+                      "type": "string",
+                      "description": "ID of the schema object"
                     },
                     {
                       "name": "name",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Name of the object"
                     },
                     {
                       "name": "epoch",
                       "type": [
                         "int",
                         "null"
-                      ]
+                      ],
+                      "doc": "Epoch time of the object creation"
                     },
                     {
                       "name": "self",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object"
                     },
                     {
                       "name": "description",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Description of the object"
                     },
                     {
                       "name": "documentation",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "URI of the documentation of the object"
                     },
                     {
                       "name": "labels",
@@ -720,11 +766,13 @@
                           "string",
                           "null"
                         ]
-                      }
+                      },
+                      "doc": "Labels for the object"
                     },
                     {
                       "name": "origin",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object origin"
                     },
                     {
                       "name": "createdat",
@@ -734,7 +782,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object creation"
                     },
                     {
                       "name": "modifiedat",
@@ -744,7 +793,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object modification"
                     },
                     {
                       "type": "boolean",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -25,40 +25,50 @@
     "message": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "messageid": {
+          "type": "string",
+          "description": "ID of the message object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "basemessageurl": {
           "type": "string",
@@ -79,9 +89,6 @@
           "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
         }
       },
-      "required": [
-        "id"
-      ],
       "allOf": [
         {
           "oneOf": [
@@ -820,40 +827,50 @@
     "endpoint": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "endpointid": {
+          "type": "string",
+          "description": "ID of the endpoint object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "usage": {
           "type": "string",
@@ -904,9 +921,6 @@
           }
         }
       },
-      "required": [
-        "id"
-      ],
       "allOf": [
         {
           "oneOf": [
@@ -1195,7 +1209,7 @@
                     "qos": {
                       "type": "integer",
                       "minimum": 0,
-                      "description": "The MQTT QoS level\u00f6. May be 0, 1, or 2"
+                      "description": "The MQTT QoS level\u00c3\u00b6. May be 0, 1, or 2"
                     },
                     "retain": {
                       "type": "boolean",
@@ -1490,40 +1504,50 @@
     "messagegroup": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "messagegroupid": {
+          "type": "string",
+          "description": "ID of the messagegroup object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "envelope": {
           "type": "string",
@@ -1539,48 +1563,59 @@
             "$ref": "#/definitions/message"
           }
         }
-      },
-      "required": [
-        "id"
-      ]
+      }
     },
     "schemaVersion": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "versionid": {
+          "type": "string",
+          "description": "ID of the schema version"
+        },
+        "schemaid": {
+          "type": "string",
+          "description": "ID of the schema object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "validation": {
           "type": "boolean",
@@ -1607,7 +1642,6 @@
             }
           },
           "required": [
-            "id",
             "schema"
           ]
         },
@@ -1620,7 +1654,6 @@
             }
           },
           "required": [
-            "id",
             "schemabase64"
           ]
         },
@@ -1633,7 +1666,6 @@
             }
           },
           "required": [
-            "id",
             "schemaurl"
           ]
         }
@@ -1642,40 +1674,50 @@
     "schema": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "schemaid": {
+          "type": "string",
+          "description": "ID of the schema object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         }
       },
       "oneOf": [
@@ -1689,7 +1731,6 @@
             }
           },
           "required": [
-            "id",
             "versionsurl"
           ]
         },
@@ -1703,7 +1744,6 @@
             }
           },
           "required": [
-            "id",
             "versions"
           ]
         }
@@ -1712,40 +1752,50 @@
     "schemagroup": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "schemagroupid": {
+          "type": "string",
+          "description": "ID of the schemagroup object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "schemas": {
           "type": "object",
@@ -1753,10 +1803,7 @@
             "$ref": "#/definitions/schema"
           }
         }
-      },
-      "required": [
-        "id"
-      ]
+      }
     }
   }
 }

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -3249,40 +3249,50 @@
       "message": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "messageid": {
+            "type": "string",
+            "description": "ID of the message object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "basemessageurl": {
             "type": "string",
@@ -3303,9 +3313,6 @@
             "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
           }
         },
-        "required": [
-          "id"
-        ],
         "discriminator": {
           "propertyName": "protocol",
           "mapping": {
@@ -3393,40 +3400,50 @@
       "endpoint": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "endpointid": {
+            "type": "string",
+            "description": "ID of the endpoint object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "usage": {
             "type": "string",
@@ -3477,9 +3494,6 @@
             }
           }
         },
-        "required": [
-          "id"
-        ],
         "discriminator": {
           "propertyName": "protocol",
           "mapping": {
@@ -3495,40 +3509,50 @@
       "messagegroup": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "messagegroupid": {
+            "type": "string",
+            "description": "ID of the messagegroup object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "envelope": {
             "type": "string",
@@ -3544,48 +3568,59 @@
               "$ref": "#/components/schemas/message"
             }
           }
-        },
-        "required": [
-          "id"
-        ]
+        }
       },
       "schemaVersion": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "versionid": {
+            "type": "string",
+            "description": "ID of the schema version"
+          },
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "validation": {
             "type": "boolean",
@@ -3612,7 +3647,6 @@
               }
             },
             "required": [
-              "id",
               "schema"
             ]
           },
@@ -3625,7 +3659,6 @@
               }
             },
             "required": [
-              "id",
               "schemabase64"
             ]
           },
@@ -3638,7 +3671,6 @@
               }
             },
             "required": [
-              "id",
               "schemaurl"
             ]
           }
@@ -3647,40 +3679,50 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           }
         },
         "oneOf": [
@@ -3694,7 +3736,6 @@
               }
             },
             "required": [
-              "id",
               "versionsurl"
             ]
           },
@@ -3708,7 +3749,6 @@
               }
             },
             "required": [
-              "id",
               "versions"
             ]
           }
@@ -3717,40 +3757,50 @@
       "schemagroup": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "schemagroupid": {
+            "type": "string",
+            "description": "ID of the schemagroup object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "schemas": {
             "type": "object",
@@ -3758,10 +3808,7 @@
               "$ref": "#/components/schemas/schema"
             }
           }
-        },
-        "required": [
-          "id"
-        ]
+        }
       }
     }
   }

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -12,40 +12,46 @@
           "name": "EndpointType",
           "fields": [
             {
-              "name": "id",
-              "type": "string"
+              "name": "endpointid",
+              "type": "string",
+              "description": "ID of the endpoint object"
             },
             {
               "name": "name",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Name of the object"
             },
             {
               "name": "epoch",
               "type": [
                 "int",
                 "null"
-              ]
+              ],
+              "doc": "Epoch time of the object creation"
             },
             {
               "name": "self",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object"
             },
             {
               "name": "description",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Description of the object"
             },
             {
               "name": "documentation",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "URI of the documentation of the object"
             },
             {
               "name": "labels",
@@ -55,11 +61,13 @@
                   "string",
                   "null"
                 ]
-              }
+              },
+              "doc": "Labels for the object"
             },
             {
               "name": "origin",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object origin"
             },
             {
               "name": "createdat",
@@ -69,7 +77,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object creation"
             },
             {
               "name": "modifiedat",
@@ -79,7 +88,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object modification"
             },
             {
               "type": "string",
@@ -214,40 +224,46 @@
                   "name": "MessageType",
                   "fields": [
                     {
-                      "name": "id",
-                      "type": "string"
+                      "name": "messageid",
+                      "type": "string",
+                      "description": "ID of the message object"
                     },
                     {
                       "name": "name",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Name of the object"
                     },
                     {
                       "name": "epoch",
                       "type": [
                         "int",
                         "null"
-                      ]
+                      ],
+                      "doc": "Epoch time of the object creation"
                     },
                     {
                       "name": "self",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object"
                     },
                     {
                       "name": "description",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Description of the object"
                     },
                     {
                       "name": "documentation",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "URI of the documentation of the object"
                     },
                     {
                       "name": "labels",
@@ -257,11 +273,13 @@
                           "string",
                           "null"
                         ]
-                      }
+                      },
+                      "doc": "Labels for the object"
                     },
                     {
                       "name": "origin",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object origin"
                     },
                     {
                       "name": "createdat",
@@ -271,7 +289,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object creation"
                     },
                     {
                       "name": "modifiedat",
@@ -281,7 +300,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object modification"
                     },
                     {
                       "type": "string",

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -13,40 +13,50 @@
     "message": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "messageid": {
+          "type": "string",
+          "description": "ID of the message object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "basemessageurl": {
           "type": "string",
@@ -67,9 +77,6 @@
           "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
         }
       },
-      "required": [
-        "id"
-      ],
       "allOf": [
         {
           "oneOf": [
@@ -808,40 +815,50 @@
     "endpoint": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "endpointid": {
+          "type": "string",
+          "description": "ID of the endpoint object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "usage": {
           "type": "string",
@@ -892,9 +909,6 @@
           }
         }
       },
-      "required": [
-        "id"
-      ],
       "allOf": [
         {
           "oneOf": [
@@ -1183,7 +1197,7 @@
                     "qos": {
                       "type": "integer",
                       "minimum": 0,
-                      "description": "The MQTT QoS level\u00f6. May be 0, 1, or 2"
+                      "description": "The MQTT QoS level\u00c3\u00b6. May be 0, 1, or 2"
                     },
                     "retain": {
                       "type": "boolean",

--- a/message/schemas/document-schema.avsc
+++ b/message/schemas/document-schema.avsc
@@ -12,40 +12,46 @@
           "name": "MessagegroupType",
           "fields": [
             {
-              "name": "id",
-              "type": "string"
+              "name": "messagegroupid",
+              "type": "string",
+              "description": "ID of the messagegroup object"
             },
             {
               "name": "name",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Name of the object"
             },
             {
               "name": "epoch",
               "type": [
                 "int",
                 "null"
-              ]
+              ],
+              "doc": "Epoch time of the object creation"
             },
             {
               "name": "self",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object"
             },
             {
               "name": "description",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Description of the object"
             },
             {
               "name": "documentation",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "URI of the documentation of the object"
             },
             {
               "name": "labels",
@@ -55,11 +61,13 @@
                   "string",
                   "null"
                 ]
-              }
+              },
+              "doc": "Labels for the object"
             },
             {
               "name": "origin",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object origin"
             },
             {
               "name": "createdat",
@@ -69,7 +77,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object creation"
             },
             {
               "name": "modifiedat",
@@ -79,7 +88,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object modification"
             },
             {
               "type": "string",
@@ -109,40 +119,46 @@
                   "name": "MessageType",
                   "fields": [
                     {
-                      "name": "id",
-                      "type": "string"
+                      "name": "messageid",
+                      "type": "string",
+                      "description": "ID of the message object"
                     },
                     {
                       "name": "name",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Name of the object"
                     },
                     {
                       "name": "epoch",
                       "type": [
                         "int",
                         "null"
-                      ]
+                      ],
+                      "doc": "Epoch time of the object creation"
                     },
                     {
                       "name": "self",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object"
                     },
                     {
                       "name": "description",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Description of the object"
                     },
                     {
                       "name": "documentation",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "URI of the documentation of the object"
                     },
                     {
                       "name": "labels",
@@ -152,11 +168,13 @@
                           "string",
                           "null"
                         ]
-                      }
+                      },
+                      "doc": "Labels for the object"
                     },
                     {
                       "name": "origin",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object origin"
                     },
                     {
                       "name": "createdat",
@@ -166,7 +184,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object creation"
                     },
                     {
                       "name": "modifiedat",
@@ -176,7 +195,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object modification"
                     },
                     {
                       "type": "string",

--- a/message/schemas/document-schema.json
+++ b/message/schemas/document-schema.json
@@ -13,40 +13,50 @@
     "message": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "messageid": {
+          "type": "string",
+          "description": "ID of the message object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "basemessageurl": {
           "type": "string",
@@ -67,9 +77,6 @@
           "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
         }
       },
-      "required": [
-        "id"
-      ],
       "allOf": [
         {
           "oneOf": [
@@ -808,40 +815,50 @@
     "messagegroup": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "messagegroupid": {
+          "type": "string",
+          "description": "ID of the messagegroup object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "envelope": {
           "type": "string",
@@ -857,10 +874,7 @@
             "$ref": "#/definitions/message"
           }
         }
-      },
-      "required": [
-        "id"
-      ]
+      }
     }
   }
 }

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -1831,40 +1831,50 @@
       "message": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "messageid": {
+            "type": "string",
+            "description": "ID of the message object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "basemessageurl": {
             "type": "string",
@@ -1885,9 +1895,6 @@
             "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
           }
         },
-        "required": [
-          "id"
-        ],
         "discriminator": {
           "propertyName": "protocol",
           "mapping": {
@@ -1903,40 +1910,50 @@
       "messagegroup": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "messagegroupid": {
+            "type": "string",
+            "description": "ID of the messagegroup object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "envelope": {
             "type": "string",
@@ -1952,10 +1969,7 @@
               "$ref": "#/components/schemas/message"
             }
           }
-        },
-        "required": [
-          "id"
-        ]
+        }
       }
     }
   }

--- a/schema/schemas/document-schema.avsc
+++ b/schema/schemas/document-schema.avsc
@@ -12,40 +12,46 @@
           "name": "SchemagroupType",
           "fields": [
             {
-              "name": "id",
-              "type": "string"
+              "name": "schemagroupid",
+              "type": "string",
+              "description": "ID of the schemagroup object"
             },
             {
               "name": "name",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Name of the object"
             },
             {
               "name": "epoch",
               "type": [
                 "int",
                 "null"
-              ]
+              ],
+              "doc": "Epoch time of the object creation"
             },
             {
               "name": "self",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object"
             },
             {
               "name": "description",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "Description of the object"
             },
             {
               "name": "documentation",
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "doc": "URI of the documentation of the object"
             },
             {
               "name": "labels",
@@ -55,11 +61,13 @@
                   "string",
                   "null"
                 ]
-              }
+              },
+              "doc": "Labels for the object"
             },
             {
               "name": "origin",
-              "type": "string"
+              "type": "string",
+              "doc": "URI of the object origin"
             },
             {
               "name": "createdat",
@@ -69,7 +77,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object creation"
             },
             {
               "name": "modifiedat",
@@ -79,7 +88,8 @@
                   "logicalType": "time-millis"
                 },
                 "null"
-              ]
+              ],
+              "doc": "Time of the object modification"
             },
             {
               "name": "Extensions",
@@ -99,40 +109,46 @@
                   "name": "SchemaType",
                   "fields": [
                     {
-                      "name": "id",
-                      "type": "string"
+                      "name": "schemaid",
+                      "type": "string",
+                      "description": "ID of the schema object"
                     },
                     {
                       "name": "name",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Name of the object"
                     },
                     {
                       "name": "epoch",
                       "type": [
                         "int",
                         "null"
-                      ]
+                      ],
+                      "doc": "Epoch time of the object creation"
                     },
                     {
                       "name": "self",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object"
                     },
                     {
                       "name": "description",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "Description of the object"
                     },
                     {
                       "name": "documentation",
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "doc": "URI of the documentation of the object"
                     },
                     {
                       "name": "labels",
@@ -142,11 +158,13 @@
                           "string",
                           "null"
                         ]
-                      }
+                      },
+                      "doc": "Labels for the object"
                     },
                     {
                       "name": "origin",
-                      "type": "string"
+                      "type": "string",
+                      "doc": "URI of the object origin"
                     },
                     {
                       "name": "createdat",
@@ -156,7 +174,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object creation"
                     },
                     {
                       "name": "modifiedat",
@@ -166,7 +185,8 @@
                           "logicalType": "time-millis"
                         },
                         "null"
-                      ]
+                      ],
+                      "doc": "Time of the object modification"
                     },
                     {
                       "type": "boolean",

--- a/schema/schemas/document-schema.json
+++ b/schema/schemas/document-schema.json
@@ -13,40 +13,54 @@
     "schemaVersion": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "versionid": {
+          "type": "string",
+          "description": "ID of the schema version"
+        },
+        "schemaid": {
+          "type": "string",
+          "description": "ID of the schema object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "validation": {
           "type": "boolean",
@@ -73,7 +87,6 @@
             }
           },
           "required": [
-            "id",
             "schema"
           ]
         },
@@ -86,7 +99,6 @@
             }
           },
           "required": [
-            "id",
             "schemabase64"
           ]
         },
@@ -99,7 +111,6 @@
             }
           },
           "required": [
-            "id",
             "schemaurl"
           ]
         }
@@ -108,40 +119,50 @@
     "schema": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "schemaid": {
+          "type": "string",
+          "description": "ID of the schema object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         }
       },
       "oneOf": [
@@ -155,7 +176,6 @@
             }
           },
           "required": [
-            "id",
             "versionsurl"
           ]
         },
@@ -169,7 +189,6 @@
             }
           },
           "required": [
-            "id",
             "versions"
           ]
         }
@@ -178,40 +197,50 @@
     "schemagroup": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
+        "schemagroupid": {
+          "type": "string",
+          "description": "ID of the schemagroup object"
         },
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the object"
         },
         "epoch": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Epoch time of the object creation"
         },
         "self": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Description of the object"
         },
         "documentation": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the documentation of the object"
         },
         "labels": {
-          "type": "object"
+          "type": "object",
+          "description": "Labels for the object"
         },
         "origin": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "URI of the object origin"
         },
         "createdat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object creation"
         },
         "modifiedat": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "description": "Time of the object modification"
         },
         "schemas": {
           "type": "object",
@@ -219,10 +248,7 @@
             "$ref": "#/definitions/schema"
           }
         }
-      },
-      "required": [
-        "id"
-      ]
+      }
     }
   }
 }

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -1107,40 +1107,54 @@
       "schemaVersion": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "versionid": {
+            "type": "string",
+            "description": "ID of the schema version"
+          },
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "validation": {
             "type": "boolean",
@@ -1167,7 +1181,6 @@
               }
             },
             "required": [
-              "id",
               "schema"
             ]
           },
@@ -1180,7 +1193,6 @@
               }
             },
             "required": [
-              "id",
               "schemabase64"
             ]
           },
@@ -1193,7 +1205,6 @@
               }
             },
             "required": [
-              "id",
               "schemaurl"
             ]
           }
@@ -1202,40 +1213,50 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           }
         },
         "oneOf": [
@@ -1249,7 +1270,6 @@
               }
             },
             "required": [
-              "id",
               "versionsurl"
             ]
           },
@@ -1263,7 +1283,6 @@
               }
             },
             "required": [
-              "id",
               "versions"
             ]
           }
@@ -1272,40 +1291,50 @@
       "schemagroup": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
+          "schemagroupid": {
+            "type": "string",
+            "description": "ID of the schemagroup object"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Name of the object"
           },
           "epoch": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Epoch time of the object creation"
           },
           "self": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object"
           },
           "description": {
-            "type": "string"
+            "type": "string",
+            "description": "Description of the object"
           },
           "documentation": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the documentation of the object"
           },
           "labels": {
-            "type": "object"
+            "type": "object",
+            "description": "Labels for the object"
           },
           "origin": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "URI of the object origin"
           },
           "createdat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object creation"
           },
           "modifiedat": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Time of the object modification"
           },
           "schemas": {
             "type": "object",
@@ -1313,10 +1342,7 @@
               "$ref": "#/components/schemas/schema"
             }
           }
-        },
-        "required": [
-          "id"
-        ]
+        }
       }
     }
   }

--- a/tools/schema-generator.py
+++ b/tools/schema-generator.py
@@ -445,7 +445,7 @@ def generate_json_schema(model_definition, for_openapi=False) -> dict:
             props.update(copy.deepcopy(json_common_attributes))
             
             if resource.get("hasdocument", True):
-                 resource_schema = {
+                resource_schema = {
                     "type": "object",
                     "properties": props,
                     "oneOf": [


### PR DESCRIPTION
Signed-off-by: Clemens Vasters <clemens@vasters.com>

Fixes #

Changes the identifier model to RESOURCEid and GROUPid

**Release Note**

```release-note
This change implements the revision of the "id" model where all ids of groups and resources are
prefixed with the singular group or resource name, e.g. "schemaid" for the schema resource. The
ids are also no longer required in the document representation since they can be inferred from
the containing dictionary entry keys.
```
