### PR TITLE
Changes for week of Nov 4

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -14,7 +14,5 @@ jobs:
           cache-dependency-path: "tools/requirements.txt"
       - name: Install tools dependencies
         run: python -m pip install -r tools/requirements.txt
-      - name: Test Tools
-        run: make -f tools/Makefile test_tools
       - name: Verify Specification
-        run: make -f tools/Makefile verify
+        run: make -f tools/Makefile verify makeschema

--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -439,12 +439,12 @@
                     },
                     {
                       "type": "string",
-                      "name": "schemaformat",
+                      "name": "dataschemaformat",
                       "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
                     },
                     {
                       "type": "record",
-                      "name": "schema",
+                      "name": "dataschema",
                       "fields": [
                         {
                           "name": "object",
@@ -482,8 +482,13 @@
                     },
                     {
                       "type": "string",
-                      "name": "schemauri",
+                      "name": "dataschemauri",
                       "doc": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+                    },
+                    {
+                      "type": "string",
+                      "name": "datacontenttype",
+                      "doc": "The content type for the message payload"
                     }
                   ]
                 }

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -75,18 +75,22 @@
           "format": "uri",
           "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
         },
-        "schemaformat": {
+        "dataschemaformat": {
           "type": "string",
           "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
         },
-        "schema": {
+        "dataschema": {
           "type": "object",
           "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
         },
-        "schemauri": {
+        "dataschemauri": {
           "type": "string",
           "format": "uri",
           "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+        },
+        "datacontenttype": {
+          "type": "string",
+          "description": "The content type for the message payload"
         }
       },
       "allOf": [
@@ -121,6 +125,12 @@
                       "type": "object",
                       "description": "CloudEvents spec version",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents spec version"
@@ -134,6 +144,12 @@
                       "type": "object",
                       "description": "CloudEvents id",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents id value template"
@@ -147,6 +163,12 @@
                       "type": "object",
                       "description": "CloudEvents type",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents type value template"
@@ -160,6 +182,12 @@
                       "type": "object",
                       "description": "CloudEvents source",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents source value template"
@@ -173,6 +201,12 @@
                       "type": "object",
                       "description": "CloudEvents subject",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents subject value template"
@@ -187,6 +221,12 @@
                       "type": "object",
                       "description": "The timestamp of when the event happened",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "The timestamp value template"
@@ -201,6 +241,12 @@
                       "type": "object",
                       "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "format": "uri-template",
@@ -217,13 +263,16 @@
                     "type": "object",
                     "description": "CloudEvent extension property",
                     "properties": {
-                      "value": {
-                        "type": "string",
-                        "description": "The value template"
+                      "description": {
+                        "type": "string"
                       },
                       "type": {
                         "type": "string",
                         "description": "The value type"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value template"
                       },
                       "required": {
                         "type": "boolean",
@@ -287,6 +336,13 @@
                           "type": "object",
                           "description": "AMQP message-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP message-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP message-id value template"
@@ -301,6 +357,13 @@
                           "type": "object",
                           "description": "AMQP user-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP user-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP user-id value template"
@@ -315,6 +378,13 @@
                           "type": "object",
                           "description": "AMQP to",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP to value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP to value template"
@@ -329,6 +399,13 @@
                           "type": "object",
                           "description": "AMQP subject",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP subject value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP subject value template"
@@ -343,6 +420,13 @@
                           "type": "object",
                           "description": "AMQP reply-to",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP reply-to value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP reply-to value template"
@@ -357,6 +441,13 @@
                           "type": "object",
                           "description": "AMQP correlation-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP correlation-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP correlation-id value template"
@@ -371,6 +462,13 @@
                           "type": "object",
                           "description": "AMQP content-type",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP content-type value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP content-type value template"
@@ -385,6 +483,13 @@
                           "type": "object",
                           "description": "AMQP content-encoding",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP content-encoding value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP content-encoding value template"
@@ -399,6 +504,13 @@
                           "type": "object",
                           "description": "AMQP absolute-expiry-time",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP absolute-expiry-time value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP absolute-expiry-time value template"
@@ -413,6 +525,13 @@
                           "type": "object",
                           "description": "AMQP group-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP group-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP group-id value template"
@@ -427,6 +546,13 @@
                           "type": "object",
                           "description": "AMQP group-sequence",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP group-sequence value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP group-sequence value template"
@@ -441,6 +567,13 @@
                           "type": "object",
                           "description": "AMQP reply-to-group-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP reply-to-group-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP reply-to-group-id value template"
@@ -458,6 +591,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The application property type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The application property value template"
@@ -465,10 +605,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "The application property required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The application property type"
                           }
                         }
                       }
@@ -478,6 +614,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The message annotation type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The message annotation value"
@@ -485,10 +628,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "Whether the message annotation is required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The message annotation type"
                           }
                         }
                       }
@@ -498,6 +637,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The annotation type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The delivery annotation value"
@@ -505,10 +651,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "Whether the annotation is required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The annotation type"
                           }
                         }
                       }
@@ -518,6 +660,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "AMQP header type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "AMQP header value"
@@ -525,10 +674,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "AMQP header required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "AMQP header type"
                           }
                         }
                       }
@@ -538,6 +683,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "AMQP footer type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "AMQP footer value"
@@ -545,10 +697,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "AMQP footer required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "AMQP footer type"
                           }
                         }
                       }
@@ -577,9 +725,16 @@
                       "type": "object",
                       "description": "MQTT qos",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT qos value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT qos value required"
                         }
                       }
                     },
@@ -587,9 +742,16 @@
                       "type": "object",
                       "description": "MQTT retain",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "boolean",
                           "description": "MQTT retain value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT retain value required"
                         }
                       }
                     },
@@ -597,9 +759,16 @@
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT topic-name value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT topic-name value required"
                         }
                       }
                     }
@@ -627,9 +796,16 @@
                       "type": "object",
                       "description": "MQTT qos",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "integer",
                           "description": "MQTT qos value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT qos value required"
                         }
                       }
                     },
@@ -637,9 +813,16 @@
                       "type": "object",
                       "description": "MQTT retain",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "boolean",
                           "description": "MQTT retain value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT retain value required"
                         }
                       }
                     },
@@ -647,9 +830,16 @@
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT topic-name value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT topic-name value required"
                         }
                       }
                     },
@@ -657,9 +847,16 @@
                       "type": "object",
                       "description": "MQTT message-expiry-interval",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "integer",
                           "description": "MQTT message-expiry-interval value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT message-expiry-interval value required"
                         }
                       }
                     },
@@ -667,9 +864,16 @@
                       "type": "object",
                       "description": "MQTT response-topic",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT response-topic value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT response-topic value required"
                         }
                       }
                     },
@@ -677,9 +881,16 @@
                       "type": "object",
                       "description": "MQTT correlation-data",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT correlation-data value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT correlation-data value required"
                         }
                       }
                     },
@@ -687,9 +898,16 @@
                       "type": "object",
                       "description": "MQTT content-type",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT content-type value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT content-type value required"
                         }
                       }
                     },
@@ -702,6 +920,9 @@
                           "name": {
                             "type": "string",
                             "description": "MQTT user-property name"
+                          },
+                          "description": {
+                            "type": "string"
                           },
                           "value": {
                             "type": "string",
@@ -752,9 +973,16 @@
                             "type": "string",
                             "description": "The Apache Kafka header name"
                           },
+                          "description": {
+                            "type": "string"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The Apache Kafka header value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The Apache Kafka header required"
                           }
                         }
                       }
@@ -793,17 +1021,43 @@
                             "type": "string",
                             "description": "The HTTP header name"
                           },
