### PR TITLE
Compatibility

### DIFF
--- a/core/spec.md
+++ b/core/spec.md
@@ -3910,6 +3910,9 @@ and the following Resource level attributes:
   - If present, it MUST be a case-sensitive value from the model defined
     enumeration range.
   - When not present, the implied default value is `none`.
+  - The value may change from `none` to any other defined value. However, once
+    set to a non-`none` value, it MUST NOT be changed. Instead, a new
+    resource should be defined with the new compatibility value.
 
 ##### `defaultversionid` Attribute
 - Type: String

--- a/core/spec.md
+++ b/core/spec.md
@@ -3978,6 +3978,8 @@ and the following Resource level attributes:
 - Constraints:
   - When not present, the default value is `false`.
   - REQUIRED when `true`, otherwise OPTIONAL.
+  - If `enforcecompatibility` is set to `true`, this attribute MUST always
+    be set to `false`.
   - If present, it MUST be a case-sensitive `true` or `false`.
   - If present in a request, a value of `null` MUST have the same meaning as
     deleting the attribute, implicitly setting it to `false`.

--- a/core/spec.md
+++ b/core/spec.md
@@ -3860,7 +3860,7 @@ and the following Resource level attributes:
   - MUST be a read-only attribute.
   - When not present, the default value is `false`.
   - REQUIRED when `true`, otherwise OPTIONAL.
-  - If present, it MUST be a case sensitive `true` or `false`.
+  - If present, it MUST be a case-sensitive `true` or `false`.
   - A request to update a read-only Resource MUST generate an error unless
     the `?noreadonly` query parameter was used, in which case the error MUST
     be silently ignored. See [Registry APIs](#registry-apis) for more
@@ -3907,7 +3907,7 @@ and the following Resource level attributes:
   - `none` - No compatibility checking is performed.
 
 - Constraints:
-  - If present, it MUST be a case sensitive value from the model defined
+  - If present, it MUST be a case-sensitive value from the model defined
     enumeration range.
   - When not present, the implied default value is `none`.
 
@@ -3975,7 +3975,7 @@ and the following Resource level attributes:
 - Constraints:
   - When not present, the default value is `false`.
   - REQUIRED when `true`, otherwise OPTIONAL.
-  - If present, it MUST be a case sensitive `true` or `false`.
+  - If present, it MUST be a case-sensitive `true` or `false`.
   - If present in a request, a value of `null` MUST have the same meaning as
     deleting the attribute, implicitly setting it to `false`.
   - The processing of the `defaultversionsticky` and `defaultversionid`

--- a/core/spec.md
+++ b/core/spec.md
@@ -1900,16 +1900,18 @@ The following defines the specification-defined capabilities:
   reject all attempts to create/update a Resource (or its Versions) that would
   result in those entities violating the stated compatibility rules.
 
-  This includes the server rejecting requests to update the `compatibility`
-  attribute's value if any of the Resource's Versions would violate the
-  compatibility rules.
-
   A value of `false` indicates that the server MUST NOT perform any
   compatibility checking.
 
-  Attempts to change this value from `false` to `true` MUST fail if doing so
-  would result in any existing Version violating the `compatibility` rules
-  defined for the owning Resource.
+  Attempts to change this value from `false` to `true` SHOULD NOT result in
+  any validation of existing versions. Instead, compatibility will be
+  enforced for any new versions that are added.
+
+  This value can be set to `true` at any time, but can't be reset to`false`.
+  Once compatibility is enforced, it must remain enforced. Changing this
+  requires a new registry to be created as it's a fundamental change for
+  clients of the registry, which should be signaled accordingly.
+
 - If not specified, the default value is `false`.
 
 #### `flags`


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Why keep compatibility in v1 of the spec

Compatibility levels up the value of a registry. Apart from it being a resource I can use to discover and query the current schemas, it becomes a resource that can enforce a compatibility strategy. Looking at the existing schema registries out there, most (if not all) of them support compatibility enforcement (albeit not for all schemas):
- [Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/fundamentals/schema-evolution.html#schema-evolution)
- [Event Hubs Schema Registry](https://learn.microsoft.com/en-us/azure/event-hubs/schema-registry-concepts#schema-evolution)
- [Apicurio](https://www.apicur.io/registry/docs/apicurio-registry/3.0.x/getting-started/assembly-rule-reference.html)
- [AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/schema-registry.html#schema-registry-compatibility)

## Proposed Changes

### `enforcecompatibility`

The registry-wide `enforcecompatibility` setting can't be changed once set to `true`.

#### Reasoning

- If it was previously set to false, previous versions aren't reevaluated, only future versions are. This makes it behave much more like a setting or flag, not causing any validation to happen when modified. Instead, compatbility will be enforced when changes are made.
- Changing from `true` back to `false` is not allowed as it's a fundamental change in how the registry behaves.

### Resource-level `compatibility`

The resource-level `compatibility` setting can be changed from `none` to another value, but can't be changed to any other value. The new value will only be vallidated for future changes.

#### Reasoning

It's unlikely that a resource that adhered to one compatibility strategy can adhere to another compatibility strategy without changing previous versions, unless it was always fully compatible. In addition, a change in the compatibility strategy is very much like a contract change which should be clearly visible, as users of the registry may be making assumptions based on the previously defined strategy.

### `setdefaultversionsticky`

The `setdefaultversionsticky` attribute can't be set to `true` when the registry has `enforcecompatibility` set to `true`. This is to avoid having to keep track of the order of versions as they were set according to this attribute. 
Any request to set the `setdefaultversionsticky` to `true` when `enforcecompatibility` is turned on should result in a failure.

#### Reasoning

This allows us to defer the inclusion of version-ordering as indicated by the sticky flag in the spec, and instead allows us to rely on the version's creation date. This may however implicate that we need a server creation date time which can't be set or altered by the client.

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note

```
