### PR TITLE
Week of Feb 24

### DIFF
--- a/core/model.json
+++ b/core/model.json
@@ -5,7 +5,8 @@
       "type": "string",
       "readonly": true,
       "immutable": true,
-      "serverrequired": true
+      "serverrequired": true,
+      "default": "0.5"
     },
     "registryid": {
       "name": "registryid",

--- a/core/sample-model.json
+++ b/core/sample-model.json
@@ -5,7 +5,8 @@
       "type": "string",
       "readonly": true,
       "immutable": true,
-      "serverrequired": true
+      "serverrequired": true,
+      "default": "0.5"
     },
     "registryid": {
       "name": "registryid",
@@ -96,6 +97,8 @@
         "isdefault": {
           "name": "isdefault",
           "type": "boolean"
+          "serverrequired": true,
+          "default": false
         },
         "description": {
           "name": "description",
@@ -227,17 +230,16 @@
               "name": "readonly",
               "type": "boolean",
               "readonly": true
+              "serverrequired": true,
+              "default": false
             },
             "compatibility": {
               "name": "compatibility",
               "type": "string",
               "enum": [ "none", "backward", "backward_transitive", "forward",
                         "forward_transitive", "full", "full_transitive" ]
-            },
-            "defaultversionsticky": {
-              "name": "defaultversionsticky",
-              "type": "boolean",
-              "serverrequired": true
+              "serverrequired": true,
+              "default": "none"
             },
             "defaultversionid": {
               "name": "defaultversionid",
@@ -248,7 +250,13 @@
               "name": "defaultversionurl",
               "type": "url",
               "readonly": true,
-              "serverrequired": true
+              "serverrequired": true,
+            }
+            "defaultversionsticky": {
+              "name": "defaultversionsticky",
+              "type": "boolean",
+              "serverrequired": true,
+              "default": false
             }
           }
         }

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -181,7 +181,7 @@ To create a new release:
   any potential noteworthy activities of the group:
   - Send it to the mailing list
   - Announce the release on our