+                          "description": {
+                            "type": "string"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The HTTP header value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The HTTP header required"
                           }
                         }
                       }
                     },
                     "query": {
-                      "type": "object",
+                      "type": "array",
                       "description": "The HTTP query parameters",
-                      "properties": {}
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The HTTP query parameter"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "The HTTP query parameter value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The HTTP query parameter required"
+                          }
+                        }
+                      }
                     },
                     "path": {
                       "type": "string",
@@ -973,7 +1227,7 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "uri": {
+                          "url": {
                             "type": "string",
                             "format": "uri",
                             "description": "Network accessible location"
@@ -991,7 +1245,7 @@
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
-                          "resourceurl": {
+                          "resourceuri": {
                             "type": "string",
                             "format": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -2551,6 +2551,12 @@
                 "type": "object",
                 "description": "CloudEvents spec version",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents spec version"
@@ -2564,6 +2570,12 @@
                 "type": "object",
                 "description": "CloudEvents id",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents id value template"
@@ -2577,6 +2589,12 @@
                 "type": "object",
                 "description": "CloudEvents type",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents type value template"
@@ -2590,6 +2608,12 @@
                 "type": "object",
                 "description": "CloudEvents source",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents source value template"
@@ -2603,6 +2627,12 @@
                 "type": "object",
                 "description": "CloudEvents subject",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents subject value template"
@@ -2617,6 +2647,12 @@
                 "type": "object",
                 "description": "The timestamp of when the event happened",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "The timestamp value template"
@@ -2631,6 +2667,12 @@
                 "type": "object",
                 "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "format": "uri-template",
@@ -2647,13 +2689,16 @@
               "type": "object",
               "description": "CloudEvent extension property",
               "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "The value template"
+                "description": {
+                  "type": "string"
                 },
                 "type": {
                   "type": "string",
                   "description": "The value type"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "The value template"
                 },
                 "required": {
                   "type": "boolean",
@@ -2713,6 +2758,13 @@
                     "type": "object",
                     "description": "AMQP message-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP message-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP message-id value template"
@@ -2727,6 +2779,13 @@
                     "type": "object",
                     "description": "AMQP user-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP user-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP user-id value template"
@@ -2741,6 +2800,13 @@
                     "type": "object",
                     "description": "AMQP to",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP to value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP to value template"
@@ -2755,6 +2821,13 @@
                     "type": "object",
                     "description": "AMQP subject",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP subject value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP subject value template"
@@ -2769,6 +2842,13 @@
                     "type": "object",
                     "description": "AMQP reply-to",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP reply-to value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP reply-to value template"
@@ -2783,6 +2863,13 @@
                     "type": "object",
                     "description": "AMQP correlation-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP correlation-id value template"
@@ -2797,6 +2884,13 @@
                     "type": "object",
                     "description": "AMQP content-type",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP content-type value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP content-type value template"
@@ -2811,6 +2905,13 @@
                     "type": "object",
                     "description": "AMQP content-encoding",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP content-encoding value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP content-encoding value template"
@@ -2825,6 +2926,13 @@
                     "type": "object",
                     "description": "AMQP absolute-expiry-time",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP absolute-expiry-time value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP absolute-expiry-time value template"
@@ -2839,6 +2947,13 @@
                     "type": "object",
                     "description": "AMQP group-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP group-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP group-id value template"
@@ -2853,6 +2968,13 @@
                     "type": "object",
                     "description": "AMQP group-sequence",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP group-sequence value template"
@@ -2867,6 +2989,13 @@
                     "type": "object",
                     "description": "AMQP reply-to-group-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP reply-to-group-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP reply-to-group-id value template"
@@ -2884,6 +3013,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The application property type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The application property value template"
@@ -2891,10 +3027,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "The application property required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "The application property type"
                     }
                   }
                 }
@@ -2904,6 +3036,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The message annotation type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The message annotation value"
@@ -2911,10 +3050,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "Whether the message annotation is required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "The message annotation type"
                     }
                   }
                 }
@@ -2924,6 +3059,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The annotation type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The delivery annotation value"
@@ -2931,10 +3073,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "Whether the annotation is required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "The annotation type"
                     }
                   }
                 }
@@ -2944,6 +3082,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "AMQP header type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP header value"
@@ -2951,10 +3096,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "AMQP header required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "AMQP header type"
                     }
                   }
                 }
@@ -2964,6 +3105,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "AMQP footer type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP footer value"
@@ -2971,10 +3119,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "AMQP footer required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "AMQP footer type"
                     }
                   }
                 }
@@ -3003,9 +3147,16 @@
                 "type": "object",
                 "description": "MQTT qos",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT qos value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT qos value required"
                   }
                 }
               },
@@ -3013,9 +3164,16 @@
                 "type": "object",
                 "description": "MQTT retain",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "boolean",
                     "description": "MQTT retain value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT retain value required"
                   }
                 }
               },
@@ -3023,9 +3181,16 @@
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT topic-name value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT topic-name value required"
                   }
                 }
               }
@@ -3053,9 +3218,16 @@
                 "type": "object",
                 "description": "MQTT qos",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "integer",
                     "description": "MQTT qos value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT qos value required"
                   }
                 }
               },
@@ -3063,9 +3235,16 @@
                 "type": "object",
                 "description": "MQTT retain",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "boolean",
                     "description": "MQTT retain value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT retain value required"
                   }
                 }
               },
@@ -3073,9 +3252,16 @@
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT topic-name value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT topic-name value required"
                   }
                 }
               },
@@ -3083,9 +3269,16 @@
                 "type": "object",
                 "description": "MQTT message-expiry-interval",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "integer",
                     "description": "MQTT message-expiry-interval value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT message-expiry-interval value required"
                   }
                 }
               },
@@ -3093,9 +3286,16 @@
                 "type": "object",
                 "description": "MQTT response-topic",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT response-topic value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT response-topic value required"
                   }
                 }
               },
@@ -3103,9 +3303,16 @@
                 "type": "object",
                 "description": "MQTT correlation-data",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT correlation-data value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT correlation-data value required"
                   }
                 }
               },
@@ -3113,9 +3320,16 @@
                 "type": "object",
                 "description": "MQTT content-type",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT content-type value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT content-type value required"
                   }
                 }
               },
@@ -3128,6 +3342,9 @@
                     "name": {
                       "type": "string",
                       "description": "MQTT user-property name"
+                    },
+                    "description": {
+                      "type": "string"
                     },
                     "value": {
                       "type": "string",
@@ -3178,9 +3395,16 @@
                       "type": "string",
                       "description": "The Apache Kafka header name"
                     },
+                    "description": {
+                      "type": "string"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The Apache Kafka header value"
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "description": "The Apache Kafka header required"
                     }
                   }
                 }
@@ -3219,17 +3443,43 @@
                       "type": "string",
                       "description": "The HTTP header name"
                     },
+                    "description": {
+                      "type": "string"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The HTTP header value"
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "description": "The HTTP header required"
                     }
                   }
                 }
               },
               "query": {
-                "type": "object",
+                "type": "array",
                 "description": "The HTTP query parameters",
-                "properties": {}
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "The HTTP query parameter"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The HTTP query parameter value"
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "description": "The HTTP query parameter required"
+                    }
+                  }
+                }
               },
               "path": {
                 "type": "string",
@@ -3299,18 +3549,22 @@
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
           },
-          "schemaformat": {
+          "dataschemaformat": {
             "type": "string",
             "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
           },
-          "schema": {
+          "dataschema": {
             "type": "object",
             "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
           },
-          "schemauri": {
+          "dataschemauri": {
             "type": "string",
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+          },
+          "datacontenttype": {
+            "type": "string",
+            "description": "The content type for the message payload"
           }
         },
         "discriminator": {

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -162,8 +162,9 @@ schema for its payload.
             }
           },
 
-          "schemaformat": "Protobuf/3.0",
-          "schema": "syntax = \"proto3\"; message Metrics { float metric = 1; } }"
+          "dataschemaformat": "Protobuf/3.0",
+          "dataschema": "syntax = \"proto3\"; message Metrics { float metric = 1; } }"
+          "datacontenttype": "Protobuf/3.0",
 
           "metaurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/meta",
           "versionsurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/versions",
@@ -264,8 +265,9 @@ scenarios:
             }
           },
 
