### PR TITLE
Changes for week of Jan13

### DIFF
--- a/schema/model.json
+++ b/schema/model.json
@@ -28,13 +28,6 @@
             }
           },
           "metaattributes": {
-            "compatibility": {
-              "name": "compatibility",
-              "type": "string",
-              "enum": [ "none", "backward", "backward_transitive", "forward",
-                        "forward_transitive", "full", "full_transitive" ],
-              "default": "backward"
-            },
             "validation": {
               "name": "validation",
               "type": "boolean",


### PR DESCRIPTION
- typo and wording clarifications in main spec
- remove duplicate "compatibility" in schema, it's part of core attributes now
- replaced `?export` with `?compact` and just removes the dup info. Any
  inlining would need to be requested by the client
- defined `/export` to be `/?compact&inline=*,model,capabilities`
- remove ?nested
- tweaks valid chars for ID: `[a-zA-Z0-9_][a-zA-Z0-9_.\-~@]{0,127}`
- IDs must be no longer than 128 chars
- s/$structure/$details/g

Fixes: https://github.com/xregistry/spec/issues/234
Fixes: https://github.com/xregistry/spec/issues/233
Fixes: https://github.com/xregistry/spec/issues/232
Fixes: https://github.com/xregistry/spec/issues/220
Fixes: https://github.com/xregistry/spec/issues/229
Fixes: https://github.com/xregistry/spec/issues/224
Fixes: https://github.com/xregistry/spec/issues/237