### PR TITLE
Changes for week of Nov 18

### DIFF
--- a/core/primer.md
+++ b/core/primer.md
@@ -307,6 +307,37 @@ points worth noting:
   Version isn't being deleted. Note that a `404` in the `DELETE .../ID` case
   is an error and no changes to the "default" Version will occur.
 
+### Detection of Referenced Resources
+
+The xRegistry specification allows for Resources to appear in multiple Groups
+via use of the `xref` feature. This could lead to situations where a user
+deletes a Resource without knowing that other Resources reference it -
+resulting in "dangling pointers". The specification does not define any
+mechanism by which a user can determine if a Resource is the target of an
+`xref`, or how many other Resources might reference it, in order to avoid
+this situation. However, implementations may choose to take some action to
+help users if they wish. For example, provide some kind of "warning" of the
+impending "dangling pointer" state prior to doing the delete, or providing
+some kind of "xref counter" extension on the target Resource. The specification
+might consider adding some feature to address this in the future, but as of now
+it is left as an implementation choice.
+
+### Shared/Referenced Resources
+
+As discussed above, Resource may appear in multiple Groups via use of the
+`xref` feature. Users of the Registry may wish to consider how best to manage
+these "shared" Resources within their associated Groups. For example, if a
+Resource might be removed from any of the Groups it is a member of, then it
+might be best to create a dedicated "shared resources" type of Group so that
+it can have a lifecycle that is independent of its association of any other
+Group. Similarly, choosing an initial Group for the Resource could be a
+critical decision as it can not be changed later on, and that Group ID will
+be part of the Resource's unique identifier forever.
+
+Additionally, how the implementation of the xRegistry manages
+access-control-rights of Resources (often via Groups) might influence the
+initial placement into a Group of a new Resource.
+
 # Default Version and Maximum Versions
 
 Each Resource type can specify the maximum number of Versions that the

--- a/core/spec.md
+++ b/core/spec.md
@@ -1906,6 +1906,8 @@ The following describes the attributes of Registry model:
     level, are active at the same time then there MUST NOT be duplicate
     `ifvalues` attributes names between those `ifvalues` sections.
   - `ifvalues` `"VALUE"` MUST NOT be an empty string.
+  - `ifvalues` `"VALUE"` MUST NOT start with the `^` (carrot) character as its
+    presence at the beginning of `"VALUE"` is reserved for future use.
   - `ifvalues` `siblingattributes` MAY include additional `ifvalues`
     definitions.
   - Type: Map where each value of the attribute is the key of the map.
@@ -5034,19 +5036,27 @@ inline[=PATH[,...]]
 
 Where `PATH` is a string indicating which inlinable attributes to show in
 in the response. References to nested attributes are represented using a
-dot(`.`) notation - for example `GROUPS.RESOURCES`. To reference an attribute
-with a dot as part of its name, the JSON PATH escaping mechanism MUST be
-used: `['my.name']`. For example, `prop1.my.name.prop2` would be specified
-as `prop1['my.name'].prop2` if `my.name` is the name of one attribute.
+dot(`.`) notation where the xRegistry collections names along the hierarchy
+are concatenated. For example: `endpoints.messages.versions` will inline all
+Versions of Messages. Non-leaf parts of the `PATH` MUST only reference
+xRegistry collection names and not any specific entity IDs since `PATH` is
+meant to be an abstract traversal of the model.
+
+To reference an attribute with a dot as part of its name, the JSON PATH
+escaping mechanism MUST be used: `['my.name']`. For example,
+`prop1.my.name.prop2` would be specified as `prop1['my.name'].prop2` if
+`my.name` is the name of one attribute.
 
 There MAY be multiple `PATH`s specified, either as comma separated values on
 a single `?inline` query parameter or via multiple `?inline` query parameters.
 
-Absence of a `PATH`, or a `PATH` attribute with a value of `*` indicates that
-all nested inlinable attributes at that level in the hierarchy (and below)
-MUST be inlined. Use of `*` MUST only be used as the last attribute name
-(in its entirety) in the `PATH`. For example, `foo*`, or `*.foo` are not
-valid `PATH`s, but `*` and `endpoints.*` are.
+The `*` value MAY be used to indicate that all nested inlinable attributes
+at that level in the hierarchy (and below) MUST be inlined. Use of `*` MUST
+only be used as the last part of the `PATH` (in its entirety). For example,
+`foo*` and `*.foo` are not valid `PATH` values, but `*` and `endpoints.*` are.
+
+An `?inline` query parameter without any value MAY be supported and if so it
+MUST have the same semantic meaning as `?inline=*`.
 
 The specific value of `PATH` will vary based on where the request is directed.
 For example, a request to the root of the Registry MUST start with a `GROUPS`