-          "schemaformat": "Protobuf/3.0",
-          "schemaurl": "#/schemagroups/com.example.telemetry/schema/com.example.telemetrydata/versions/1.0"
+          "dataschemaformat": "Protobuf/3.0",
+          "dataschemauri": "#/schemagroups/com.example.telemetry/schema/com.example.telemetrydata/versions/1.0"
+          "datacontenttype": "Protobuf/3.0",
 
           "metaurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/meta",
           "versionsurl": "https://example.com/endpoints/com.example.telemetry/messages/com.example.telemetry/versions",

--- a/core/spec.md
+++ b/core/spec.md
@@ -5017,11 +5017,14 @@ Use of this feature is useful for cases where the contents of the Registry are
 to be represented as a single (self-contained) document.
 
 Some examples:
-- `GET /?inline=model`
-- `GET /?inline=model,endpoints`
-- `GET /?inline=endpoints.messages`
-- `GET /endpoints/ep1/?inline=messages.message`
-- `GET /endpoints/ep1/messages/msg1?inline=message`
+- `GET /?inline=model`                 # Just 'model'
+- `GET /?inline=model,endpoints`       # Model and one level under `endpoints`
+- `GET /?inline=*`                     # Everything except 'model'
+- `GET /?inline=model,*`               # Everything, including 'model'
+- `GET /?inline=endpoints.messages`    # One level below 'endpoints.messages'
+- `GET /?inline=endpoints.*`           # Everything below 'endpoints'
+- `GET /endpoints/ep1/?inline=messages.message`     # Just 'message'
+- `GET /endpoints/ep1/messages/msg1?inline=message` # Just 'message'
 
 The format of the `?inline` query parameter is:
 
@@ -5038,8 +5041,12 @@ as `prop1['my.name'].prop2` if `my.name` is the name of one attribute.
 
 There MAY be multiple `PATH`s specified, either as comma separated values on
 a single `?inline` query parameter or via multiple `?inline` query parameters.
-Absence of a `PATH`, or a `PATH` value of `*` indicates that all nested
-inlinable attributes MUST be inlined on all levels of the data returned.
+
+Absence of a `PATH`, or a `PATH` attribute with a value of `*` indicates that
+all nested inlinable attributes at that level in the hierarchy (and below)
+MUST be inlined. Use of `*` MUST only be used as the last attribute name
+(in its entirety) in the `PATH`. For example, `foo*`, or `*.foo` are not
+valid `PATH`s, but `*` and `endpoints.*` are.
 
 The specific value of `PATH` will vary based on where the request is directed.
 For example, a request to the root of the Registry MUST start with a `GROUPS`
@@ -5058,6 +5065,7 @@ For example, given a Registry with a model that has `endpoints` as a Group and
 | /endpoints/ep1 | ?inline=messages.message | Inline the Resource itself |
 | /endpoints/ep1 | ?inline=endpoints | Invalid, already in `endpoints` and there is no `RESOURCE` called `endpoints` |
 | / | ?inline=endpoints.messages.meta | Inlines the `meta` attributes/sub-object of each `message` returned. |
+| / | ?inline=endpoints.* | Inlines everything for all `endpoints`. |
 
 Note that asking for an attribute to be inlined will implicitly cause all of
 its parents to be inlined as well, but just the parent's collections needed to

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -111,9 +111,9 @@
                       "item": {
                         "type": "object",
                         "attributes": {
-                          "uri": {
-                            "name": "uri",
-                            "type": "uri",
+                          "url": {
+                            "name": "url",
+                            "type": "url",
                             "description": "Network accessible location",
                             "clientrequired": true,
                             "serverrequired": true
@@ -139,9 +139,9 @@
                             "clientrequired": true,
                             "serverrequired": true
                           },
-                          "resourceurl": {
-                            "name": "resourceurl",
-                            "type": "url",
+                          "resourceuri": {
+                            "name": "resourceuri",
+                            "type": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"
                           },
                           "authorityuri": {

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -439,12 +439,12 @@
                     },
                     {
                       "type": "string",
-                      "name": "schemaformat",
+                      "name": "dataschemaformat",
                       "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
                     },
                     {
                       "type": "record",
-                      "name": "schema",
+                      "name": "dataschema",
                       "fields": [
                         {
                           "name": "object",
@@ -482,8 +482,13 @@
                     },
                     {
                       "type": "string",
-                      "name": "schemauri",
+                      "name": "dataschemauri",
                       "doc": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+                    },
+                    {
+                      "type": "string",
+                      "name": "datacontenttype",
+                      "doc": "The content type for the message payload"
                     }
                   ]
                 }

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -63,18 +63,22 @@
           "format": "uri",
           "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
         },
-        "schemaformat": {
+        "dataschemaformat": {
           "type": "string",
           "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
         },
-        "schema": {
+        "dataschema": {
           "type": "object",
           "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
         },
-        "schemauri": {
+        "dataschemauri": {
           "type": "string",
           "format": "uri",
           "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+        },
+        "datacontenttype": {
+          "type": "string",
+          "description": "The content type for the message payload"
         }
       },
       "allOf": [
@@ -109,6 +113,12 @@
                       "type": "object",
                       "description": "CloudEvents spec version",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents spec version"
@@ -122,6 +132,12 @@
                       "type": "object",
                       "description": "CloudEvents id",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents id value template"
@@ -135,6 +151,12 @@
                       "type": "object",
                       "description": "CloudEvents type",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents type value template"
@@ -148,6 +170,12 @@
                       "type": "object",
                       "description": "CloudEvents source",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents source value template"
@@ -161,6 +189,12 @@
                       "type": "object",
                       "description": "CloudEvents subject",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents subject value template"
@@ -175,6 +209,12 @@
                       "type": "object",
                       "description": "The timestamp of when the event happened",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "The timestamp value template"
@@ -189,6 +229,12 @@
                       "type": "object",
                       "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "format": "uri-template",
@@ -205,13 +251,16 @@
                     "type": "object",
                     "description": "CloudEvent extension property",
                     "properties": {
-                      "value": {
-                        "type": "string",
-                        "description": "The value template"
+                      "description": {
+                        "type": "string"
                       },
                       "type": {
                         "type": "string",
                         "description": "The value type"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value template"
                       },
                       "required": {
                         "type": "boolean",
@@ -275,6 +324,13 @@
                           "type": "object",
                           "description": "AMQP message-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP message-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP message-id value template"
@@ -289,6 +345,13 @@
                           "type": "object",
                           "description": "AMQP user-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP user-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP user-id value template"
@@ -303,6 +366,13 @@
                           "type": "object",
                           "description": "AMQP to",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP to value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP to value template"
@@ -317,6 +387,13 @@
                           "type": "object",
                           "description": "AMQP subject",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP subject value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP subject value template"
@@ -331,6 +408,13 @@
                           "type": "object",
                           "description": "AMQP reply-to",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP reply-to value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP reply-to value template"
@@ -345,6 +429,13 @@
                           "type": "object",
                           "description": "AMQP correlation-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP correlation-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP correlation-id value template"
@@ -359,6 +450,13 @@
                           "type": "object",
                           "description": "AMQP content-type",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP content-type value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP content-type value template"
@@ -373,6 +471,13 @@
                           "type": "object",
                           "description": "AMQP content-encoding",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP content-encoding value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP content-encoding value template"
@@ -387,6 +492,13 @@
                           "type": "object",
                           "description": "AMQP absolute-expiry-time",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP absolute-expiry-time value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP absolute-expiry-time value template"
@@ -401,6 +513,13 @@
                           "type": "object",
                           "description": "AMQP group-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP group-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP group-id value template"
@@ -415,6 +534,13 @@
                           "type": "object",
                           "description": "AMQP group-sequence",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP group-sequence value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP group-sequence value template"
@@ -429,6 +555,13 @@
                           "type": "object",
                           "description": "AMQP reply-to-group-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP reply-to-group-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP reply-to-group-id value template"
@@ -446,6 +579,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The application property type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The application property value template"
@@ -453,10 +593,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "The application property required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The application property type"
                           }
                         }
                       }
@@ -466,6 +602,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The message annotation type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The message annotation value"
@@ -473,10 +616,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "Whether the message annotation is required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The message annotation type"
                           }
                         }
                       }
@@ -486,6 +625,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The annotation type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The delivery annotation value"
@@ -493,10 +639,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "Whether the annotation is required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The annotation type"
                           }
                         }
                       }
@@ -506,6 +648,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "AMQP header type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "AMQP header value"
@@ -513,10 +662,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "AMQP header required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "AMQP header type"
                           }
                         }
                       }