-    [twitter account](http://twitter.com/xregistryio)
+    [twitter account](https://twitter.com/xregistryio)
   - Add it to the "announcement" section of our
     [website](https://xregistry.io/)
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -16,6 +16,9 @@ Contributions do not constitute an official endorsement.
 - **Google**
   - Jon Skeet - [@jskeet](https://github.com/jskeet)
 
+- ** HDI Global SE**
+  - Manuel Ottlik - [@manuelottlik](https://github.com/manuelottlik)
+
 - **Microsoft**
   - Clemens Vasters - [@clemensv](https://github.com/clemensv)
 

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -164,7 +164,9 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
 
                     "node": {
@@ -175,7 +177,9 @@
                     "durable": {
                       "name": "durable",
                       "type": "boolean",
-                      "description": "The AMQP durable flag. Whether the node is durable or transient"
+                      "description": "The AMQP durable flag. Whether the node is durable or transient",
+                      "serverrequired": true,
+                      "default": false
                     },
                     "linkproperties": {
                       "name": "linkproperties",
@@ -196,11 +200,13 @@
                     "distributionmode": {
                       "name": "distributionmode",
                       "type": "string",
-                      "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
                       "enum": [
                         "move",
                         "copy"
-                      ]
+                      ],
+                      "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
+                      "serverrequired": true,
+                      "default": "move"
                     },
                     "*": {
                       "name": "*",
@@ -280,7 +286,9 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
 
                     "topic": {
@@ -291,17 +299,23 @@
                     "qos": {
                       "name": "qos",
                       "type": "uinteger",
-                      "description": "The MQTT QoS level. May be 0, 1, or 2"
+                      "description": "The MQTT QoS level. May be 0, 1, or 2",
+                      "serverrequired": true,
+                      "default": 0
                     },
                     "retain": {
                       "name": "retain",
                       "type": "boolean",
-                      "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                      "description": "The MQTT retain flag to use for publishers on ths endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
                     "cleansession": {
                       "name": "cleansession",
                       "type": "boolean",
-                      "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                      "description": "The MQTT clean session flag to use for publishers on this endpoint",
+                      "serverrequired": true,
+                      "default": true
                     },
                     "willtopic": {
                       "name": "willtopic",
@@ -391,7 +405,9 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
 
                     "topic": {
@@ -402,17 +418,23 @@
                     "qos": {
                       "name": "qos",
                       "type": "uinteger",
-                      "description": "The MQTT QoS level. May be 0, 1, or 2"
+                      "description": "The MQTT QoS level. May be 0, 1, or 2",
+                      "serverrequired": true,
+                      "default": 0
                     },
                     "retain": {
                       "name": "retain",
                       "type": "boolean",
-                      "description": "The MQTT retain flag to use for publishers on ths endpoint"
+                      "description": "The MQTT retain flag to use for publishers on ths endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
                     "cleansession": {
                       "name": "cleansession",
                       "type": "boolean",
-                      "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                      "description": "The MQTT clean session flag to use for publishers on this endpoint",
+                      "serverrequired": true,
+                      "default": true
                     },
                     "willtopic": {
                       "name": "willtopic",
@@ -502,13 +524,17 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
 
                     "method": {
                       "name": "method",
                       "type": "string",
-                      "description": "The HTTP method name"
+                      "description": "The HTTP method name",
+                      "serverrequired": true,
+                      "default": "POST"
                     },
                     "headers": {
                       "name": "headers",
@@ -620,7 +646,9 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
 
                     "topic": {
@@ -633,7 +661,9 @@
                     "acks": {
                       "name": "acks",
                       "type": "integer",
-                      "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                      "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1",
+                      "serverrequired": true,
+                      "default": 1
                     },
                     "key": {
                       "name": "key",
@@ -736,7 +766,9 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
+                      "serverrequired": true,
+                      "default": false
                     },
 
                     "subject": {

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -96,36 +96,36 @@ this form:
         "deployed": BOOLEAN, ?
 
         # "HTTP" protocol options
-        "method": "STRING", ?                          # default: POST
+        "method": "STRING", ?                          # Default: POST
         "headers": [ { "name": "STRING", "value": "STRING" } * ], ?
         "query": { "STRING": "STRING" * } ?
 
         # "AMQP/1.0" protocol options
         "node": "STRING", ?
-        "durable": BOOLEAN, ?                          # default: false
+        "durable": BOOLEAN, ?                          # Default: false
         "linkproperties": { "STRING": "STRING" * }, ?
         "connectionproperties": { "STRING": "STRING" * }, ?
-        "distributionmode": "move" | "copy" ?          # default: "move"
+        "distributionmode": "move" | "copy" ?          # Default: move
 
         # "MQTT/3.1.1" protocol options
         "topic": "STRING", ?
-        "qos": UINTEGER, ?                             # default: 0
-        "retrain": BOOLEAN, ?                          # default: false
-        "cleansession": BOOLEAN, ?                     # default: true
+        "qos": UINTEGER, ?                             # Default: 0
+        "retain": BOOLEAN, ?                           # Default: false
+        "cleansession": BOOLEAN, ?                     # Default: true
         "willtopic": "STRING", ?
         "willmessage": "STRING" ?
 
         # "MQTT/5.0" protocol options
         "topic": "STRING", ?
-        "qos": UINTEGER, ?                             # default: 0
-        "retrain": BOOLEAN, ?                          # default: false
-        "cleansession": BOOLEAN, ?                     # default: true
+        "qos": UINTEGER, ?                             # Default: 0
+        "retain": BOOLEAN, ?                           # Default: false
+        "cleansession": BOOLEAN, ?                     # Default: true
         "willtopic": "STRING", ?
         "willmessage": "STRING" ?
 
         # "KAFKA" protocol options
         "topic": "STRING", ?
-        "acks": INTEGER, ?                             # default: 1
+        "acks": INTEGER, ?                             # Default: 1
         "key": "STRING", ?
         "partition": INTEGER, ?
         "consumergroup": "STRING", ?
@@ -306,7 +306,7 @@ The following attributes are defined for Endpoints:
   string or excluded from the serialization entirely.
 - Constraints:
   - OPTIONAL
-  - If present, MUST be a string
+  - When specified, the value MUST be a non-empty string
 - Examples:
   - `queue1`
 
@@ -317,15 +317,15 @@ The following attributes are defined for Endpoints:
     An OPTIONAL property indicating the time when the Endpoint entered, or will
     enter, a deprecated state. The date MAY be in the past or future. If this
     property is not present the Endpoint is already in a deprecated state.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp.
+    When specified, this MUST be an [RFC3339][rfc3339] timestamp.
 
   - `removal`<br>
     An OPTIONAL property indicating the time when the Endpoint MAY be removed.
     The Endpoint MUST NOT be removed before this time. If this property is not
     present then client can not make any assumption as to when the Endpoint
     might be removed. Note: as with most properties, this property is mutable.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT be
-    sooner than the `effective` time if present.
+    When specified, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT
+    be sooner than the `effective` time.
 
   - `alternative`<br>
     An OPTIONAL property specifying the URL to an alternative Endpoint the
@@ -409,10 +409,10 @@ This specification defines the following envelope options for the indicated
 - `mode` : indicates whether the CloudEvent generated will use `binary` or
   `structured`
   (mode)[https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message].
-  If present, its value MUST be one of: `binary` or `structured`. When not
-  present, the endpoint is indicating that either mode is acceptable.
+  When specified, its value MUST be one of: `binary` or `structured`. When not
+  specified, the endpoint is indicating that either mode is acceptable.
 - `format` : indicates the format of the CloudEvent when sent in `structured`
-  mode. This attribute MUST NOT be present when `mode` is `binary`. The value
+  mode. This attribute MUST NOT be specified when `mode` is `binary`. The value
   used MUST match the expected content type of the message (e.g. for HTTP the
   `Content-Type` header value).
 
@@ -477,7 +477,7 @@ TODO merge this into the previous 'protocol' section
   additional protocol names.
 
   Predefined protocols are referred to by name and version as
-  `{NAME}/{VERSION}`. If the version is not specified, the default version of
+  `{NAME}/{VERSION}`. When the version is not specified, the default version of
   the protocol is assumed. The version number format is determined by the
   protocol specification's usage of versions.
 
@@ -541,7 +541,7 @@ TODO merge this into the previous 'protocol' section
 
 - Type: Map
 - Description: OPTIONAL authorization configuration details of the endpoint.
-  When present, the authorization configuration MUST be a map of non-empty
+  When specified, the authorization configuration MUST be a map of non-empty
   strings to non-empty strings. The configuration keys below MUST be used as
   defined. Additional, endpoint-specific configuration keys MAY be added.
 
@@ -604,7 +604,7 @@ TODO merge this into the previous 'protocol' section
   the liveness of the endpoint.
 - Constraints:
   - OPTIONAL.
-  - Default value is `false`.
+  - When not specified, the default value is MUST be `false`.
 
 #### `protocoloptions.options`
 
@@ -614,7 +614,7 @@ TODO merge this into the previous 'protocol' section
   [protocol options](#protocol-options) section below.
 - Constraints:
   - OPTIONAL
-  - When present, MUST be a map of non-empty strings to `ANY` type values.
+  - When specified, MUST be a map of non-empty strings to `ANY` type values.
   - If `protocoloptions.protocol` is a well-known protocol, the options MUST be
     compliant with the [protocol's options](#protocol-options).
 
@@ -710,8 +710,9 @@ valid HTTP URIs using the "http" or "https" scheme.
 
 The following options are defined for HTTP:
 
-- `method`: The HTTP method to use for the endpoint. The default value is
-  `POST`. The value MUST be a valid HTTP method name.
+- `method`: The HTTP method to use for the endpoint.
+  - When not specified the default value MUST be `POST`.
+  - The value MUST be a valid HTTP method name.
 - `headers`: An array of HTTP headers to use for the endpoint. HTTP allows for
   duplicate headers. The objects in the array have the following attributes:
   - `name`: The name of the HTTP header. The value MUST be a non-empty string.
@@ -753,19 +754,22 @@ URI is present, it MUST be a valid AMQP node name.
 The following options are defined for AMQP endpoints.
 
 - `node`: The name of the AMQP node (a queue or topic or some addressable
-  entity) to use for the endpoint. If present, the value overrides the path
-  portion of the Endpoint URI.
-- `durable`: If `true`, the AMQP `durable` flag is set on transfers. The default
-  value is `false`. This option only applies to `usage:producer` endpoints.
-- `linkproperties`: A map of AMQP link properties to use for the endpoint. The
-  value MUST be a map of non-empty strings to non-empty strings.
+  entity) to use for the endpoint.
+  - When specified, the value overrides the path portion of the Endpoint URI.
+- `durable`: If `true`, the AMQP `durable` flag is set on transfers.
+  - When not specified, the default value MUST be `false`.
+  - This option only applies to `usage:producer` endpoints.
+- `linkproperties`: A map of AMQP link properties to use for the endpoint.
+  - The value MUST be a map of non-empty strings to non-empty strings.
 - `connection-properties`: A map of AMQP connection properties to use for the
-  endpoint. The value MUST be a map of non-empty strings to non-empty strings.
-- `distribution-mode`: Either `move` or `copy`. The default value is `move`. The
-  distribution mode is AMQP's way of expressing whether a receiver operates on
-  copies of messages (it's a topic subscriber) or whether it moves messages from
-  the queue (it's a queue consumer). This option only applies to
-  `usage:consumer` endpoints.
+  endpoint.
+  - The value MUST be a map of non-empty strings to non-empty strings.
+- `distributionmode`: Either `move` or `copy`.
+  - When not specified, the default value MUST be `move`.
+  - The distribution mode is AMQP's way of expressing whether a receiver
+    operates on copies of messages (it's a topic subscriber) or whether it
+    moves messages from the queue (it's a queue consumer). This option only
+    applies to `usage:consumer` endpoints.
 
 The values of all `linkproperties` and `connection-properties` MAY contain
 placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the
@@ -787,7 +791,7 @@ Example:
     "connection-properties": {
       "my-connection-property": "my-connection-property-value"
     },
-    "distribution-mode": "move"
+    "distributionmode": "move"
   }
 }
 ```
@@ -802,25 +806,31 @@ schemes "tcp" (plain TCP/1883), "ssl" (TLS TCP/8883), and "wss"
 
 The following options are defined for MQTT endpoints.
 
-- `topic`: The MQTT topic to use for the endpoint. If present, the value
-  overrides the path portion of the Endpoint URI. The value MAY contain
-  placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax
-- `qos`: The MQTT Quality of Service (QoS) level to use for the endpoint. The
-  value MUST be an integer between 0 and 2. The default value is 0. The value is
-  overidden by the `qos` property of the
-  [MQTT message format](../message/spec.md#mqtt311-and-mqtt50-protocols).
-- `retain`: If `true`, the MQTT `retain` flag is set on transfers. The default
-  value is `false`. The value is overidden by the `retain` property of the [MQTT
-  message format](../message/spec.md#mqtt311-and-mqtt50-protocols). This
-  option only applies to `usage:producer` endpoints.
+- `topic`: The MQTT topic to use for the endpoint.
+  - When specified, the value overrides the path portion of the Endpoint URI.
+  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
+    URI Template syntax.
+- `qos`: The MQTT Quality of Service (QoS) level to use for the endpoint.
+  - The value MUST be an integer between 0 and 2.
+  - When not specified, the default value MUST be 0.
+  - The value is overidden by the `qos` property of the
+    [MQTT message format](../message/spec.md#mqtt311-and-mqtt50-protocols).
+- `retain`: If `true`, the MQTT `retain` flag is set on transfers.
+  - When not specified, the default value is `false`.
+  - The value is overidden by the `retain` property of the [MQTT
+    message format](../message/spec.md#mqtt311-and-mqtt50-protocols). This
+    option only applies to `usage:producer` endpoints.
 - `cleansession`: If `true`, the MQTT `cleansession` flag is set on
-  connections. The default value is `true`.
-- `willtopic`: The MQTT `willtopic` to use for the endpoint. The value MUST be
-  a non-empty string. The value MAY contain placeholders using the
-  [RFC6570][RFC6570] Level 1 URI Template syntax
+  connections.
+  - When not specified, the default value MUST be `true`.
+- `willtopic`: The MQTT `willtopic` to use for the endpoint.
+  - The value MUST be a non-empty string.
+  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
+    URI Template syntax.
 - `willmessage`: This is URI and/or JSON Pointer that refers to the MQTT
-  `willmessage` to use for the endpoint. The value MUST be a non-empty string.
-  It MUST point to a valid
+  `willmessage` to use for the endpoint.
+  - The value MUST be a non-empty string.
+  - It MUST point to a valid
   [´message´](../message/spec.md#message-definitions) that MUST either
   use the ["CloudEvents/1.0"](../message/spec.md#cloudevents10) or
   ["MQTT/3.1.1." or "MQTT/5.0"](../message/spec.md#mqtt311-and-mqtt50-protocols)
@@ -851,23 +861,27 @@ usage, e.g.  `SSL://{host}:{port}` or `PLAINTEXT://{host}:{port}`.
 
 The following options are defined for Kafka endpoints.
 
-- `topic`: The Kafka topic to use for the endpoint. The value MUST be a
-  non-empty string if present. The value MAY contain placeholders using the
-  [RFC6570][RFC6570] Level 1 URI Template syntax
-- `acks`: The Kafka `acks` setting to use for the endpoint. The value MUST be an
-  integer between -1 and 1. The default value is 1. This option only applies to
-  `usage:producer` endpoints.
-- `key`: The fixed Kafka key to use for this endpoint. The value MUST be a
-  non-empty string if present. This option only applies to `usage:producer`
-  endpoints. The value MAY contain placeholders using the
-  [RFC6570][RFC6570] Level 1 URI Template syntax
-- `partition`: The fixed Kafka partition to use for this endpoint. The value
-  MUST be an integer if present. This option only applies to `usage:producer`
-  endpoints.
-- `consumergroup`: The Kafka consumer group to use for this endpoint. The value
-  MUST be a non-empty string if present. This option only applies to
-  `usage:consumer` endpoints. The value MAY contain placeholders using the
-  [RFC6570][RFC6570] Level 1 URI Template syntax
+- `topic`: The Kafka topic to use for the endpoint.
+  - When specified, the value MUST be a non-empty string.
+  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
+    URI Template syntax.
+- `acks`: The Kafka `acks` setting to use for the endpoint.
+  - The value MUST be an integer between -1 and 1.
+  - When not specified, the default value MUST be 1.
+  - This option only applies to `usage:producer` endpoints.
+- `key`: The fixed Kafka key to use for this endpoint.
+  - When specified, the value MUST be a non-empty string.
+  - This option only applies to `usage:producer` endpoints.
+  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
+    URI Template syntax.
+- `partition`: The fixed Kafka partition to use for this endpoint.
+  - When specified, the value MUST be an integer.
+  - This option only applies to `usage:producer` endpoints.
+- `consumergroup`: The Kafka consumer group to use for this endpoint.
+  - When specified, the value MUST be a non-empty string.
+  - This option only applies to `usage:consumer` endpoints.
+  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
+    URI Template syntax.
 
 Example:
 
@@ -891,8 +905,9 @@ include a port number, e.g. `nats://{host}:{port}` or `tls://{host}:{port}`.
 
 The following options are defined for NATS endpoints.
 
-- `subject`: The NATS subject to use. The value MAY contain placeholders using
-  the [RFC6570][RFC6570] Level 1 URI Template syntax
+- `subject`: The NATS subject to use.
+  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
+    URI Template syntax.
 
 Example:
 
@@ -907,7 +922,6 @@ Example:
 ```
 
 ## References
-
 
 [JSON Pointer]: https://www.rfc-editor.org/rfc/rfc6901
 [CloudEvents Types]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system

--- a/message/model.json
+++ b/message/model.json
@@ -114,7 +114,9 @@
                             },
                             "type": {
                               "name": "type",
-                              "type": "string"
+                              "type": "string",
+                              "serverrequired": true,
+                              "default": "string"
                             },
                             "value": {
                               "name": "value",
@@ -182,7 +184,9 @@
                             "required": {
                               "name": "required",
                               "description": "CloudEvents subject required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -207,7 +211,9 @@
                             "required": {
                               "name": "required",
                               "description": "The timestamp required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -232,7 +238,9 @@
                             "required": {
                               "name": "required",
                               "description": "The uri required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -258,7 +266,9 @@
                             "required": {
                               "name": "required",
                               "description": "Whether the extension is required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         }
@@ -329,7 +339,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP message-id required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": true
                                 }
                               }
                             },
@@ -355,7 +367,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP user-id required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -381,7 +395,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP to required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -407,7 +423,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP subject required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": true
                                 }
                               }
                             },
@@ -433,7 +451,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP reply-to required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -459,7 +479,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP correlation-id required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -485,7 +507,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP content-type required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -511,7 +535,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP content-encoding required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -537,7 +563,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP absolute-expiry-time required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -563,7 +591,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP group-id required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -589,7 +619,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP group-sequence required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             },
@@ -615,7 +647,9 @@
                                 "required": {
                                   "name": "required",
                                   "description": "AMQP reply-to-group-id required",
-                                  "type": "boolean"
+                                  "type": "boolean",
+                                  "serverrequired": true,
+                                  "default": false
                                 }
                               }
                             }
@@ -644,7 +678,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "The application property required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }
@@ -672,7 +708,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "Whether the message annotation is required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }
@@ -700,7 +738,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "Whether the annotation is required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }
@@ -728,7 +768,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "AMQP header required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }
@@ -756,7 +798,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "AMQP footer required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }
@@ -789,7 +833,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT qos value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -805,12 +851,16 @@
                             "value": {
                               "name": "value",
                               "description": "MQTT retain value template",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             },
                             "required": {
                               "name": "required",
                               "description": "MQTT retain value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -831,7 +881,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT topic-name value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         }
@@ -863,7 +915,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT qos value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -879,12 +933,16 @@
                             "value": {
                               "name": "value",
                               "description": "MQTT retain value template",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             },
                             "required": {
                               "name": "required",
                               "description": "MQTT retain value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -905,7 +963,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT topic-name value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -926,7 +986,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT message-expiry-interval value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -947,7 +1009,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT response-topic value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -968,7 +1032,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT correlation-data value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -989,7 +1055,9 @@
                             "required": {
                               "name": "required",
                               "description": "MQTT content-type value required",
-                              "type": "boolean"
+                              "type": "boolean",
+                              "serverrequired": true,
+                              "default": false
                             }
                           }
                         },
@@ -1067,7 +1135,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "The Apache Kafka header required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }
@@ -1075,7 +1145,9 @@
                         "timestamp": {
                           "name": "timestamp",
                           "description": "The Apache Kafka timestamp",
-                          "type": "integer"
+                          "type": "integer",
+                          "serverrequired": true,
+                          "default": 0
                         }
                       }
                     }
@@ -1112,7 +1184,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "The HTTP header required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }
@@ -1141,7 +1215,9 @@
                               "required": {
                                 "name": "required",
                                 "description": "The HTTP query parameter required",
-                                "type": "boolean"
+                                "type": "boolean",
+                                "serverrequired": true,
+                                "default": false
                               }
                             }
                           }

--- a/message/spec.md
+++ b/message/spec.md
@@ -100,7 +100,7 @@ this form:
             "STRING": {
               "type": "TYPE", ?
               "value": ANY, ?
-              "required": BOOLEAN ?            # Default is 'false'
+              "required": BOOLEAN              # Default=false
             } *
           }, ?
           "envelopeoptions": {
@@ -509,7 +509,7 @@ headers/properties/attributes constraints:
 - Description: Indicates whether the property is REQUIRED to be present in a
   message of this type.
 - Constraints:
-  - OPTIONAL. Defaults to `false`.
+  - OPTIONAL. Defaults MUST be `false`.
   - If present, MUST be a boolean value.
 
 ##### `description`
@@ -555,7 +555,7 @@ current timestamp when creating a message.
 - Description: The type of the property. This is used to constrain the value of
   the property.
 - Constraints:
-  - OPTIONAL. Defaults to "string".
+  - OPTIONAL. Default value MUST be "string".
   - The valid types are those defined in the [CloudEvents][CloudEvents Types]
     core specification, with some additions:
     - `var`: Any type of value, including `null`.
@@ -618,8 +618,8 @@ The following rules apply to the attribute declarations:
 - The `type`, `id`, and `source` attributes implicitly have the `required` flag
   set to `true` and MUST NOT be declared as `required: false`.
 - The `id` attribute's `value` SHOULD NOT be defined.
-- The `time` attribute's `value` defaults to `01-01-0000T00:00:00Z` ("current
-  time") and SHOULD NOT be declared with a different value.
+- The `time` attribute's `value` default value MUST be `01-01-0000T00:00:00Z`
+  ("current time") and SHOULD NOT be declared with a different value.
 - The `datacontenttype` attribute's `value` is inferred from the
   [`dataschemaformat`](#dataschemaformat) attribute of the message definition
   if absent.
@@ -633,7 +633,7 @@ The following rules apply to the attribute declarations:
   `urireference` MAY be changed to
   `uritemplate` or the `subject` type `string` MAY be constrained to a
   `urireference` or `stringified integer`. If no CloudEvents type definition
-  exists, the type defaults to `string`.
+  exists, the default value MUST be `string`.
 
 The values of all `string` and `uritemplate`-typed attributes MAY contain
 placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the

--- a/schema/model.json
+++ b/schema/model.json
@@ -31,7 +31,9 @@
             "validation": {
               "name": "validation",
               "type": "boolean",
-              "description": "Verify compliance with specified schema 'format'"
+              "description": "Verify compliance with specified schema 'format'",
+              "serverrequired": true,
+              "default": true
             }
           }
         }

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -308,7 +308,7 @@ the core xRegistry Resource
   (but it an allowable value), then the server MUST NOT perform any validation.
 - Constraints:
   - OPTIONAL
-  - When not specified, the default value is `true`.
+  - When not specified, the default value MUST be `true`.
   - MUST be a Resource level attribute defined within the `metaattributes`
     section of the model.
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,9 +3,9 @@ all: verify makeschema
 		( echo "schema files have been updated, make sure you commit them" ; \
 		  exit 1 )
 
-verify: spellcheck tabcheck test_tools
-	@python tools/verify.py .
-	@echo
+verify: text links
+
+text: spellcheck tabcheck
 
 spellcheck:
 	tools/spellcheck */spec.md core/primer.md
@@ -15,9 +15,9 @@ tabcheck:
 	tools/tabcheck */*.md  */*.json
 	@echo
 
-deps:
-	@echo Loading python deps
-	@python -m pip install -qq -r tools/requirements.txt
+links: test_tools
+	@python tools/verify.py .
+	@echo
 
 makeschema:
 	@echo Rebuilding the schemas...
@@ -33,6 +33,10 @@ makeschema:
 	@python tools/schema-generator.py --type json-schema --output cloudevents/schemas/document-schema.json endpoint/model.json message/model.json schema/model.json
 	@python tools/schema-generator.py --type avro-schema --output cloudevents/schemas/document-schema.avsc endpoint/model.json message/model.json schema/model.json
 	@python tools/schema-generator.py --type openapi --output cloudevents/schemas/openapi.json endpoint/model.json message/model.json schema/model.json
+
+deps:
+	@echo Loading python deps
+	@python -m pip install -qq -r tools/requirements.txt
 
 test_tools: deps
 	@pytest tools/

--- a/tools/dict
+++ b/tools/dict
@@ -102,6 +102,7 @@ jsonschema
 keyname
 lifecycle
 linkproperties
+maxmaxversions
 maxversions
 messagegroupid
 messagegroupscount
@@ -136,6 +137,7 @@ mykey
 mylinkproperty
 mylinkpropertyvalue
 mymessagetype
+myobj
 myorg
 myproject
 myqueue

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,7 +1,7 @@
 markdown
 bs4 
 tenacity
-aiohttp
+aiohttp==3.11.12
 tqdm
 pymdown-extensions
 pytest-asyncio

--- a/tools/verify.py
+++ b/tools/verify.py
@@ -154,7 +154,7 @@ async def _uri_availability_issues(uri: HttpUri, settings: Settings) -> Sequence
                 async with ClientSession() as session:
                     with closing(
                         await session.get(
-                            uri, timeout=settings.http_timeout_seconds, ssl=False
+                            uri, timeout=settings.http_timeout_seconds, ssl=False, max_field_size=81900
                         )
                     ) as response:
                         match response.status:


### PR DESCRIPTION
- lots of clean-up for consistency
- add Manuel to contributors doc
- minor tweak to tooling/verification logic
- require attributes with default vaules to be serialized by servers
  - added `serverrequired:true` and `default` values to our model files
- ban changing spec-defined attribute's default values
  - allow extensions to be changed, unless their spec says otherwise
- add != filter operator and 'null' to mean attribute is absent (e.g. ?filter=foo=null means 'foo' is absent)
- make it clear that `?filter=myobj.attr!=5` == `NOT(myobj.attr=5)` and missing `myobj` matches the `!=` operator
- new format for `/capabilities?offered`

Fixes #260 
Fixes #262 