### PR TITLE
Changes for week of Jan 20

### DIFF
--- a/message/spec.md
+++ b/message/spec.md
@@ -79,6 +79,13 @@ this form:
           "createdat": "TIMESTAMP",
           "modifiedat": "TIMESTAMP",
 
+          "deprecated": {
+            "effective": "TIMESTAMP", ?
+            "removal": "TIMESTAMP", ?
+            "alternative": "URL", ?
+            "docs": "URL"?
+          }, ?
+
           "basemessageurl": "URL", ?           # Message being extended
 
           "envelope": "STRING", ?              # e.g. CloudEvents/1.0
@@ -237,6 +244,50 @@ the look-up value (id) of messages with their related events.
 The following extensions are defined for the `message` Resource in addition to
 the core xRegistry Resource
 [attributes](../core/spec.md#attributes-and-extensions):
+
+#### `deprecated`
+
+- Type: Object containing the following properties:
+  - `effective`<br>
+    An OPTIONAL property indicating the time when the message entered, or will
+    enter, a deprecated state. The date MAY be in the past or future. If this
+    property is not present the message is already in a deprecated state.
+    If present, this MUST be an [RFC3339][rfc3339] timestamp.
+
+  - `removal`<br>
+    An OPTIONAL property indicating the time when the message MAY be removed.
+    The message MUST NOT be removed before this time. If this property is not
+    present then client can not make any assumption as to when the message
+    might be removed. Note: as with most properties, this property is mutable.
+    If present, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT be
+    sooner than the `effective` time if present.
+
+  - `alternative`<br>
+    An OPTIONAL property specifying the URL to an alternative message the
+    client can consider as a replacement for this message. There is no
+    guarantee that the referenced message is an exact replacement, rather the
+    client is expected to investigate the message to determine if it is
+    appropriate.
+
+  - `docs`<br>
+    An OPTIONAL property specifying the URL to additional information about
+    the deprecation of the message. This specification does not mandate any
+    particular format or information, however some possibilities include:
+    reasons for the deprecation or additional information about likely
+    alternative message. The URL MUST support an HTTP GET request.
+
+  Note that an implementation is not mandated to use this attribute in
+  advance of removing an message, but is it RECOMMENDED that they do so.
+- Constraints:
+  - OPTIONAL
+- Examples:
+  - `"deprecated": {}`
+  - ```
+    "deprecated": {
+      "removal": "2030-12-19T00:00:00-00:00",
+      "alternative": "https://example.com/messages/popped"
+    }
+    ```
 
 #### `basemessageurl`
 

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -71,6 +71,13 @@ this form:
           "createdat": "TIMESTAMP",
           "modifiedat": "TIMESTAMP",
 
+          "deprecated": {
+            "effective": "TIMESTAMP", ?
+            "removal": "TIMESTAMP", ?
+            "alternative": "URL", ?
+            "docs": "URL"?
+          }, ?
+
           "format": "STRING", ?
 
           "schemaurl": "URL", ?
@@ -293,6 +300,50 @@ the core xRegistry Resource
   - When not specified, the default value is `true`.
   - MUST be a Resource level attribute defined within the `metaattributes`
     section of the model.
+
+#### `deprecated`
+
+- Type: Object containing the following properties:
+  - `effective`<br>
+    An OPTIONAL property indicating the time when the schema entered, or will
+    enter, a deprecated state. The date MAY be in the past or future. If this
+    property is not present the schema is already in a deprecated state.
+    If present, this MUST be an [RFC3339][rfc3339] timestamp.
+
+  - `removal`<br>
+    An OPTIONAL property indicating the time when the schema MAY be removed.
+    The schema MUST NOT be removed before this time. If this property is not
+    present then client can not make any assumption as to when the schema
+    might be removed. Note: as with most properties, this property is mutable.
+    If present, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT be
+    sooner than the `effective` time if present.
+
+  - `alternative`<br>
+    An OPTIONAL property specifying the URL to an alternative schema the
+    client can consider as a replacement for this schema. There is no
+    guarantee that the referenced schema is an exact replacement, rather the
+    client is expected to investigate the schema to determine if it is
+    appropriate.
+
+  - `docs`<br>
+    An OPTIONAL property specifying the URL to additional information about
+    the deprecation of the schema. This specification does not mandate any
+    particular format or information, however some possibilities include:
+    reasons for the deprecation or additional information about likely
+    alternative schema. The URL MUST support an HTTP GET request.
+
+  Note that an implementation is not mandated to use this attribute in
+  advance of removing an schema, but is it RECOMMENDED that they do so.
+- Constraints:
+  - OPTIONAL
+- Examples:
+  - `"deprecated": {}`
+  - ```
+    "deprecated": {
+      "removal": "2030-12-19T00:00:00-00:00",
+      "alternative": "https://example.com/schema/myschema"
+    }
+    ```
 
 #### `format`
 

--- a/tools/dict
+++ b/tools/dict
@@ -112,6 +112,7 @@ metaschema
 metaschemas
 metaurl
 middleware
+modelversion
 modifiedat
 modifiedby
 monotomically
@@ -189,6 +190,7 @@ serverrequired
 setdefaultversionid
 setdefaultversionsticky
 setversionid
+sharedschema
 shortself
 shorturl
 siblingattributes


### PR DESCRIPTION
- Misc typos/clean-up
- Require `target` to NOT point to a model entity that uses `ximport`.
  Meaning, `target` is not transitive - to keep things simple.
- Tweak usage of `target`. Can be on any relative URL/URI, and if value starts
  with `/` then it must match the xid template. Similar for `relation` but
  `relation` must be an xid... but `target` is optional for all types.
- Add "deprecated" to messages and schemas
- define "xref" as a "relation" type with "target"="self-xid"
- add "modelversion" as a model label
- make ?compact convert self, COLLECTONSurl, defaultverionurl into relative
  URLs if they're part of the response
- mandate that all relative URLs start with "/" and they're relative to the
  root path of the Registry
- ban model changes that turn on hasDoc if Resources have RESOURCE* attribute
  extension names

Fixes: https://github.com/xregistry/spec/issues/236
Fixes: https://github.com/xregistry/spec/issues/226
Fixes: https://github.com/xregistry/spec/issues/227
Fixes: https://github.com/xregistry/spec/issues/189
Fixes: https://github.com/xregistry/spec/issues/238