@@ -526,6 +671,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "AMQP footer type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "AMQP footer value"
@@ -533,10 +685,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "AMQP footer required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "AMQP footer type"
                           }
                         }
                       }
@@ -565,9 +713,16 @@
                       "type": "object",
                       "description": "MQTT qos",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT qos value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT qos value required"
                         }
                       }
                     },
@@ -575,9 +730,16 @@
                       "type": "object",
                       "description": "MQTT retain",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "boolean",
                           "description": "MQTT retain value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT retain value required"
                         }
                       }
                     },
@@ -585,9 +747,16 @@
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT topic-name value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT topic-name value required"
                         }
                       }
                     }
@@ -615,9 +784,16 @@
                       "type": "object",
                       "description": "MQTT qos",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "integer",
                           "description": "MQTT qos value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT qos value required"
                         }
                       }
                     },
@@ -625,9 +801,16 @@
                       "type": "object",
                       "description": "MQTT retain",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "boolean",
                           "description": "MQTT retain value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT retain value required"
                         }
                       }
                     },
@@ -635,9 +818,16 @@
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT topic-name value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT topic-name value required"
                         }
                       }
                     },
@@ -645,9 +835,16 @@
                       "type": "object",
                       "description": "MQTT message-expiry-interval",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "integer",
                           "description": "MQTT message-expiry-interval value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT message-expiry-interval value required"
                         }
                       }
                     },
@@ -655,9 +852,16 @@
                       "type": "object",
                       "description": "MQTT response-topic",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT response-topic value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT response-topic value required"
                         }
                       }
                     },
@@ -665,9 +869,16 @@
                       "type": "object",
                       "description": "MQTT correlation-data",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT correlation-data value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT correlation-data value required"
                         }
                       }
                     },
@@ -675,9 +886,16 @@
                       "type": "object",
                       "description": "MQTT content-type",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT content-type value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT content-type value required"
                         }
                       }
                     },
@@ -690,6 +908,9 @@
                           "name": {
                             "type": "string",
                             "description": "MQTT user-property name"
+                          },
+                          "description": {
+                            "type": "string"
                           },
                           "value": {
                             "type": "string",
@@ -740,9 +961,16 @@
                             "type": "string",
                             "description": "The Apache Kafka header name"
                           },
+                          "description": {
+                            "type": "string"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The Apache Kafka header value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The Apache Kafka header required"
                           }
                         }
                       }
@@ -781,17 +1009,43 @@
                             "type": "string",
                             "description": "The HTTP header name"
                           },
+                          "description": {
+                            "type": "string"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The HTTP header value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The HTTP header required"
                           }
                         }
                       }
                     },
                     "query": {
-                      "type": "object",
+                      "type": "array",
                       "description": "The HTTP query parameters",
-                      "properties": {}
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The HTTP query parameter"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "The HTTP query parameter value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The HTTP query parameter required"
+                          }
+                        }
+                      }
                     },
                     "path": {
                       "type": "string",
@@ -961,7 +1215,7 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "uri": {
+                          "url": {
                             "type": "string",
                             "format": "uri",
                             "description": "Network accessible location"
@@ -979,7 +1233,7 @@
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
-                          "resourceurl": {
+                          "resourceuri": {
                             "type": "string",
                             "format": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"

--- a/message/model.json
+++ b/message/model.json
@@ -53,6 +53,14 @@
                           "description": "CloudEvents spec version",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
+                            "type": {
+                              "name": "type",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "CloudEvents spec version",
@@ -74,6 +82,14 @@
                           "description": "CloudEvents id",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
+                            "type": {
+                              "name": "type",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "CloudEvents id value template",
@@ -95,6 +111,14 @@
                           "type": "object",
                           "description": "CloudEvents type",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
+                            "type": {
+                              "name": "type",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "type": "string",
@@ -116,6 +140,14 @@
                           "description": "CloudEvents source",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
+                            "type": {
+                              "name": "type",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "CloudEvents source value template",
@@ -137,6 +169,14 @@
                           "description": "CloudEvents subject",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
+                            "type": {
+                              "name": "type",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "CloudEvents subject value template",
@@ -154,6 +194,14 @@
                           "description": "The timestamp of when the event happened",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
+                            "type": {
+                              "name": "type",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "The timestamp value template",
@@ -171,6 +219,14 @@
                           "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
+                            "type": {
+                              "name": "type",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "The uri value template",
@@ -188,14 +244,18 @@
                           "description": "CloudEvent extension property",
                           "type": "object",
                           "attributes": {
-                            "value": {
-                              "name": "value",
-                              "description": "The value template",
+                            "description": {
+                              "name": "description",
                               "type": "string"
                             },
                             "type": {
                               "name": "type",
                               "description": "The value type",
+                              "type": "string"
+                            },
+                            "value": {
+                              "name": "value",
+                              "description": "The value template",
                               "type": "string"
                             },
                             "required": {
@@ -255,6 +315,15 @@
                               "description": "AMQP message-id",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP message-id value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP message-id value template",
@@ -272,6 +341,15 @@
                               "description": "AMQP user-id",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP user-id value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP user-id value template",
@@ -289,6 +367,15 @@
                               "description": "AMQP to",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP to value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP to value template",
@@ -306,6 +393,15 @@
                               "description": "AMQP subject",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP subject value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP subject value template",
@@ -323,6 +419,15 @@
                               "description": "AMQP reply-to",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP reply-to value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP reply-to value template",
@@ -340,6 +445,15 @@
                               "description": "AMQP correlation-id",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP correlation-id value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP correlation-id value template",
@@ -357,6 +471,15 @@
                               "description": "AMQP content-type",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP content-type value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP content-type value template",
@@ -374,6 +497,15 @@
                               "description": "AMQP content-encoding",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP content-encoding value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP content-encoding value template",
@@ -391,6 +523,15 @@
                               "description": "AMQP absolute-expiry-time",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP absolute-expiry-time value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP absolute-expiry-time value template",
@@ -408,6 +549,15 @@
                               "description": "AMQP group-id",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP group-id value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP group-id value template",
@@ -425,6 +575,15 @@
                               "description": "AMQP group-sequence",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP group-sequence value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP group-sequence value template",
@@ -442,6 +601,15 @@
                               "description": "AMQP reply-to-group-id",
                               "type": "object",
                               "attributes": {
+                                "description": {
+                                  "name": "description",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "name": "type",
+                                  "description": "AMQP reply-to-group-id value type",
+                                  "type": "string"
+                                },
                                 "value": {
                                   "name": "value",
                                   "description": "AMQP reply-to-group-id value template",
@@ -462,6 +630,15 @@
                           "item": {
                             "type": "object",
                             "attributes": {
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "The application property type",
+                                "type": "string"
+                              },
                               "value": {
                                 "name": "value",
                                 "description": "The application property value template",
@@ -471,11 +648,6 @@
                                 "name": "required",
                                 "description": "The application property required",
                                 "type": "boolean"
-                              },
-                              "type": {
-                                "name": "type",
-                                "description": "The application property type",
-                                "type": "string"
                               }
                             }
                           }
@@ -486,6 +658,15 @@
                           "item": {
                             "type": "object",
                             "attributes": {
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "The message annotation type",
+                                "type": "string"
+                              },
                               "value": {
                                 "name": "value",
                                 "description": "The message annotation value",
@@ -495,11 +676,6 @@
                                 "name": "required",
                                 "description": "Whether the message annotation is required",
                                 "type": "boolean"
-                              },
-                              "type": {
-                                "name": "type",
-                                "description": "The message annotation type",
-                                "type": "string"
                               }
                             }
                           }
@@ -510,6 +686,15 @@
                           "item": {
                             "type": "object",
                             "attributes": {
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "The annotation type",
+                                "type": "string"
+                              },
                               "value": {
                                 "name": "value",
                                 "description": "The delivery annotation value",
@@ -519,11 +704,6 @@
                                 "name": "required",
                                 "description": "Whether the annotation is required",
                                 "type": "boolean"
-                              },
-                              "type": {
-                                "name": "type",
-                                "description": "The annotation type",
-                                "type": "string"
                               }
                             }
                           }
@@ -534,6 +714,15 @@
                           "item": {
                             "type": "object",
                             "attributes": {
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "AMQP header type",
+                                "type": "string"
+                              },
                               "value": {
                                 "name": "value",
                                 "description": "AMQP header value",
@@ -543,11 +732,6 @@
                                 "name": "required",
                                 "description": "AMQP header required",
                                 "type": "boolean"
-                              },
-                              "type": {
-                                "name": "type",
-                                "description": "AMQP header type",
-                                "type": "string"
                               }
                             }
                           }
@@ -558,6 +742,15 @@
                           "item": {
                             "type": "object",
                             "attributes": {
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
+                              "type": {
+                                "name": "type",
+                                "description": "AMQP footer type",
+                                "type": "string"
+                              },
                               "value": {
                                 "name": "value",
                                 "description": "AMQP footer value",
@@ -567,11 +760,6 @@
                                 "name": "required",
                                 "description": "AMQP footer required",
                                 "type": "boolean"
-                              },
-                              "type": {
-                                "name": "type",
-                                "description": "AMQP footer type",
-                                "type": "string"
                               }
                             }
                           }
@@ -592,10 +780,19 @@
                           "description": "MQTT qos",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT qos value template",
                               "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT qos value required",
+                              "type": "boolean"
                             }
                           }
                         },
@@ -604,9 +801,18 @@
                           "description": "MQTT retain",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT retain value template",
+                              "type": "boolean"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT retain value required",
                               "type": "boolean"
                             }
                           }
@@ -616,10 +822,19 @@
                           "description": "MQTT topic-name",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT topic-name value template",
                               "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT topic-name value required",
+                              "type": "boolean"
                             }
                           }
                         }
@@ -639,10 +854,19 @@
                           "description": "MQTT qos",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT qos value template",
                               "type": "integer"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT qos value required",
+                              "type": "boolean"
                             }
                           }
                         },
@@ -651,9 +875,18 @@
                           "description": "MQTT retain",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT retain value template",
+                              "type": "boolean"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT retain value required",
                               "type": "boolean"
                             }
                           }
