### PR TITLE
Changes for week of Oct 21

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -748,15 +748,6 @@
                     },
                     {
                       "type": "string",
-                      "name": "compatibility"
-                    },
-                    {
-                      "type": "boolean",
-                      "name": "validation",
-                      "doc": "Verify compliance with specified schema 'format'"
-                    },
-                    {
-                      "type": "string",
                       "name": "format",
                       "doc": "Schema format identifier for this schema version"
                     },

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -1582,13 +1582,6 @@
           "type": "string",
           "format": "date-time"
         },
-        "compatibility": {
-          "type": "string"
-        },
-        "validation": {
-          "type": "boolean",
-          "description": "Verify compliance with specified schema 'format'"
-        },
         "format": {
           "type": "string",
           "description": "Schema format identifier for this schema version"

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -3587,13 +3587,6 @@
             "type": "string",
             "format": "date-time"
           },
-          "compatibility": {
-            "type": "string"
-          },
-          "validation": {
-            "type": "boolean",
-            "description": "Verify compliance with specified schema 'format'"
-          },
           "format": {
             "type": "string",
             "description": "Schema format identifier for this schema version"

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -132,9 +132,10 @@ schema for its payload.
       "messages": {
         "com.example.telemetry": {
           "messageid": "com.example.telemetry",
+          "versionid": "1.0",
           "self": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry",
           "epoch": 5,
-
+          "isdefault": true,
           "description": "device telemetry event",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
@@ -164,9 +165,7 @@ schema for its payload.
           "schemaformat": "Protobuf/3.0",
           "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; } }"
 
-          "defaultversionid": "1.0",
-          "defaultversionurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/versions/1.0",
-
+          "metaurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/meta",
           "versionsurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/versions",
           "versionscount": 1
         }
@@ -235,10 +234,10 @@ scenarios:
       "messages": {
         "com.example.telemetry": {
           "messageid": "com.example.telemetry",
+          "versionid": "1.0",
           "self": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry",
           "epoch": 5,
-          "description": "device telemetry event",
-
+          "isdefault": true,
           "description": "device telemetry event",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
@@ -268,9 +267,7 @@ scenarios:
           "schemaformat": "Protobuf/3.0",
           "schemaurl": "#/schemagroups/com.example.telemetry/schema/com.example.telemetrydata/versions/1.0"
 
-          "defaultversionid": "1.0",
-          "defaultversionurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/versions/1.0",
-
+          "metaurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/meta",
           "versionsurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/versions",
           "versionscount": 1
         }
@@ -291,9 +288,10 @@ scenarios:
       "schemas": {
         "com.example.telemetrydata": {
           "schemaid": "com.example.telemetrydata",
+          "versionid": "1.0",
           "self": "https://example.com/schemagroups/com.example.telemetry/schemas",
           "epoch": 5,
-
+          "isdefault": true,
           "description": "device telemetry event data",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
@@ -301,27 +299,9 @@ scenarios:
           "format": "Protobuf/3.0",
           "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; }"
 
-          "defaultversionid": "1.0",
-          "defaultversionurl": "https://example.com/schemagroups/com.example.telemetry/schemas/versions/1.0",
-
+          "metaurl": "https://example.com/schemagroups/com.example.telemetry/schemas/meta",
           "versionscount": 1,
-          "versionsurl": "https://example.com/schemagroups/com.example.telemetry/schemas/versions",
-          "versions": {
-            "1.0": {
-              "resourceid": "com.example.telemetrydata",
-              "versionid": "1.0",
-              "self": "https://example.com/schemagroups/com.example.telemetry/schemas/versions/1.0",
-              "epoch": 5,
-
-              "isdefault": true,
-              "description": "device telemetry event data",
-              "createdat": "2024-04-30T12:00:00Z",
-              "modifiedat": "2024-04-31T12:00:00Z",
-
-              "format": "Protobuf/3.0",
-              "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; }"
-            }
-          }
+          "versionsurl": "https://example.com/schemagroups/com.example.telemetry/schemas/versions"
         }
       }
     }

--- a/core/sample-model.json
+++ b/core/sample-model.json
@@ -84,6 +84,10 @@
           "name": "name",
           "type": "string"
         },
+        "isdefault": {
+          "name": "isdefault",
+          "type": "boolean"
+        },
         "description": {
           "name": "description",
           "type": "string"
@@ -125,8 +129,7 @@
               "name": "sample_resourceid",
               "type": "string",
               "immutable": true,
-              "serverrequired": true,
-              "location": "resource"
+              "serverrequired": true
             },
             "versionid": {
               "name": "versionid",
@@ -138,32 +141,12 @@
               "name": "self",
               "type": "url",
               "readonly": true,
-              "serverrequired": true,
-              "location": "both"
-            },
-            "xref": {
-              "name": "xref",
-              "type": "url",
-              "location": "resource"
+              "serverrequired": true
             },
             "epoch": {
               "name": "epoch",
               "type": "uinteger",
-              "serverrequired": true,
-              "location": "resource"
-            },
-            "readonly": {
-              "name": "readonly",
-              "type": "boolean",
-              "readonly": true,
-              "location": "resource"
-            },
-            "compatibility": {
-              "name": "compatibility",
-              "type": "string",
-              "enum": [ "none", "backward", "backward_transitive", "forward",
-                        "forward_transitive", "full", "full_transitive" ],
-              "location": "resource"
+              "serverrequired": true
             },
             "name": {
               "name": "name",
@@ -203,26 +186,56 @@
             "contenttype": {
               "name": "contenttype",
               "type": "string"
+            }
+          },
+          "metaattributes": {
+            "sample_resourceid": {
+              "name": "sample_resourceid",
+              "type": "string",
+              "immutable": true,
+              "serverrequired": true
             },
-
+            "self": {
+              "name": "self",
+              "type": "url",
+              "readonly": true,
+              "serverrequired": true
+            },
+            "xref": {
+              "name": "xref",
+              "type": "url"
+            },
+            "epoch": {
+              "name": "epoch",
+              "type": "uinteger",
+              "serverrequired": true
+            },
+            "readonly": {
+              "name": "readonly",
+              "type": "boolean",
+              "readonly": true
+            },
+            "compatibility": {
+              "name": "compatibility",
+              "type": "string",
+              "enum": [ "none", "backward", "backward_transitive", "forward",
+                        "forward_transitive", "full", "full_transitive" ]
+            },
             "defaultversionsticky": {
               "name": "defaultversionsticky",
               "type": "boolean",
-              "serverrequired": true,
-              "location": "resource"
+              "serverrequired": true
             },
             "defaultversionid": {
               "name": "defaultversionid",
               "type": "string",
-              "serverrequired": true,
-              "location": "resource"
+              "serverrequired": true
             },
             "defaultversionurl": {
               "name": "defaultversionurl",
               "type": "url",
               "readonly": true,
-              "serverrequired": true,
-              "location": "resource"
+              "serverrequired": true
             }
           }
         }

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -3,7 +3,7 @@
 <!-- no verify-links -->
 
 xRegistry is a specification for describing event data in common formats.