--- a/core/spec.md
+++ b/core/spec.md
@@ -548,11 +548,28 @@ of the existing entity. Then the existing entity can be deleted.
   differs from the existing value. A value of `null` MUST be treated the same
   as a request with no `epoch` attribute at all.
 
-  Versions do not have their own `epoch` values that are separate from their
-  owning Resource's value. Updating a Resource or any of its Versions will
-  update the shared Resource `epoch` value for all of those entities. This
-  means that concurrent updates to different Versions of the same Resource
-  might result in an epoch validation error for the second update request.
+  The semantics of `epoch` are the same as the semantics of the
+  [HTTP ETag](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3)
+  and
+  [HTTP If-Match](https://datatracker.ietf.org/doc/html/rfc9110#section-13.1.1)
+  Headers, and as such the following rules apply when using HTTP as the
+  protocol:
+  - When the response body references a single entity, its `epoch` value MUST
+    also appear as an HTTP `ETag` header. Note that a response body with a
+    map or array that only includes one entity does not satisfy this
+    requirement.
+  - When the xRegistry metadata of a Resource, or Version, is serialized as
+    HTTP headers, and prefixed with `xRegistry-`, the `xRegistry-epoch` header
+    MUST NOT be present since the `ETag` header MUST already be present with
+    the value.
+  - When a request includes an HTTP `If-Match` header, then its value MUST
+    match the existing entity's `epoch` value. And if not, a
+    `412 Precondition Failed` error MUST be generated. Note, that `*` MUST
+    match all possible `epoch` value, but will fail if the entity does not
+    already exist (per the HTTP specification).
+  - The `If-Match` verification MUST be done in addition to the `epoch`
+    checking specified above. In other words, a present but non-matching value
+    in either location MUST generate an error.
 - Constraints:
   - MUST be an unsigned integer equal to or greater than zero.
   - MUST increase in value each time the entity is updated.
@@ -959,6 +976,7 @@ update a Message where the `defaultversionid` is `v1`:
 
 ```yaml
 PUT http://example.com/endpoints/ep1/messages/msg1?nested
+
 {
   "messageid": "msg1",
   "versionid": "v1",
@@ -1336,6 +1354,7 @@ A successful response MUST be of the form:
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "UINTEGER"
 
 {
   "specversion": "STRING",
@@ -1370,6 +1389,7 @@ GET /
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "1"
 
 {
   "specversion": "0.5",
@@ -1397,6 +1417,7 @@ GET /?inline=schemagroups,model
 
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "1"
 
 {
   "specversion": "0.5",
@@ -1477,6 +1498,7 @@ PUT /[?nested]
 or
 PATCH /[?nested]
 Content-Type: application/json; charset=utf-8
+If-Match: "UINTEGER|*" ?
 
 {
   "registryid": "STRING", ?
@@ -1517,6 +1539,7 @@ on the Registry would return, and be of the form:
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "UINTEGER"
 
 {
   "specversion": "STRING",
@@ -1557,6 +1580,7 @@ Content-Type: application/json; charset=utf-8
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "2"
 
 {
   "specversion": "0.5",
@@ -1906,7 +1930,7 @@ The following describes the attributes of Registry model:
     level, are active at the same time then there MUST NOT be duplicate
     `ifvalues` attributes names between those `ifvalues` sections.
   - `ifvalues` `"VALUE"` MUST NOT be an empty string.
-  - `ifvalues` `"VALUE"` MUST NOT start with the `^` (carrot) character as its
+  - `ifvalues` `"VALUE"` MUST NOT start with the `^` (caret) character as its
     presence at the beginning of `"VALUE"` is reserved for future use.
   - `ifvalues` `siblingattributes` MAY include additional `ifvalues`
     definitions.
@@ -2751,6 +2775,7 @@ A successful response MUST be of the form:
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Link: <URL>;rel=next;count=UINTEGER ?
+ETag: "UINTEGER"
 
 {
   "KEY": {                                     # GROUPid
@@ -2955,6 +2980,7 @@ A successful response MUST be of the form:
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "UINTEGER"
 
 {
   "GROUPid": "STRING",
@@ -2986,6 +3012,7 @@ GET /endpoints/ep1
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "1"
 
 {
   "GROUPid": "ep1",
@@ -4131,6 +4158,7 @@ Update default Version of a Resource as xRegistry metadata:
 ```yaml
 PUT /endpoints/ep1/messages/msg1$structure
 Content-Type: application/json; charset=utf-8
+ETag: "1"
 
 {
   "epoch": 1,
@@ -4147,6 +4175,7 @@ Content-Type: application/json; charset=utf-8
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/1.0
+ETag: "2"
 
 {
   "messageid": "msg1",
@@ -4306,6 +4335,7 @@ A successful response MUST be of the form:
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Location: URL ?
+ETag: "UINTEGER"
 
 {
   "RESOURCEid": "STRING",
@@ -4370,6 +4400,7 @@ GET /endpoints/ep1/messages/msg1$structure
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/1.0
+ETag: "1"
 
 {
   "messageid": "msg1",
@@ -4898,6 +4929,7 @@ A successful response MUST be of the form:
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "UINTEGER"
 
 {
   "RESOURCEid": "STRING",
@@ -4936,6 +4968,7 @@ GET /endpoints/ep1/messages/msg1/versions/1.0$structure
 ```yaml
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "2"
 
 {
   "messageid": "msg1",
@@ -5036,13 +5069,13 @@ inline[=PATH[,...]]
 
 Where `PATH` is a string indicating which inlinable attributes to show in
 in the response. References to nested attributes are represented using a
-dot(`.`) notation where the xRegistry collections names along the hierarchy
+dot (`.`) notation where the xRegistry collections names along the hierarchy
 are concatenated. For example: `endpoints.messages.versions` will inline all
 Versions of Messages. Non-leaf parts of the `PATH` MUST only reference
 xRegistry collection names and not any specific entity IDs since `PATH` is
 meant to be an abstract traversal of the model.
 
-To reference an attribute with a dot as part of its name, the JSON PATH
+To reference an attribute with a dot as part of its name, the JSONPath
 escaping mechanism MUST be used: `['my.name']`. For example,
 `prop1.my.name.prop2` would be specified as `prop1['my.name'].prop2` if
 `my.name` is the name of one attribute.
@@ -5144,17 +5177,17 @@ The format of `EXPRESSION` is:
 ```
 
 Where:
-- `PATH` MUST be a dot(`.`) notation traversal of the Registry to the entity
+- `PATH` MUST be a dot (`.`) notation traversal of the Registry to the entity
   of interest, or absent if at the top of the Registry request. Note that
   the `PATH` value is based on the requesting URL and not the root of the
   Registry. See the examples below. To reference an attribute with a dot as
-  part of its name, the JSON PATH escaping mechanism MUST be used:
+  part of its name, the JSONPath escaping mechanism MUST be used:
   `['my.name']`. For example, `prop1.my.name.prop2` would be specified as
   `prop1['my.name'].prop2` if `my.name` is the name of one attribute.
 - `PATH` MUST only consist of valid `GROUPS`, `RESOURCES` or `versions`,
   otherwise an error MUST be generated.
 - `ATTRIBUTE` MUST be the attribute in the entity to be examined.
-- Complex attributes (e.g. `labels`) MUST use dot(`.`) to reference nested
+- Complex attributes (e.g. `labels`) MUST use dot (`.`) to reference nested
   attributes. For example: `labels.stage=dev` for a filter.
 - A reference to a nonexistent attribute SHOULD NOT generate an error and
   SHOULD be treated the same as a non-matching situation.

--- a/tools/dict
+++ b/tools/dict
@@ -92,6 +92,7 @@ javadoc
 json
 jsonschema
 keyname
+lifecycle
 linkproperties
 maxversions
 messagegroupid

--- a/tools/dict
+++ b/tools/dict
@@ -90,6 +90,7 @@ interoperable
 isdefault
 javadoc
 json
+jsonpath
 jsonschema
 keyname
 lifecycle


### PR DESCRIPTION
- Allow for ?inline (same as ?inline=*) and clarify the text a bit
- Don't allow `^` in ifvalue "VALUE" - we'll use this for regexp detection in the future
- Add text in the Primer about xref and how deleting the targets might result in dangling pointers - impl choice if they want to do something about it
- And provide some guidance on choosing proper groups for resources
- Add ETag/If-Match semantics (leveraging `epoch` value)

Fixes: #25
Fixes: #135