@@ -663,10 +896,19 @@
                           "description": "MQTT topic-name",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT topic-name value template",
                               "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT topic-name value required",
+                              "type": "boolean"
                             }
                           }
                         },
@@ -675,10 +917,19 @@
                           "description": "MQTT message-expiry-interval",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT message-expiry-interval value template",
                               "type": "integer"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT message-expiry-interval value required",
+                              "type": "boolean"
                             }
                           }
                         },
@@ -687,10 +938,19 @@
                           "description": "MQTT response-topic",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT response-topic value template",
                               "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT response-topic value required",
+                              "type": "boolean"
                             }
                           }
                         },
@@ -699,10 +959,19 @@
                           "description": "MQTT correlation-data",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT correlation-data value template",
                               "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT correlation-data value required",
+                              "type": "boolean"
                             }
                           }
                         },
@@ -711,10 +980,19 @@
                           "description": "MQTT content-type",
                           "type": "object",
                           "attributes": {
+                            "description": {
+                              "name": "description",
+                              "type": "string"
+                            },
                             "value": {
                               "name": "value",
                               "description": "MQTT content-type value template",
                               "type": "string"
+                            },
+                            "required": {
+                              "name": "required",
+                              "description": "MQTT content-type value required",
+                              "type": "boolean"
                             }
                           }
                         },
@@ -728,6 +1006,10 @@
                               "name": {
                                 "name": "name",
                                 "description": "MQTT user-property name",
+                                "type": "string"
+                              },
+                              "description": {
+                                "name": "description",
                                 "type": "string"
                               },
                               "value": {
@@ -776,10 +1058,19 @@
                                 "description": "The Apache Kafka header name",
                                 "type": "string"
                               },
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
                               "value": {
                                 "name": "value",
                                 "description": "The Apache Kafka header value",
                                 "type": "string"
+                              },
+                              "required": {
+                                "name": "required",
+                                "description": "The Apache Kafka header required",
+                                "type": "boolean"
                               }
                             }
                           }
@@ -812,10 +1103,19 @@
                                 "description": "The HTTP header name",
                                 "type": "string"
                               },
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
                               "value": {
                                 "name": "value",
                                 "description": "The HTTP header value",
                                 "type": "string"
+                              },
+                              "required": {
+                                "name": "required",
+                                "description": "The HTTP header required",
+                                "type": "boolean"
                               }
                             }
                           }
@@ -823,7 +1123,31 @@
                         "query": {
                           "name": "query",
                           "description": "The HTTP query parameters",
-                          "type": "object"
+                          "type": "array",
+                          "item": {
+                            "type": "object",
+                            "attributes": {
+                              "name": {
+                                "name": "name",
+                                "description": "The HTTP query parameter",
+                                "type": "string"
+                              },
+                              "description": {
+                                "name": "description",
+                                "type": "string"
+                              },
+                              "value": {
+                                "name": "value",
+                                "description": "The HTTP query parameter value",
+                                "type": "string"
+                              },
+                              "required": {
+                                "name": "required",
+                                "description": "The HTTP query parameter required",
+                                "type": "boolean"
+                              }
+                            }
+                          }
                         },
                         "path": {
                           "name": "path",
@@ -841,20 +1165,25 @@
                 }
               }
             },
-            "schemaformat": {
-              "name": "schemaformat",
+            "dataschemaformat": {
+              "name": "dataschemaformat",
               "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry",
               "type": "string"
             },
-            "schema": {
-              "name": "schema",
+            "dataschema": {
+              "name": "dataschema",
               "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry",
               "type": "any"
             },
-            "schemauri": {
-              "name": "schemauri",
+            "dataschemauri": {
+              "name": "dataschemauri",
               "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry",
               "type": "uri"
+            },
+            "datacontenttype": {
+              "name": "datacontenttype",
+              "description": "The content type for the message payload",
+              "type": "string"
             }
           }
         }

--- a/message/schemas/document-schema.avsc
+++ b/message/schemas/document-schema.avsc
@@ -334,12 +334,12 @@
                     },
                     {
                       "type": "string",
-                      "name": "schemaformat",
+                      "name": "dataschemaformat",
                       "doc": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
                     },
                     {
                       "type": "record",
-                      "name": "schema",
+                      "name": "dataschema",
                       "fields": [
                         {
                           "name": "object",
@@ -377,8 +377,13 @@
                     },
                     {
                       "type": "string",
-                      "name": "schemauri",
+                      "name": "dataschemauri",
                       "doc": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+                    },
+                    {
+                      "type": "string",
+                      "name": "datacontenttype",
+                      "doc": "The content type for the message payload"
                     }
                   ]
                 }

--- a/message/schemas/document-schema.json
+++ b/message/schemas/document-schema.json
@@ -63,18 +63,22 @@
           "format": "uri",
           "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
         },