-As a textual specification, language barriers MAY slow down the progress of 
+As a textual specification, language barriers MAY slow down the progress of
 understanding CloudEvents for some people.
 Thus, we welcome anyone to
 [translate](../languages/languages-spec.md) the xRegistry specifications into

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -210,7 +210,7 @@
                       "type": "any"
                     }
                   }
-                }  
+                }
               }
             },
             "MQTT/5.0": {
@@ -767,7 +767,7 @@
           "item" : {
             "type": "uri"
           }
-        },          
+        },
         "*": {
           "name": "*",
           "type": "any"
@@ -776,7 +776,7 @@
       "resources": {
         "messages": {
           "$include": "../message/model.json#/groups/messagegroups/resources/messages"
-        }        
+        }
       }
     }
   }

--- a/message/spec.md
+++ b/message/spec.md
@@ -67,11 +67,9 @@ this form:
       "messages" : {
         "KEY": {                               # messageid
           "messageid": "STRING",               # xRegistry core attributes
+          "versionid": "STRING",
           "self": "URL",
-          "xref": "URL", ?
           "epoch": UINTEGER,
-          "readonly": BOOLEAN, ?
-
           "name": "STRING", ?
           "description": "STRING", ?
           "documentation": "URL", ?
@@ -104,10 +102,8 @@ this form:
           "schema": ANY, ?
           "schemauri": "URI", ?
 
-          "defaultversionsticky": BOOLEAN, ?
-          "defaultversionid": "STRING",
-          "defaultversionurl": "URL",
-
+          "metaurl": "URL",
+          "meta": { ... }, ?
           "versionsurl": "URL",
           "versionscount": UINTEGER,
           "versions": { ... } ?

--- a/schema/model.json
+++ b/schema/model.json
@@ -20,20 +20,6 @@
           "plural": "schemas",
 
           "attributes": {
-            "compatibility": {
-              "name": "compatibility",
-              "type": "string",
-              "enum": [ "none", "backward", "backward_transitive", "forward",
-                        "forward_transitive", "full", "full_transitive" ],
-              "default": "backwards",
-              "location": "resource"
-            },
-            "validation": {
-              "name": "validation",
-              "type": "boolean",
-              "description": "Verify compliance with specified schema 'format'",
-              "location": "resource"
-            },
             "format": {
               "name": "format",
               "type": "string",
@@ -42,6 +28,20 @@
             "*": {
               "name": "*",
               "type": "any"
+            }
+          },
+          "metaattributes": {
+            "compatibility": {
+              "name": "compatibility",
+              "type": "string",
+              "enum": [ "none", "backward", "backward_transitive", "forward",
+                        "forward_transitive", "full", "full_transitive" ],
+              "default": "backward"
+            },
+            "validation": {
+              "name": "validation",
+              "type": "boolean",
+              "description": "Verify compliance with specified schema 'format'"
             }
           }
         }

--- a/schema/schemas/document-schema.avsc
+++ b/schema/schemas/document-schema.avsc
@@ -170,15 +170,6 @@
                     },
                     {
                       "type": "string",
-                      "name": "compatibility"
-                    },
-                    {
-                      "type": "boolean",
-                      "name": "validation",
-                      "doc": "Verify compliance with specified schema 'format'"
-                    },
-                    {
-                      "type": "string",
                       "name": "format",
                       "doc": "Schema format identifier for this schema version"
                     },

--- a/schema/schemas/document-schema.json
+++ b/schema/schemas/document-schema.json
@@ -48,13 +48,6 @@
           "type": "string",
           "format": "date-time"
         },