-        "schemaformat": {
+        "dataschemaformat": {
           "type": "string",
           "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
         },
-        "schema": {
+        "dataschema": {
           "type": "object",
           "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
         },
-        "schemauri": {
+        "dataschemauri": {
           "type": "string",
           "format": "uri",
           "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+        },
+        "datacontenttype": {
+          "type": "string",
+          "description": "The content type for the message payload"
         }
       },
       "allOf": [
@@ -109,6 +113,12 @@
                       "type": "object",
                       "description": "CloudEvents spec version",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents spec version"
@@ -122,6 +132,12 @@
                       "type": "object",
                       "description": "CloudEvents id",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents id value template"
@@ -135,6 +151,12 @@
                       "type": "object",
                       "description": "CloudEvents type",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents type value template"
@@ -148,6 +170,12 @@
                       "type": "object",
                       "description": "CloudEvents source",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents source value template"
@@ -161,6 +189,12 @@
                       "type": "object",
                       "description": "CloudEvents subject",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "CloudEvents subject value template"
@@ -175,6 +209,12 @@
                       "type": "object",
                       "description": "The timestamp of when the event happened",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "The timestamp value template"
@@ -189,6 +229,12 @@
                       "type": "object",
                       "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "format": "uri-template",
@@ -205,13 +251,16 @@
                     "type": "object",
                     "description": "CloudEvent extension property",
                     "properties": {
-                      "value": {
-                        "type": "string",
-                        "description": "The value template"
+                      "description": {
+                        "type": "string"
                       },
                       "type": {
                         "type": "string",
                         "description": "The value type"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value template"
                       },
                       "required": {
                         "type": "boolean",
@@ -275,6 +324,13 @@
                           "type": "object",
                           "description": "AMQP message-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP message-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP message-id value template"
@@ -289,6 +345,13 @@
                           "type": "object",
                           "description": "AMQP user-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP user-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP user-id value template"
@@ -303,6 +366,13 @@
                           "type": "object",
                           "description": "AMQP to",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP to value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP to value template"
@@ -317,6 +387,13 @@
                           "type": "object",
                           "description": "AMQP subject",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP subject value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP subject value template"
@@ -331,6 +408,13 @@
                           "type": "object",
                           "description": "AMQP reply-to",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP reply-to value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP reply-to value template"
@@ -345,6 +429,13 @@
                           "type": "object",
                           "description": "AMQP correlation-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP correlation-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP correlation-id value template"
@@ -359,6 +450,13 @@
                           "type": "object",
                           "description": "AMQP content-type",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP content-type value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP content-type value template"
@@ -373,6 +471,13 @@
                           "type": "object",
                           "description": "AMQP content-encoding",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP content-encoding value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP content-encoding value template"
@@ -387,6 +492,13 @@
                           "type": "object",
                           "description": "AMQP absolute-expiry-time",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP absolute-expiry-time value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP absolute-expiry-time value template"
@@ -401,6 +513,13 @@
                           "type": "object",
                           "description": "AMQP group-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP group-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP group-id value template"
@@ -415,6 +534,13 @@
                           "type": "object",
                           "description": "AMQP group-sequence",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP group-sequence value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP group-sequence value template"
@@ -429,6 +555,13 @@
                           "type": "object",
                           "description": "AMQP reply-to-group-id",
                           "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string",
+                              "description": "AMQP reply-to-group-id value type"
+                            },
                             "value": {
                               "type": "string",
                               "description": "AMQP reply-to-group-id value template"
@@ -446,6 +579,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The application property type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The application property value template"
@@ -453,10 +593,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "The application property required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The application property type"
                           }
                         }
                       }
@@ -466,6 +602,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The message annotation type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The message annotation value"
@@ -473,10 +616,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "Whether the message annotation is required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The message annotation type"
                           }
                         }
                       }
@@ -486,6 +625,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "The annotation type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The delivery annotation value"
@@ -493,10 +639,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "Whether the annotation is required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "The annotation type"
                           }
                         }
                       }
@@ -506,6 +648,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "AMQP header type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "AMQP header value"
@@ -513,10 +662,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "AMQP header required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "AMQP header type"
                           }
                         }
                       }
@@ -526,6 +671,13 @@
                       "additionalProperties": {
                         "type": "object",
                         "properties": {
+                          "description": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "AMQP footer type"
+                          },
                           "value": {
                             "type": "string",
                             "description": "AMQP footer value"
@@ -533,10 +685,6 @@
                           "required": {
                             "type": "boolean",
                             "description": "AMQP footer required"
-                          },
-                          "type": {
-                            "type": "string",
-                            "description": "AMQP footer type"
                           }
                         }
                       }
@@ -565,9 +713,16 @@
                       "type": "object",
                       "description": "MQTT qos",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT qos value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT qos value required"
                         }
                       }
                     },
@@ -575,9 +730,16 @@
                       "type": "object",
                       "description": "MQTT retain",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "boolean",
                           "description": "MQTT retain value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT retain value required"
                         }
                       }
                     },
@@ -585,9 +747,16 @@
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT topic-name value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT topic-name value required"
                         }
                       }
                     }
@@ -615,9 +784,16 @@
                       "type": "object",
                       "description": "MQTT qos",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "integer",
                           "description": "MQTT qos value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT qos value required"
                         }
                       }
                     },
@@ -625,9 +801,16 @@
                       "type": "object",
                       "description": "MQTT retain",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "boolean",
                           "description": "MQTT retain value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT retain value required"
                         }
                       }
                     },
@@ -635,9 +818,16 @@
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT topic-name value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT topic-name value required"
                         }
                       }
                     },
@@ -645,9 +835,16 @@
                       "type": "object",
                       "description": "MQTT message-expiry-interval",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "integer",
                           "description": "MQTT message-expiry-interval value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT message-expiry-interval value required"
                         }
                       }
                     },
@@ -655,9 +852,16 @@
                       "type": "object",
                       "description": "MQTT response-topic",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT response-topic value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT response-topic value required"
                         }
                       }
                     },
@@ -665,9 +869,16 @@
                       "type": "object",
                       "description": "MQTT correlation-data",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT correlation-data value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT correlation-data value required"
                         }
                       }
                     },
@@ -675,9 +886,16 @@
                       "type": "object",
                       "description": "MQTT content-type",
                       "properties": {
+                        "description": {
+                          "type": "string"
+                        },
                         "value": {
                           "type": "string",
                           "description": "MQTT content-type value template"
+                        },
+                        "required": {
+                          "type": "boolean",
+                          "description": "MQTT content-type value required"
                         }
                       }
                     },
@@ -690,6 +908,9 @@
                           "name": {
                             "type": "string",
                             "description": "MQTT user-property name"
+                          },
+                          "description": {
+                            "type": "string"
                           },
                           "value": {
                             "type": "string",
@@ -740,9 +961,16 @@
                             "type": "string",
                             "description": "The Apache Kafka header name"
                           },
+                          "description": {
+                            "type": "string"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The Apache Kafka header value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The Apache Kafka header required"
                           }
                         }
                       }
@@ -781,17 +1009,43 @@
                             "type": "string",
                             "description": "The HTTP header name"
                           },
+                          "description": {
+                            "type": "string"
+                          },
                           "value": {
                             "type": "string",
                             "description": "The HTTP header value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The HTTP header required"
                           }
                         }
                       }
                     },
                     "query": {
-                      "type": "object",
+                      "type": "array",
                       "description": "The HTTP query parameters",
-                      "properties": {}
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "The HTTP query parameter"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string",
+                            "description": "The HTTP query parameter value"
+                          },
+                          "required": {
+                            "type": "boolean",
+                            "description": "The HTTP query parameter required"
+                          }
+                        }
+                      }
                     },
                     "path": {
                       "type": "string",

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -1133,6 +1133,12 @@
                 "type": "object",
                 "description": "CloudEvents spec version",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents spec version"
@@ -1146,6 +1152,12 @@
                 "type": "object",
                 "description": "CloudEvents id",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents id value template"
@@ -1159,6 +1171,12 @@
                 "type": "object",
                 "description": "CloudEvents type",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents type value template"
@@ -1172,6 +1190,12 @@
                 "type": "object",
                 "description": "CloudEvents source",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents source value template"
@@ -1185,6 +1209,12 @@
                 "type": "object",
                 "description": "CloudEvents subject",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "CloudEvents subject value template"
@@ -1199,6 +1229,12 @@
                 "type": "object",
                 "description": "The timestamp of when the event happened",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "The timestamp value template"
@@ -1213,6 +1249,12 @@
                 "type": "object",
                 "description": "The uri of the schema that the event payload adheres to. If the dataschema attribute is not present, it MUST be interpreted as no schema. An application MAY assign a meaning to the dataschema attribute if it is not present by default",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "format": "uri-template",
@@ -1229,13 +1271,16 @@
               "type": "object",
               "description": "CloudEvent extension property",
               "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "The value template"
+                "description": {
+                  "type": "string"
                 },
                 "type": {
                   "type": "string",
                   "description": "The value type"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "The value template"
                 },
                 "required": {
                   "type": "boolean",
@@ -1295,6 +1340,13 @@
                     "type": "object",
                     "description": "AMQP message-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP message-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP message-id value template"
@@ -1309,6 +1361,13 @@
                     "type": "object",
                     "description": "AMQP user-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP user-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP user-id value template"
@@ -1323,6 +1382,13 @@
                     "type": "object",
                     "description": "AMQP to",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP to value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP to value template"
@@ -1337,6 +1403,13 @@
                     "type": "object",
                     "description": "AMQP subject",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP subject value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP subject value template"
@@ -1351,6 +1424,13 @@
                     "type": "object",
                     "description": "AMQP reply-to",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP reply-to value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP reply-to value template"
@@ -1365,6 +1445,13 @@
                     "type": "object",
                     "description": "AMQP correlation-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP correlation-id value template"
@@ -1379,6 +1466,13 @@
                     "type": "object",
                     "description": "AMQP content-type",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP content-type value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP content-type value template"
@@ -1393,6 +1487,13 @@
                     "type": "object",
                     "description": "AMQP content-encoding",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP content-encoding value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP content-encoding value template"
@@ -1407,6 +1508,13 @@
                     "type": "object",
                     "description": "AMQP absolute-expiry-time",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP absolute-expiry-time value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP absolute-expiry-time value template"
@@ -1421,6 +1529,13 @@
                     "type": "object",
                     "description": "AMQP group-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP group-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP group-id value template"
@@ -1435,6 +1550,13 @@
                     "type": "object",
                     "description": "AMQP group-sequence",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP group-sequence value template"
@@ -1449,6 +1571,13 @@
                     "type": "object",
                     "description": "AMQP reply-to-group-id",
                     "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP reply-to-group-id value type"
+                      },
                       "value": {
                         "type": "string",
                         "description": "AMQP reply-to-group-id value template"
@@ -1466,6 +1595,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The application property type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The application property value template"
@@ -1473,10 +1609,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "The application property required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "The application property type"
                     }
                   }
                 }
@@ -1486,6 +1618,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The message annotation type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The message annotation value"
@@ -1493,10 +1632,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "Whether the message annotation is required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "The message annotation type"
                     }
                   }
                 }
@@ -1506,6 +1641,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "The annotation type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The delivery annotation value"
@@ -1513,10 +1655,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "Whether the annotation is required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "The annotation type"
                     }
                   }
                 }
@@ -1526,6 +1664,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "AMQP header type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP header value"
@@ -1533,10 +1678,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "AMQP header required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "AMQP header type"
                     }
                   }
                 }
@@ -1546,6 +1687,13 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "AMQP footer type"
+                    },
                     "value": {
                       "type": "string",
                       "description": "AMQP footer value"
@@ -1553,10 +1701,6 @@
                     "required": {
                       "type": "boolean",
                       "description": "AMQP footer required"
-                    },
-                    "type": {
-                      "type": "string",
-                      "description": "AMQP footer type"
                     }
                   }
                 }
@@ -1585,9 +1729,16 @@
                 "type": "object",
                 "description": "MQTT qos",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT qos value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT qos value required"
                   }
                 }
               },
@@ -1595,9 +1746,16 @@
                 "type": "object",
                 "description": "MQTT retain",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "boolean",
                     "description": "MQTT retain value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT retain value required"
                   }
                 }
               },
@@ -1605,9 +1763,16 @@
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT topic-name value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT topic-name value required"
                   }
                 }
               }
@@ -1635,9 +1800,16 @@
                 "type": "object",
                 "description": "MQTT qos",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "integer",
                     "description": "MQTT qos value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT qos value required"
                   }
                 }
               },
@@ -1645,9 +1817,16 @@
                 "type": "object",
                 "description": "MQTT retain",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "boolean",
                     "description": "MQTT retain value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT retain value required"
                   }
                 }
               },
@@ -1655,9 +1834,16 @@
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT topic-name value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT topic-name value required"
                   }
                 }
               },
@@ -1665,9 +1851,16 @@
                 "type": "object",
                 "description": "MQTT message-expiry-interval",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "integer",
                     "description": "MQTT message-expiry-interval value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT message-expiry-interval value required"
                   }
                 }
               },
@@ -1675,9 +1868,16 @@
                 "type": "object",
                 "description": "MQTT response-topic",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT response-topic value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT response-topic value required"
                   }
                 }
               },
@@ -1685,9 +1885,16 @@
                 "type": "object",
                 "description": "MQTT correlation-data",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT correlation-data value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT correlation-data value required"
                   }
                 }
               },
@@ -1695,9 +1902,16 @@
                 "type": "object",
                 "description": "MQTT content-type",
                 "properties": {
+                  "description": {
+                    "type": "string"
+                  },
                   "value": {
                     "type": "string",
                     "description": "MQTT content-type value template"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "MQTT content-type value required"
                   }
                 }
               },
@@ -1710,6 +1924,9 @@
                     "name": {
                       "type": "string",
                       "description": "MQTT user-property name"
+                    },
+                    "description": {
+                      "type": "string"
                     },
                     "value": {
                       "type": "string",
@@ -1760,9 +1977,16 @@
                       "type": "string",
                       "description": "The Apache Kafka header name"
                     },
+                    "description": {
+                      "type": "string"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The Apache Kafka header value"
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "description": "The Apache Kafka header required"
                     }
                   }
                 }
@@ -1801,17 +2025,43 @@
                       "type": "string",
                       "description": "The HTTP header name"
                     },
+                    "description": {
+                      "type": "string"
+                    },
                     "value": {
                       "type": "string",
                       "description": "The HTTP header value"
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "description": "The HTTP header required"
                     }
                   }
                 }
               },
               "query": {
-                "type": "object",
+                "type": "array",
                 "description": "The HTTP query parameters",
-                "properties": {}
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "The HTTP query parameter"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "The HTTP query parameter value"
+                    },
+                    "required": {
+                      "type": "boolean",
+                      "description": "The HTTP query parameter required"
+                    }
+                  }
+                }
               },
               "path": {
                 "type": "string",
@@ -1881,18 +2131,22 @@
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
           },