-        "compatibility": {
-          "type": "string"
-        },
-        "validation": {
-          "type": "boolean",
-          "description": "Verify compliance with specified schema 'format'"
-        },
         "format": {
           "type": "string",
           "description": "Schema format identifier for this schema version"

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -1142,13 +1142,6 @@
             "type": "string",
             "format": "date-time"
           },
-          "compatibility": {
-            "type": "string"
-          },
-          "validation": {
-            "type": "boolean",
-            "description": "Verify compliance with specified schema 'format'"
-          },
           "format": {
             "type": "string",
             "description": "Schema format identifier for this schema version"

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -59,13 +59,9 @@ this form:
       "schemas": {
         "KEY": {                                   # schemaid
           "schemaid": "STRING",                    # xRegistry core attributes
+          "versionid": "STRING",
           "self": "URL",
-          "xreg": "URL", ?
           "epoch": UINTEGER,
-          "readonly": BOOLEAN, ?
-
-          "validation": BOOLEAN, ?                 # Resource level attrs
-
           "name": "STRING", ?                      # Version level attrs
           "description": "STRING", ?
           "documentation": "URL", ?
@@ -80,9 +76,11 @@ this form:
           "schema": ANY ?
           "schemabase64": "STRING", ?
 
-          "defaultversionsticky": BOOLEAN, ?       # Res level Ver-related attrs
-          "defaultversionid": "STRING",
-          "defaultversionurl": "URL",
+          "metaurl": "URL",                        # Resource level attrs
+          "meta": {
+            ... core spec meta attributes ...
+            "validation": BOOLEAN ?
+          }, ?
 
           "versionsurl": "URL",
           "versionscount": UINTEGER,
@@ -180,12 +178,13 @@ detail below, is as follows:
               "name": "format",
               "type": "string",
               "description": "Schema format identifier for this schema version"
-            },
+            }
+          },
+          "metaattributes": {
             "validation": {
               "name": "validation",
               "type": "boolean",
-              "description": "Verify compliance with specified 'format'",
-              "location": "resource"
+              "description": "Verify compliance with specified 'format'"
             }
           }
         }
@@ -294,8 +293,8 @@ the core xRegistry Resource
 - Constraints:
   - OPTIONAL
   - When not specified, the default value is `true`.