-          "schemaformat": {
+          "dataschemaformat": {
             "type": "string",
             "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
           },
-          "schema": {
+          "dataschema": {
             "type": "object",
             "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
           },
-          "schemauri": {
+          "dataschemauri": {
             "type": "string",
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemaurl' attribute of the schema registry"
+          },
+          "datacontenttype": {
+            "type": "string",
+            "description": "The content type for the message payload"
           }
         },
         "discriminator": {

--- a/message/spec.md
+++ b/message/spec.md
@@ -98,9 +98,10 @@ this form:
           "protocol": "STRING", ?              # e.g. HTTP/1.1
           "protocoloptions": { ... }, ?
 
-          "schemaformat": "STRING", ?
-          "schema": ANY, ?
-          "schemauri": "URI", ?
+          "dataschemaformat": "STRING", ?
+          "dataschema": ANY, ?
+          "dataschemauri": "URI", ?
+          "datacontenttype": "STRING", ?
 
           "metaurl": "URL",
           "meta": { ... }, ?
@@ -337,7 +338,7 @@ specification.
 - Examples:
   - See [Message protocols](#message-protocols)
 
-#### `schemaformat`
+#### `dataschemaformat`
 
 - Type: String
 - Description: Identifies the schema format applicable to the message payload,
@@ -354,34 +355,63 @@ specification.
   - 'Avro/1.9.0'
   - 'Protobuf/3'
 
-#### `schema`
+#### `dataschema`
 
 - Type: Any
 - Description: Contains the inline schema for the message payload. The schema
-  format is identified by the `schemaformat` attribute. Equivalent to the
+  format is identified by the `dataschemaformat` attribute. Equivalent to the
   schemaversion
   ['schema'](../schema/spec.md#schema) attribute
 - Constraints:
   - OPTIONAL.
-  - Mutually exclusive with the `schemauri` attribute.
-  - If present, `schemaformat` MUST be present.
+  - Mutually exclusive with the `dataschemauri` attribute.
+  - If present, `dataschemaformat` MUST be present.
 - Examples:
   - See [Schema Formats](../schema/spec.md#schema-formats)
 
-#### `schemauri`
+#### `dataschemauri`
 
 - Type: URI-reference
 - Description: Contains a relative or absolute URI that points to the schema
   object to use for the message payload. The schema format is identified by the
-  `schemaformat` attribute. See
+  `dataschemaformat` attribute. See
   [Schema Formats](../schema/spec.md#schema-formats) for details on
   how to reference specific schema objects for the message payload. It is not
   sufficient for the URI-reference to point to a schema document; it MUST
   resolve to a concrete schema object.
 - Constraints:
   - OPTIONAL.
-  - Mutually exclusive with the `schema` attribute.
-  - If present, `schemaformat` MUST be present.
+  - Mutually exclusive with the `dataschema` attribute.
+  - If present, `dataschemaformat` MUST be present.
+
+#### `datacontenttype`
+
+- Type: Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
+- Description: Content type of the message payload. This attribute MAY be
+  duplicative with some other metadata within the message definition. For
+  example, in the case of using CloudEvents, the `envelopemetadata` attribute
+  might include the `datacontenttype` attribute. This possible duplication
+  of data is expected so as to allow for a more consistent, and easy, discovery
+  of the message's format. This means that if this information does appear in
+  more than one location within the message metadata they MUST all have the
+  same values.
+
+  Note that when an `envelope` is defined for a message and the data of
+  interest is serialized as being nested within the envelope (e.g.
+  CloudEvents "structured" mode), then this attribute MUST be the content type
+  of the message envelope and not of the data nested within the envelope.
+
+  As specified in [RFC 2045](https://tools.ietf.org/html/rfc2045), the media
+  type part of the content type MUST be treated in a case-insensitive manner
+  by consumers, along with the attribute names in parameters. For example,
+  a `datacontenttype` of `text/plain; charset=utf-8` MUST be treated in the
+  same way as `TEXT/Plain; CharSet=utf-8`.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST adhere to the format specified in
+    [RFC 2046](https://tools.ietf.org/html/rfc2046)
+- For Media Type examples see
+  [IANA Media Types](http://www.iana.org/assignments/media-types/media-types.xhtml)
 
 ### Metadata Envelopes and Message Protocols
 
@@ -532,10 +562,11 @@ The following rules apply to the attribute declarations:
 - The `time` attribute's `value` defaults to `01-01-0000T00:00:00Z` ("current
   time") and SHOULD NOT be declared with a different value.
 - The `datacontenttype` attribute's `value` is inferred from the
-  [`schemaformat`](#schemaformat) attribute of the message definition if absent.
+  [`dataschemaformat`](#dataschemaformat) attribute of the message definition
+  if absent.
 - The `dataschema` attribute's `value` is inferred from the
-  [`schemauri`](#schemauri) attribute or
-  [`schema`](#schema) attribute of the message definition if
+  [`dataschemauri`](#dataschemauri) attribute or
+  [`dataschema`](#dataschema) attribute of the message definition if
   absent.
 - The `type` of the property definition defaults to the CloudEvents type
   definition for the attribute, if any. The `type` of an attribute MAY be
@@ -620,8 +651,8 @@ CloudEvents base specification. The implied `datacontenttype` is
       "required": true
     },
   },
-  "schemaformat": "JsonSchema/draft-07",
-  "schemauri": "https://example.com/schemas/com.example.myevent.json",
+  "dataschemaformat": "JsonSchema/draft-07",
+  "dataschemauri": "https://example.com/schemas/com.example.myevent.json",
 }
 ```
 
@@ -679,14 +710,17 @@ The following example defines a message that is sent over HTTP/1.1:
         "value": "application/json"
       }
     ],
-    "query": {
-      "foo": "bar"
-    },
+    "query": [
+      {
+        "name": "foo",
+        "value": "bar"
+      }
+    ],
     "path": "/foo/{bar}",
     "method": "POST"
   },
-  "schemaformat": "JsonSchema/draft-07",
-  "schemauri": "https://example.com/schemas/com.example.myevent.json",
+  "dataschemaformat": "JsonSchema/draft-07",
+  "dataschemauri": "https://example.com/schemas/com.example.myevent.json",
 }
 ```
 

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -403,7 +403,7 @@ the schema Resource is a JSON object representing a JSON Schema document
 conformant with the declared version.
 
 A URI-reference, like
-[`schemauri`](../message/spec.md#schemauri) that points
+[`schemauri`](../message/spec.md#dataschemauri) that points
 to a JSON Schema document MAY use a JSON pointer expression to deep link into
 the schema document to reference a particular type definition. Otherwise the
 top-level object definition of the schema is used.
@@ -440,7 +440,7 @@ schema Resource is a string containing an XML Schema document conformant with
 the declared version.
 
 A URI-reference, like
-[`schemauri`](../message/spec.md#schemauri) that points
+[`schemauri`](../message/spec.md#dataschemauri) that points
 to a XSD Schema document MAY use an XPath expression to deep link into the
 schema document to reference a particular type definition. Otherwise the root
 element definition of the schema is used.
@@ -471,7 +471,7 @@ Examples:
 - `Avro/1.11.0` is the identifier for the Apache Avro release 1.11.0
 
 A URI-reference, like
-[`schemauri`](../message/spec.md#schemauri) that points
+[`schemauri`](../message/spec.md#dataschemauri) that points
 to an Avro Schema document MUST reference an Avro record declaration contained
 in the schema document using a URI fragment suffix `[:]{record-name}`. The ':'
 character is used as a separator when the URI already contains a fragment.
@@ -501,7 +501,7 @@ with the declared version.
 - `Protobuf/2` is the identifier for the Protobuf syntax version 2.
 
 A URI-reference, like
-[`schemauri`](../message/spec.md##schemauri that points
+[`schemauri`](../message/spec.md#dataschemauri that points
 to an Protobuf Schema document MUST reference an Protobuf `message` declaration
 contained in the schema document using a URI fragment suffix
 `[:]{message-name}`. The ':' character is used as a separator when the URI

--- a/tools/dict
+++ b/tools/dict
@@ -36,6 +36,8 @@ createdby
 crlf
 datacontenttype
 dataschema
+dataschemaformat
+dataschemauri
 datastore
 datatracker
 datetime
@@ -74,6 +76,7 @@ html
 http
 https
 hxregistry
+iana
 ietf
 ifvalues
 img
@@ -165,7 +168,6 @@ resourceurl
 resultset
 rfc
 rid
-schemaformat
 schemagroup
 schemagroupid
 schemagroups
@@ -232,6 +234,7 @@ willtopic
 wip
 wss
 www
+xhtml
 xml
 xmlschema
 xpath


### PR DESCRIPTION
- message model fixes/missing attributes
- make ?inline=* exclude 'model' by default. Need to use 'model' explicitly
- fix some uri vs url inconsistencies
  - "endpoint.protocoloptions.authorization.resourceurl" ->
    "endpoint.protocoloptions.authorization.resourceuri"
  - "endpoint.protocoloptions.endpoint.uri" ->
    "endpoint.protocoloptions.endpoint.url"
- Add text about unique messageid values in Endpoints
- Add some clarifying text around `channel`
- Add 'datacontenttype' to message def
- Add 'data" prefix to message's: schemaformat, schema and schemauri
- require `datacontenttype` to match any other "content-type" type of field that might convey the same info - e.g. under CE envelope metadata
- regen schemas

Fixes #19
Fixed #186 
Fixes #172
Fixes #146
Fixed #14