-  - MUST be a Resource level attribute as defined by the xRegistry [`location`
-    model aspect](../core/spec.md#registry-model).
+  - MUST be a Resource level attribute defined within the `metaattributes`
+    section of the model.
 
 #### `format`
 
@@ -315,8 +314,8 @@ the core xRegistry Resource
   - MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is
     the name of the schema format and `{VERSION}` is the Version of the schema
     format in the format defined by the schema format itself.
-  - MUST be a Version level attribute as defined by the xRegistry [`location`
-    model aspect](../core/spec.md#registry-model).
+  - MUST be a Version level attribute defined within the `attributes` section
+    of the model.
 - Examples:
   - `JsonSchema/draft-07`
   - `Protobuf/3`
@@ -343,14 +342,14 @@ Versions for a schema named `com.example.telemetrydata`:
       "schemas": {
         "com.example.telemetrydata": {
           "schemaid": "com.example.telemetrydata",
-          "defaultversionurl": "http://example.com/schemagroups/com.example.telemetry/schemas/com.example.telemetrydata/versions/3",
-          "defaultversionid": "3",
+          "versionid": "3",
           "description": "device telemetry event data",
           "format": "Protobuf/3",
-          # other xRegistry resource-level attributes excluded for brevity
+          # other xRegistry default Version attributes excluded for brevity
 
           "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; string unit = 2; string description = 3; } }"
 
+          "metaurl": "http://example.com/schemagroups/com.example.telemetry/schemas/com.example.telemetrydata/meta",
           "versionsurl": "http://example.com/schemagroups/com.example.telemetry/schemas/com.example.telemetrydata/versions",
           "versionscount": 3,
           "versions": {
@@ -359,7 +358,7 @@ Versions for a schema named `com.example.telemetrydata`:
               "versionid": "1",
               "description": "device telemetry event data",
               "format": "Protobuf/3",
-              # other xRegistry resource-level attributes excluded for brevity
+              # other xRegistry Version-level attributes excluded for brevity
 
               "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; } }"
             },
@@ -368,7 +367,7 @@ Versions for a schema named `com.example.telemetrydata`:
               "versionid": "2",
               "description": "device telemetry event data",
               "format": "Protobuf/3",
-              # other xRegistry resource-level attributes excluded for brevity
+              # other xRegistry Version-level attributes excluded for brevity
 
               "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; string unit = 2; } }"
             },
@@ -377,7 +376,7 @@ Versions for a schema named `com.example.telemetrydata`:
               "versionid": "3",
               "description": "device telemetry event data",
               "format": "Protobuf/3",
-              # other xRegistry resource-level attributes excluded for brevity
+              # other xRegistry Version-level attributes excluded for brevity
 
               "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; string unit = 2; string description = 3; } }"
             }

--- a/todos/primer.md
+++ b/todos/primer.md
@@ -45,8 +45,8 @@ Within that scope, two obvious items popped up:
     This includes things such as: how does an event consumer know which events
     a producer will generated? Which transport, and encoding, mechanisms do
     they support? How should a consumer subscribe for events?
-    
-2 - Subscriptions: 
+
+2 - Subscriptions:
     Once the consumer determines if a particular producer will generate events
     that are of interest to them, how can they subscribe? Ideally, in an
     interoperable way so as to not need to have custom logic for each producer.
@@ -72,7 +72,7 @@ insight into the team's focus during the development cycle.
 - Consumer wants to programmatically determine the list of events (event types)
   that a producer will generate so they can properly specify the list of events
   they are interested in as part of the subscribe() operation.
-  
+
 - Consumer wants to know which producers support certain event types so as to
   allow for the consumer to subscribe only to those producers since those are
   the only events that the consumer is interested in, or can support.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -2,12 +2,15 @@ all: verify
 
 verify: spellcheck tabcheck test_tools
 	@python tools/verify.py .
+	@echo
 
 spellcheck:
 	tools/spellcheck */spec.md core/primer.md
+	@echo
 
 tabcheck:
-	tools/tabcheck */spec.md core/primer.md
+	tools/tabcheck */*.md  */*.json
+	@echo
 
 deps:
 	@echo Loading python deps

--- a/tools/dict
+++ b/tools/dict
@@ -24,6 +24,7 @@ cloudevents
 cncf
 collectionscount
 collectionsurl
+commonattributes
 config
 configendpoints
 connectionproperties
@@ -98,9 +99,11 @@ messageid
 messagepack
 messagescount
 messagesurl
+metaattributes
 metadata
 metaschema
 metaschemas
+metaurl
 middleware
 modifiedat
 modifiedby
@@ -108,6 +111,7 @@ monotomically
 mqtt
 mqtts
 myattr
+myattribute
 myendpoint
 myentity
 myevent

--- a/tools/spellcheck
+++ b/tools/spellcheck
@@ -6,7 +6,7 @@
 set -e
 
 for f in $* ; do
-  echo Spell-checking: $f
+  echo "> $f"
 
   sed "s/\([a-zA-Z0-9]\+\)/\n\1\n/gI" < $f | \
     tr '[:upper:]' '[:lower:]' | \

--- a/tools/tabcheck
+++ b/tools/tabcheck
@@ -3,13 +3,12 @@
 set -e
 
 for f in $* ; do
-  echo Checking for tabs: $f
+  echo "> $f"
 
   if grep -nP '\t' $f ; then
     exit 1
   fi
 
-  echo Checking for trailing spaces: $f
   if grep -n "  *$" $f ; then
     exit 1
   fi


### PR DESCRIPTION
- rename $meta to $json
- Move Resource level attributes into a nested Object ("meta")
- add a "metaattributes" to model for Resources
- remove "location" model attribute since we now have "metaattributes"
- update domain specific specs, models and code gen files
- removed the ?resource and ?attribs flags as they're  not needed any more