### PR TITLE
Week of March 3

### DIFF
--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -138,7 +138,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "id": {
                       "type": "object",
@@ -157,7 +160,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "type": {
                       "type": "object",
@@ -176,7 +182,11 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "type",
+                        "required"
+                      ]
                     },
                     "source": {
                       "type": "object",
@@ -195,7 +205,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "subject": {
                       "type": "object",
@@ -215,7 +228,10 @@
                           "type": "boolean",
                           "description": "CloudEvents subject required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "time": {
                       "type": "object",
@@ -235,7 +251,10 @@
                           "type": "boolean",
                           "description": "The timestamp required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "dataschema": {
                       "type": "object",
@@ -256,7 +275,10 @@
                           "type": "boolean",
                           "description": "The uri required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     }
                   },
                   "additionalProperties": {
@@ -278,7 +300,10 @@
                         "type": "boolean",
                         "description": "Whether the extension is required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   }
                 },
                 "envelopeoptions": {
@@ -332,7 +357,7 @@
                     "properties": {
                       "type": "object",
                       "properties": {
-                        "message_id": {
+                        "message-id": {
                           "type": "object",
                           "description": "AMQP message-id",
                           "properties": {
@@ -351,9 +376,12 @@
                               "type": "boolean",
                               "description": "AMQP message-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "user_id": {
+                        "user-id": {
                           "type": "object",
                           "description": "AMQP user-id",
                           "properties": {
@@ -372,7 +400,10 @@
                               "type": "boolean",
                               "description": "AMQP user-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "to": {
                           "type": "object",
@@ -393,7 +424,10 @@
                               "type": "boolean",
                               "description": "AMQP to required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "subject": {
                           "type": "object",
@@ -414,9 +448,12 @@
                               "type": "boolean",
                               "description": "AMQP subject required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "reply_to": {
+                        "reply-to": {
                           "type": "object",
                           "description": "AMQP reply-to",
                           "properties": {
@@ -435,9 +472,12 @@
                               "type": "boolean",
                               "description": "AMQP reply-to required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "correlation_id": {
+                        "correlation-id": {
                           "type": "object",
                           "description": "AMQP correlation-id",
                           "properties": {
@@ -456,9 +496,12 @@
                               "type": "boolean",
                               "description": "AMQP correlation-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "content_type": {
+                        "content-type": {
                           "type": "object",
                           "description": "AMQP content-type",
                           "properties": {
@@ -477,9 +520,12 @@
                               "type": "boolean",
                               "description": "AMQP content-type required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "content_encoding": {
+                        "content-encoding": {
                           "type": "object",
                           "description": "AMQP content-encoding",
                           "properties": {
@@ -498,7 +544,10 @@
                               "type": "boolean",
                               "description": "AMQP content-encoding required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "absolute_expiry_time": {
                           "type": "object",
@@ -519,9 +568,12 @@
                               "type": "boolean",
                               "description": "AMQP absolute-expiry-time required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "group_id": {
+                        "group-id": {
                           "type": "object",
                           "description": "AMQP group-id",
                           "properties": {
@@ -540,9 +592,12 @@
                               "type": "boolean",
                               "description": "AMQP group-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "group_sequence": {
+                        "group-sequence": {
                           "type": "object",
                           "description": "AMQP group-sequence",
                           "properties": {
@@ -561,7 +616,10 @@
                               "type": "boolean",
                               "description": "AMQP group-sequence required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "reply_to_group_id": {
                           "type": "object",
@@ -582,11 +640,14 @@
                               "type": "boolean",
                               "description": "AMQP reply-to-group-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         }
                       }
                     },
-                    "application_properties": {
+                    "application-properties": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -606,10 +667,13 @@
                             "type": "boolean",
                             "description": "The application property required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
-                    "message_annotations": {
+                    "message-annotations": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -629,10 +693,13 @@
                             "type": "boolean",
                             "description": "Whether the message annotation is required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
-                    "delivery_annotations": {
+                    "delivery-annotations": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -652,7 +719,10 @@
                             "type": "boolean",
                             "description": "Whether the annotation is required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "header": {
@@ -675,7 +745,10 @@
                             "type": "boolean",
                             "description": "AMQP header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "footer": {
@@ -698,7 +771,10 @@
                             "type": "boolean",
                             "description": "AMQP footer required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     }
                   }
@@ -736,7 +812,10 @@
                           "type": "boolean",
                           "description": "MQTT qos value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "retain": {
                       "type": "object",
@@ -753,9 +832,13 @@
                           "type": "boolean",
                           "description": "MQTT retain value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "required"
+                      ]
                     },
-                    "topic_name": {
+                    "topic-name": {
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
@@ -770,7 +853,10 @@
                           "type": "boolean",
                           "description": "MQTT topic-name value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     }
                   }
                 }
@@ -807,7 +893,10 @@
                           "type": "boolean",
                           "description": "MQTT qos value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "retain": {
                       "type": "object",
@@ -824,9 +913,13 @@
                           "type": "boolean",
                           "description": "MQTT retain value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "required"
+                      ]
                     },
-                    "topic_name": {
+                    "topic-name": {
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
@@ -841,7 +934,10 @@
                           "type": "boolean",
                           "description": "MQTT topic-name value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "message_expiry_interval": {
                       "type": "object",
@@ -858,9 +954,12 @@
                           "type": "boolean",
                           "description": "MQTT message-expiry-interval value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "response_topic": {
+                    "response-topic": {
                       "type": "object",
                       "description": "MQTT response-topic",
                       "properties": {
@@ -875,9 +974,12 @@
                           "type": "boolean",
                           "description": "MQTT response-topic value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "correlation_data": {
+                    "correlation-data": {
                       "type": "object",
                       "description": "MQTT correlation-data",
                       "properties": {
@@ -892,9 +994,12 @@
                           "type": "boolean",
                           "description": "MQTT correlation-data value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "content_type": {
+                    "content-type": {
                       "type": "object",
                       "description": "MQTT content-type",
                       "properties": {
@@ -909,9 +1014,12 @@
                           "type": "boolean",
                           "description": "MQTT content-type value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "user_properties": {
+                    "user-properties": {
                       "type": "array",
                       "description": "MQTT user-properties",
                       "items": {
@@ -984,14 +1092,20 @@
                             "type": "boolean",
                             "description": "The Apache Kafka header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "timestamp": {
                       "type": "integer",
                       "description": "The Apache Kafka timestamp"
                     }
-                  }
+                  },
+                  "required": [
+                    "timestamp"
+                  ]
                 }
               },
               "required": [
@@ -1032,7 +1146,10 @@
                             "type": "boolean",
                             "description": "The HTTP header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "query": {
@@ -1056,7 +1173,10 @@
                             "type": "boolean",
                             "description": "The HTTP query parameter required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "path": {
@@ -1175,6 +1295,9 @@
           }
         }
       },
+      "required": [
+        "usage"
+      ],
       "allOf": [
         {
           "oneOf": [
@@ -1232,7 +1355,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "url"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1262,7 +1388,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1277,25 +1406,30 @@
                       "type": "boolean",
                       "description": "The AMQP durable flag. Whether the node is durable or transient"
                     },
-                    "linkproperties": {
+                    "link-properties": {
                       "type": "object",
                       "description": "An optional map of AMQP link properties to use with the endpoint",
                       "additionalProperties": {
                         "type": "string"
                       }
                     },
-                    "connectionproperties": {
+                    "connection-properties": {
                       "type": "object",
                       "description": "An optional map of AMQP connection properties to use with the endpoint",
                       "additionalProperties": {
                         "type": "string"
                       }
                     },
-                    "distributionmode": {
+                    "distribution-mode": {
                       "type": "string",
                       "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "durable",
+                    "distribution-mode"
+                  ]
                 }
               },
               "required": [
@@ -1326,7 +1460,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1356,7 +1493,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1388,7 +1528,13 @@
                       "type": "string",
                       "description": "The MQTT will message definition to configure for publishers on this endpoint"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "qos",
+                    "retain",
+                    "cleansession"
+                  ]
                 }
               },
               "required": [
@@ -1419,7 +1565,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1449,7 +1598,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1481,7 +1633,13 @@
                       "type": "string",
                       "description": "The MQTT will message definition to configure for publishers on this endpoint"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "qos",
+                    "retain",
+                    "cleansession"
+                  ]
                 }
               },
               "required": [
@@ -1512,7 +1670,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1542,7 +1703,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1567,7 +1731,11 @@
                             "type": "string",
                             "description": "HTTP header value"
                           }
-                        }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ]
                       }
                     },
                     "query": {
@@ -1577,7 +1745,11 @@
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "method"
+                  ]
                 }
               },
               "required": [
@@ -1608,7 +1780,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1638,7 +1813,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1672,7 +1850,12 @@
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "topic",
+                    "acks"
+                  ]
                 }
               },
               "required": [
@@ -1703,7 +1886,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1733,7 +1919,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1744,7 +1933,11 @@
                       "type": "string",
                       "description": "The NATS subject"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "subject"
+                  ]
                 }
               },
               "required": [

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -2416,7 +2416,10 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "id": {
                 "type": "object",
@@ -2435,7 +2438,10 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "type": {
                 "type": "object",
@@ -2454,7 +2460,11 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "type",
+                  "required"
+                ]
               },
               "source": {
                 "type": "object",
@@ -2473,7 +2483,10 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "subject": {
                 "type": "object",
@@ -2493,7 +2506,10 @@
                     "type": "boolean",
                     "description": "CloudEvents subject required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "time": {
                 "type": "object",
@@ -2513,7 +2529,10 @@
                     "type": "boolean",
                     "description": "The timestamp required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "dataschema": {
                 "type": "object",
@@ -2534,7 +2553,10 @@
                     "type": "boolean",
                     "description": "The uri required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               }
             },
             "additionalProperties": {
@@ -2556,7 +2578,10 @@
                   "type": "boolean",
                   "description": "Whether the extension is required"
                 }
-              }
+              },
+              "required": [
+                "required"
+              ]
             }
           },
           "envelopeoptions": {
@@ -2606,7 +2631,7 @@
               "properties": {
                 "type": "object",
                 "properties": {
-                  "message_id": {
+                  "message-id": {
                     "type": "object",
                     "description": "AMQP message-id",
                     "properties": {
@@ -2625,9 +2650,12 @@
                         "type": "boolean",
                         "description": "AMQP message-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "user_id": {
+                  "user-id": {
                     "type": "object",
                     "description": "AMQP user-id",
                     "properties": {
@@ -2646,7 +2674,10 @@
                         "type": "boolean",
                         "description": "AMQP user-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "to": {
                     "type": "object",
@@ -2667,7 +2698,10 @@
                         "type": "boolean",
                         "description": "AMQP to required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "subject": {
                     "type": "object",
@@ -2688,9 +2722,12 @@
                         "type": "boolean",
                         "description": "AMQP subject required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "reply_to": {
+                  "reply-to": {
                     "type": "object",
                     "description": "AMQP reply-to",
                     "properties": {
@@ -2709,9 +2746,12 @@
                         "type": "boolean",
                         "description": "AMQP reply-to required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "correlation_id": {
+                  "correlation-id": {
                     "type": "object",
                     "description": "AMQP correlation-id",
                     "properties": {
@@ -2730,9 +2770,12 @@
                         "type": "boolean",
                         "description": "AMQP correlation-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "content_type": {
+                  "content-type": {
                     "type": "object",
                     "description": "AMQP content-type",
                     "properties": {
@@ -2751,9 +2794,12 @@
                         "type": "boolean",
                         "description": "AMQP content-type required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "content_encoding": {
+                  "content-encoding": {
                     "type": "object",
                     "description": "AMQP content-encoding",
                     "properties": {
@@ -2772,7 +2818,10 @@
                         "type": "boolean",
                         "description": "AMQP content-encoding required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "absolute_expiry_time": {
                     "type": "object",
@@ -2793,9 +2842,12 @@
                         "type": "boolean",
                         "description": "AMQP absolute-expiry-time required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "group_id": {
+                  "group-id": {
                     "type": "object",
                     "description": "AMQP group-id",
                     "properties": {
@@ -2814,9 +2866,12 @@
                         "type": "boolean",
                         "description": "AMQP group-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "group_sequence": {
+                  "group-sequence": {
                     "type": "object",
                     "description": "AMQP group-sequence",
                     "properties": {
@@ -2835,7 +2890,10 @@
                         "type": "boolean",
                         "description": "AMQP group-sequence required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "reply_to_group_id": {
                     "type": "object",
@@ -2856,11 +2914,14 @@
                         "type": "boolean",
                         "description": "AMQP reply-to-group-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   }
                 }
               },
-              "application_properties": {
+              "application-properties": {
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
@@ -2880,10 +2941,13 @@
                       "type": "boolean",
                       "description": "The application property required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
-              "message_annotations": {
+              "message-annotations": {
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
@@ -2903,10 +2967,13 @@
                       "type": "boolean",
                       "description": "Whether the message annotation is required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
-              "delivery_annotations": {
+              "delivery-annotations": {
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
@@ -2926,7 +2993,10 @@
                       "type": "boolean",
                       "description": "Whether the annotation is required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "header": {
@@ -2949,7 +3019,10 @@
                       "type": "boolean",
                       "description": "AMQP header required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "footer": {
@@ -2972,7 +3045,10 @@
                       "type": "boolean",
                       "description": "AMQP footer required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               }
             }
@@ -3010,7 +3086,10 @@
                     "type": "boolean",
                     "description": "MQTT qos value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "retain": {
                 "type": "object",
@@ -3027,9 +3106,13 @@
                     "type": "boolean",
                     "description": "MQTT retain value required"
                   }
-                }
+                },
+                "required": [
+                  "value",
+                  "required"
+                ]
               },
-              "topic_name": {
+              "topic-name": {
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
@@ -3044,7 +3127,10 @@
                     "type": "boolean",
                     "description": "MQTT topic-name value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               }
             }
           }
@@ -3081,7 +3167,10 @@
                     "type": "boolean",
                     "description": "MQTT qos value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "retain": {
                 "type": "object",
@@ -3098,9 +3187,13 @@
                     "type": "boolean",
                     "description": "MQTT retain value required"
                   }
-                }
+                },
+                "required": [
+                  "value",
+                  "required"
+                ]
               },
-              "topic_name": {
+              "topic-name": {
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
@@ -3115,7 +3208,10 @@
                     "type": "boolean",
                     "description": "MQTT topic-name value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "message_expiry_interval": {
                 "type": "object",
@@ -3132,9 +3228,12 @@
                     "type": "boolean",
                     "description": "MQTT message-expiry-interval value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "response_topic": {
+              "response-topic": {
                 "type": "object",
                 "description": "MQTT response-topic",
                 "properties": {
@@ -3149,9 +3248,12 @@
                     "type": "boolean",
                     "description": "MQTT response-topic value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "correlation_data": {
+              "correlation-data": {
                 "type": "object",
                 "description": "MQTT correlation-data",
                 "properties": {
@@ -3166,9 +3268,12 @@
                     "type": "boolean",
                     "description": "MQTT correlation-data value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "content_type": {
+              "content-type": {
                 "type": "object",
                 "description": "MQTT content-type",
                 "properties": {
@@ -3183,9 +3288,12 @@
                     "type": "boolean",
                     "description": "MQTT content-type value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "user_properties": {
+              "user-properties": {
                 "type": "array",
                 "description": "MQTT user-properties",
                 "items": {
@@ -3258,14 +3366,20 @@
                       "type": "boolean",
                       "description": "The Apache Kafka header required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "timestamp": {
                 "type": "integer",
                 "description": "The Apache Kafka timestamp"
               }
-            }
+            },
+            "required": [
+              "timestamp"
+            ]
           }
         },
         "required": [
@@ -3306,7 +3420,10 @@
                       "type": "boolean",
                       "description": "The HTTP header required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "query": {
@@ -3330,7 +3447,10 @@
                       "type": "boolean",
                       "description": "The HTTP query parameter required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "path": {
@@ -3455,7 +3575,10 @@
                       "format": "uri",
                       "description": "Network accessible location"
                     }
-                  }
+                  },
+                  "required": [
+                    "uri"
+                  ]
                 }
               },
               "authorization": {
@@ -3485,7 +3608,10 @@
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "type"
+                  ]
                 }
               },
               "deployed": {
@@ -3496,7 +3622,11 @@
                 "type": "string",
                 "description": "The NATS subject"
               }
-            }
+            },
+            "required": [
+              "deployed",
+              "subject"
+            ]
           }
         },
         "required": [
@@ -3600,6 +3730,9 @@
             }
           }
         },
+        "required": [
+          "usage"
+        ],
         "discriminator": {
           "propertyName": "protocol",
           "mapping": {

--- a/core/model.json
+++ b/core/model.json
@@ -5,31 +5,31 @@
       "type": "string",
       "readonly": true,
       "immutable": true,
-      "serverrequired": true,
+      "required": true,
       "default": "0.5"
     },
     "registryid": {
       "name": "registryid",
       "type": "string",
       "immutable": true,
-      "serverrequired": true
+      "required": true
     },
     "self": {
       "name": "self",
       "type": "url",
       "readonly": true,
-      "serverrequired": true
+      "required": true
     },
     "xid": {
       "name": "xid",
       "type": "xid",
       "readonly": true,
-      "serverrequired": true
+      "required": true
     },
     "epoch": {
       "name": "epoch",
       "type": "uinteger",
-      "serverrequired": true
+      "required": true
     },
     "name": {
       "name": "name",

--- a/core/primer.md
+++ b/core/primer.md
@@ -657,3 +657,20 @@ the authors chose to have the server ignore unknown query parameters. It is
 worth noting that the specification says they SHOULD be ignored, not that they
 MUST be ignored. So there is room for an implementation to be very picky if
 needed, but at the risk of potentially causing interoperability problems.
+
+# Updating attributes with `ifvalues`
+
+The `ifvalues` feature might be a new concept for some readers, so a point
+of clarification might be useful. If an attribute is defined with an `ifvalues`
+aspect, then if that attribute's value changes it is possible that the
+set of sibling attributes that are part of that entity's model could change
+due to a new `ifvalues` match (or due to no match at all).
+
+When a client is performing a write operation that changes that attribute's
+value, the client must ensure that the net result of the changes are compliant
+with the resulting model. Meaning, if that attribute's new value adds or
+removes attributes then the client might need to also change other attributes
+in the entity in order to be model compliant.
+
+Likewise, implementations of the server must validate the entire entity
+against the new model, not just a subset of the entity's attributes.

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -16,14 +16,14 @@ Contributions do not constitute an official endorsement.
 - **Google**
   - Jon Skeet - [@jskeet](https://github.com/jskeet)
 
-- ** HDI Global SE**
+- **HDI Global SE**
   - Manuel Ottlik - [@manuelottlik](https://github.com/manuelottlik)
 
 - **Microsoft**
   - Clemens Vasters - [@clemensv](https://github.com/clemensv)
 
 - **Particular Software**
-  - Laila Bourgria - [@lailabougria](https://github.com/lailabougria)
+  - Laila Bougria - [@lailabougria](https://github.com/lailabougria)
 
 - **SAP**
   - Klaus Deissner - [@deissnerk](https://github.com/deissnerk)

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -14,8 +14,7 @@
             "producer"
           ],
           "strict": true,
-          "clientrequired": true,
-          "serverrequired": true
+          "required": true
         },
         "channel": {
           "name": "channel",
@@ -57,8 +56,6 @@
           "name": "envelope",
           "type": "string",
           "description": "Envelope metadata format identifier. If set, all definitions MUST use this format value",
-          "clientrequired": false,
-          "serverrequired": false,
           "ifvalues": {
             "CloudEvents/1.0": {
               "siblingattributes": {
@@ -90,8 +87,6 @@
           "name": "protocol",
           "type": "string",
           "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value",
-          "clientrequired": false,
-          "serverrequired": false,
 
           "ifvalues": {
             "AMQP/1.0": {
@@ -99,6 +94,7 @@
                 "protocoloptions": {
                   "name": "protocoloptions",
                   "type": "object",
+                  "relaxednames": true,
                   "description": "Configuration information for this endpoint",
                   "attributes": {
                     "endpoints": {
@@ -112,8 +108,7 @@
                             "name": "url",
                             "type": "url",
                             "description": "Network accessible location",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "*": {
                             "name": "*",
@@ -133,8 +128,7 @@
                             "name": "type",
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "resourceuri": {
                             "name": "resourceuri",
@@ -165,7 +159,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
 
@@ -178,34 +172,34 @@
                       "name": "durable",
                       "type": "boolean",
                       "description": "The AMQP durable flag. Whether the node is durable or transient",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
-                    "linkproperties": {
-                      "name": "linkproperties",
+                    "link-properties": {
+                      "name": "link-properties",
                       "type": "map",
                       "description": "An optional map of AMQP link properties to use with the endpoint",
                       "item": {
                         "type": "string"
                       }
                     },
-                    "connectionproperties": {
-                      "name": "connectionproperties",
+                    "connection-properties": {
+                      "name": "connection-properties",
                       "type": "map",
                       "description": "An optional map of AMQP connection properties to use with the endpoint",
                       "item": {
                         "type": "string"
                       }
                     },
-                    "distributionmode": {
-                      "name": "distributionmode",
+                    "distribution-mode": {
+                      "name": "distribution-mode",
                       "type": "string",
                       "enum": [
                         "move",
                         "copy"
                       ],
                       "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
-                      "serverrequired": true,
+                      "required": true,
                       "default": "move"
                     },
                     "*": {
@@ -234,8 +228,7 @@
                             "name": "uri",
                             "type": "uri",
                             "description": "Network accessible location",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "*": {
                             "name": "*",
@@ -255,8 +248,7 @@
                             "name": "type",
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -287,7 +279,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
 
@@ -300,21 +292,21 @@
                       "name": "qos",
                       "type": "uinteger",
                       "description": "The MQTT QoS level. May be 0, 1, or 2",
-                      "serverrequired": true,
+                      "required": true,
                       "default": 0
                     },
                     "retain": {
                       "name": "retain",
                       "type": "boolean",
                       "description": "The MQTT retain flag to use for publishers on ths endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
                     "cleansession": {
                       "name": "cleansession",
                       "type": "boolean",
                       "description": "The MQTT clean session flag to use for publishers on this endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": true
                     },
                     "willtopic": {
@@ -353,8 +345,7 @@
                             "name": "uri",
                             "type": "uri",
                             "description": "Network accessible location",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "*": {
                             "name": "*",
@@ -374,8 +365,7 @@
                             "name": "type",
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -406,7 +396,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
 
@@ -419,21 +409,21 @@
                       "name": "qos",
                       "type": "uinteger",
                       "description": "The MQTT QoS level. May be 0, 1, or 2",
-                      "serverrequired": true,
+                      "required": true,
                       "default": 0
                     },
                     "retain": {
                       "name": "retain",
                       "type": "boolean",
                       "description": "The MQTT retain flag to use for publishers on ths endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
                     "cleansession": {
                       "name": "cleansession",
                       "type": "boolean",
                       "description": "The MQTT clean session flag to use for publishers on this endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": true
                     },
                     "willtopic": {
@@ -472,8 +462,7 @@
                             "name": "uri",
                             "type": "uri",
                             "description": "Network accessible location",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "*": {
                             "name": "*",
@@ -493,8 +482,7 @@
                             "name": "type",
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -525,7 +513,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
 
@@ -533,7 +521,7 @@
                       "name": "method",
                       "type": "string",
                       "description": "The HTTP method name",
-                      "serverrequired": true,
+                      "required": true,
                       "default": "POST"
                     },
                     "headers": {
@@ -547,15 +535,13 @@
                             "name": "name",
                             "type": "string",
                             "description": "HTTP header name",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "value": {
                             "name": "value",
                             "type": "string",
                             "description": "HTTP header value",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           }
                         }
                       }
@@ -594,8 +580,7 @@
                             "name": "uri",
                             "type": "uri",
                             "description": "Network accessible location",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "*": {
                             "name": "*",
@@ -615,8 +600,7 @@
                             "name": "type",
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -647,7 +631,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
 
@@ -655,14 +639,13 @@
                       "name": "topic",
                       "type": "string",
                       "description": "Apache Kafka topic name",
-                      "clientrequired": true,
-                      "serverrequired": true
+                      "required": true
                     },
                     "acks": {
                       "name": "acks",
                       "type": "integer",
                       "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1",
-                      "serverrequired": true,
+                      "required": true,
                       "default": 1
                     },
                     "key": {
@@ -714,8 +697,7 @@
                             "name": "uri",
                             "type": "uri",
                             "description": "Network accessible location",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "*": {
                             "name": "*",
@@ -735,8 +717,7 @@
                             "name": "type",
                             "type": "string",
                             "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "clientrequired": true,
-                            "serverrequired": true
+                            "required": true
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -767,7 +748,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "serverrequired": true,
+                      "required": true,
                       "default": false
                     },
 
@@ -775,8 +756,7 @@
                       "name": "subject",
                       "type": "string",
                       "description": "The NATS subject",
-                      "clientrequired": true,
-                      "serverrequired": true
+                      "required": true
                     },
                     "*": {
                       "name": "*",

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -126,7 +126,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "id": {
                       "type": "object",
@@ -145,7 +148,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "type": {
                       "type": "object",
@@ -164,7 +170,11 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "type",
+                        "required"
+                      ]
                     },
                     "source": {
                       "type": "object",
@@ -183,7 +193,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "subject": {
                       "type": "object",
@@ -203,7 +216,10 @@
                           "type": "boolean",
                           "description": "CloudEvents subject required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "time": {
                       "type": "object",
@@ -223,7 +239,10 @@
                           "type": "boolean",
                           "description": "The timestamp required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "dataschema": {
                       "type": "object",
@@ -244,7 +263,10 @@
                           "type": "boolean",
                           "description": "The uri required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     }
                   },
                   "additionalProperties": {
@@ -266,7 +288,10 @@
                         "type": "boolean",
                         "description": "Whether the extension is required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   }
                 },
                 "envelopeoptions": {
@@ -320,7 +345,7 @@
                     "properties": {
                       "type": "object",
                       "properties": {
-                        "message_id": {
+                        "message-id": {
                           "type": "object",
                           "description": "AMQP message-id",
                           "properties": {
@@ -339,9 +364,12 @@
                               "type": "boolean",
                               "description": "AMQP message-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "user_id": {
+                        "user-id": {
                           "type": "object",
                           "description": "AMQP user-id",
                           "properties": {
@@ -360,7 +388,10 @@
                               "type": "boolean",
                               "description": "AMQP user-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "to": {
                           "type": "object",
@@ -381,7 +412,10 @@
                               "type": "boolean",
                               "description": "AMQP to required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "subject": {
                           "type": "object",
@@ -402,9 +436,12 @@
                               "type": "boolean",
                               "description": "AMQP subject required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "reply_to": {
+                        "reply-to": {
                           "type": "object",
                           "description": "AMQP reply-to",
                           "properties": {
@@ -423,9 +460,12 @@
                               "type": "boolean",
                               "description": "AMQP reply-to required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "correlation_id": {
+                        "correlation-id": {
                           "type": "object",
                           "description": "AMQP correlation-id",
                           "properties": {
@@ -444,9 +484,12 @@
                               "type": "boolean",
                               "description": "AMQP correlation-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "content_type": {
+                        "content-type": {
                           "type": "object",
                           "description": "AMQP content-type",
                           "properties": {
@@ -465,9 +508,12 @@
                               "type": "boolean",
                               "description": "AMQP content-type required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "content_encoding": {
+                        "content-encoding": {
                           "type": "object",
                           "description": "AMQP content-encoding",
                           "properties": {
@@ -486,7 +532,10 @@
                               "type": "boolean",
                               "description": "AMQP content-encoding required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "absolute_expiry_time": {
                           "type": "object",
@@ -507,9 +556,12 @@
                               "type": "boolean",
                               "description": "AMQP absolute-expiry-time required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "group_id": {
+                        "group-id": {
                           "type": "object",
                           "description": "AMQP group-id",
                           "properties": {
@@ -528,9 +580,12 @@
                               "type": "boolean",
                               "description": "AMQP group-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "group_sequence": {
+                        "group-sequence": {
                           "type": "object",
                           "description": "AMQP group-sequence",
                           "properties": {
@@ -549,7 +604,10 @@
                               "type": "boolean",
                               "description": "AMQP group-sequence required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "reply_to_group_id": {
                           "type": "object",
@@ -570,11 +628,14 @@
                               "type": "boolean",
                               "description": "AMQP reply-to-group-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         }
                       }
                     },
-                    "application_properties": {
+                    "application-properties": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -594,10 +655,13 @@
                             "type": "boolean",
                             "description": "The application property required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
-                    "message_annotations": {
+                    "message-annotations": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -617,10 +681,13 @@
                             "type": "boolean",
                             "description": "Whether the message annotation is required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
-                    "delivery_annotations": {
+                    "delivery-annotations": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -640,7 +707,10 @@
                             "type": "boolean",
                             "description": "Whether the annotation is required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "header": {
@@ -663,7 +733,10 @@
                             "type": "boolean",
                             "description": "AMQP header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "footer": {
@@ -686,7 +759,10 @@
                             "type": "boolean",
                             "description": "AMQP footer required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     }
                   }
@@ -724,7 +800,10 @@
                           "type": "boolean",
                           "description": "MQTT qos value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "retain": {
                       "type": "object",
@@ -741,9 +820,13 @@
                           "type": "boolean",
                           "description": "MQTT retain value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "required"
+                      ]
                     },
-                    "topic_name": {
+                    "topic-name": {
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
@@ -758,7 +841,10 @@
                           "type": "boolean",
                           "description": "MQTT topic-name value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     }
                   }
                 }
@@ -795,7 +881,10 @@
                           "type": "boolean",
                           "description": "MQTT qos value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "retain": {
                       "type": "object",
@@ -812,9 +901,13 @@
                           "type": "boolean",
                           "description": "MQTT retain value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "required"
+                      ]
                     },
-                    "topic_name": {
+                    "topic-name": {
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
@@ -829,7 +922,10 @@
                           "type": "boolean",
                           "description": "MQTT topic-name value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "message_expiry_interval": {
                       "type": "object",
@@ -846,9 +942,12 @@
                           "type": "boolean",
                           "description": "MQTT message-expiry-interval value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "response_topic": {
+                    "response-topic": {
                       "type": "object",
                       "description": "MQTT response-topic",
                       "properties": {
@@ -863,9 +962,12 @@
                           "type": "boolean",
                           "description": "MQTT response-topic value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "correlation_data": {
+                    "correlation-data": {
                       "type": "object",
                       "description": "MQTT correlation-data",
                       "properties": {
@@ -880,9 +982,12 @@
                           "type": "boolean",
                           "description": "MQTT correlation-data value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "content_type": {
+                    "content-type": {
                       "type": "object",
                       "description": "MQTT content-type",
                       "properties": {
@@ -897,9 +1002,12 @@
                           "type": "boolean",
                           "description": "MQTT content-type value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "user_properties": {
+                    "user-properties": {
                       "type": "array",
                       "description": "MQTT user-properties",
                       "items": {
@@ -972,14 +1080,20 @@
                             "type": "boolean",
                             "description": "The Apache Kafka header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "timestamp": {
                       "type": "integer",
                       "description": "The Apache Kafka timestamp"
                     }
-                  }
+                  },
+                  "required": [
+                    "timestamp"
+                  ]
                 }
               },
               "required": [
@@ -1020,7 +1134,10 @@
                             "type": "boolean",
                             "description": "The HTTP header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "query": {
@@ -1044,7 +1161,10 @@
                             "type": "boolean",
                             "description": "The HTTP query parameter required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "path": {
@@ -1163,6 +1283,9 @@
           }
         }
       },
+      "required": [
+        "usage"
+      ],
       "allOf": [
         {
           "oneOf": [
@@ -1220,7 +1343,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "url"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1250,7 +1376,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1265,25 +1394,30 @@
                       "type": "boolean",
                       "description": "The AMQP durable flag. Whether the node is durable or transient"
                     },
-                    "linkproperties": {
+                    "link-properties": {
                       "type": "object",
                       "description": "An optional map of AMQP link properties to use with the endpoint",
                       "additionalProperties": {
                         "type": "string"
                       }
                     },
-                    "connectionproperties": {
+                    "connection-properties": {
                       "type": "object",
                       "description": "An optional map of AMQP connection properties to use with the endpoint",
                       "additionalProperties": {
                         "type": "string"
                       }
                     },
-                    "distributionmode": {
+                    "distribution-mode": {
                       "type": "string",
                       "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "durable",
+                    "distribution-mode"
+                  ]
                 }
               },
               "required": [
@@ -1314,7 +1448,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1344,7 +1481,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1376,7 +1516,13 @@
                       "type": "string",
                       "description": "The MQTT will message definition to configure for publishers on this endpoint"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "qos",
+                    "retain",
+                    "cleansession"
+                  ]
                 }
               },
               "required": [
@@ -1407,7 +1553,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1437,7 +1586,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1469,7 +1621,13 @@
                       "type": "string",
                       "description": "The MQTT will message definition to configure for publishers on this endpoint"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "qos",
+                    "retain",
+                    "cleansession"
+                  ]
                 }
               },
               "required": [
@@ -1500,7 +1658,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1530,7 +1691,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1555,7 +1719,11 @@
                             "type": "string",
                             "description": "HTTP header value"
                           }
-                        }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ]
                       }
                     },
                     "query": {
@@ -1565,7 +1733,11 @@
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "method"
+                  ]
                 }
               },
               "required": [
@@ -1596,7 +1768,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1626,7 +1801,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1660,7 +1838,12 @@
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "topic",
+                    "acks"
+                  ]
                 }
               },
               "required": [
@@ -1691,7 +1874,10 @@
                             "format": "uri",
                             "description": "Network accessible location"
                           }
-                        }
+                        },
+                        "required": [
+                          "uri"
+                        ]
                       }
                     },
                     "authorization": {
@@ -1721,7 +1907,10 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "required": [
+                          "type"
+                        ]
                       }
                     },
                     "deployed": {
@@ -1732,7 +1921,11 @@
                       "type": "string",
                       "description": "The NATS subject"
                     }
-                  }
+                  },
+                  "required": [
+                    "deployed",
+                    "subject"
+                  ]
                 }
               },
               "required": [

--- a/message/model.json
+++ b/message/model.json
@@ -69,7 +69,7 @@
                               "enum": [
                                 true
                               ],
-                              "serverrequired": true,
+                              "required": true,
                               "default": true
                             }
                           }
@@ -98,7 +98,7 @@
                               "enum": [
                                 true
                               ],
-                              "serverrequired": true,
+                              "required": true,
                               "default": true
                             }
                           }
@@ -115,7 +115,7 @@
                             "type": {
                               "name": "type",
                               "type": "string",
-                              "serverrequired": true,
+                              "required": true,
                               "default": "string"
                             },
                             "value": {
@@ -129,7 +129,7 @@
                               "enum": [
                                 true
                               ],
-                              "serverrequired": true,
+                              "required": true,
                               "default": true
                             }
                           }
@@ -158,7 +158,7 @@
                               "enum": [
                                 true
                               ],
-                              "serverrequired": true,
+                              "required": true,
                               "default": true
                             }
                           }
@@ -185,7 +185,7 @@
                               "name": "required",
                               "description": "CloudEvents subject required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -212,7 +212,7 @@
                               "name": "required",
                               "description": "The timestamp required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -239,7 +239,7 @@
                               "name": "required",
                               "description": "The uri required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -267,7 +267,7 @@
                               "name": "required",
                               "description": "Whether the extension is required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -312,13 +312,15 @@
                       "name": "protocoloptions",
                       "description": "AMQP message metadata constraints",
                       "type": "object",
+                      "relaxednames": true,
                       "attributes": {
                         "properties": {
                           "name": "properties",
                           "type": "object",
+                          "relaxednames": true,
                           "attributes": {
-                            "message_id": {
-                              "name": "message_id",
+                            "message-id": {
+                              "name": "message-id",
                               "description": "AMQP message-id",
                               "type": "object",
                               "attributes": {
@@ -340,13 +342,13 @@
                                   "name": "required",
                                   "description": "AMQP message-id required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": true
                                 }
                               }
                             },
-                            "user_id": {
-                              "name": "user_id",
+                            "user-id": {
+                              "name": "user-id",
                               "description": "AMQP user-id",
                               "type": "object",
                               "attributes": {
@@ -368,7 +370,7 @@
                                   "name": "required",
                                   "description": "AMQP user-id required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
@@ -396,7 +398,7 @@
                                   "name": "required",
                                   "description": "AMQP to required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
@@ -424,13 +426,13 @@
                                   "name": "required",
                                   "description": "AMQP subject required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": true
                                 }
                               }
                             },
-                            "reply_to": {
-                              "name": "reply_to",
+                            "reply-to": {
+                              "name": "reply-to",
                               "description": "AMQP reply-to",
                               "type": "object",
                               "attributes": {
@@ -452,13 +454,13 @@
                                   "name": "required",
                                   "description": "AMQP reply-to required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
                             },
-                            "correlation_id": {
-                              "name": "correlation_id",
+                            "correlation-id": {
+                              "name": "correlation-id",
                               "description": "AMQP correlation-id",
                               "type": "object",
                               "attributes": {
@@ -480,13 +482,13 @@
                                   "name": "required",
                                   "description": "AMQP correlation-id required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
                             },
-                            "content_type": {
-                              "name": "content_type",
+                            "content-type": {
+                              "name": "content-type",
                               "description": "AMQP content-type",
                               "type": "object",
                               "attributes": {
@@ -508,13 +510,13 @@
                                   "name": "required",
                                   "description": "AMQP content-type required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
                             },
-                            "content_encoding": {
-                              "name": "content_encoding",
+                            "content-encoding": {
+                              "name": "content-encoding",
                               "description": "AMQP content-encoding",
                               "type": "object",
                               "attributes": {
@@ -536,7 +538,7 @@
                                   "name": "required",
                                   "description": "AMQP content-encoding required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
@@ -564,13 +566,13 @@
                                   "name": "required",
                                   "description": "AMQP absolute-expiry-time required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
                             },
-                            "group_id": {
-                              "name": "group_id",
+                            "group-id": {
+                              "name": "group-id",
                               "description": "AMQP group-id",
                               "type": "object",
                               "attributes": {
@@ -592,13 +594,13 @@
                                   "name": "required",
                                   "description": "AMQP group-id required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
                             },
-                            "group_sequence": {
-                              "name": "group_sequence",
+                            "group-sequence": {
+                              "name": "group-sequence",
                               "description": "AMQP group-sequence",
                               "type": "object",
                               "attributes": {
@@ -620,7 +622,7 @@
                                   "name": "required",
                                   "description": "AMQP group-sequence required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
@@ -648,15 +650,15 @@
                                   "name": "required",
                                   "description": "AMQP reply-to-group-id required",
                                   "type": "boolean",
-                                  "serverrequired": true,
+                                  "required": true,
                                   "default": false
                                 }
                               }
                             }
                           }
                         },
-                        "application_properties": {
-                          "name": "application_properties",
+                        "application-properties": {
+                          "name": "application-properties",
                           "type": "map",
                           "item": {
                             "type": "object",
@@ -679,14 +681,14 @@
                                 "name": "required",
                                 "description": "The application property required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }
                           }
                         },
-                        "message_annotations": {
-                          "name": "message_annotations",
+                        "message-annotations": {
+                          "name": "message-annotations",
                           "type": "map",
                           "item": {
                             "type": "object",
@@ -709,14 +711,14 @@
                                 "name": "required",
                                 "description": "Whether the message annotation is required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }
                           }
                         },
-                        "delivery_annotations": {
-                          "name": "delivery_annotations",
+                        "delivery-annotations": {
+                          "name": "delivery-annotations",
                           "type": "map",
                           "item": {
                             "type": "object",
@@ -739,7 +741,7 @@
                                 "name": "required",
                                 "description": "Whether the annotation is required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }
@@ -769,7 +771,7 @@
                                 "name": "required",
                                 "description": "AMQP header required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }
@@ -799,7 +801,7 @@
                                 "name": "required",
                                 "description": "AMQP footer required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }
@@ -815,6 +817,7 @@
                       "name": "protocoloptions",
                       "description": "MQTT message metadata constraints",
                       "type": "object",
+                      "relaxednames": true,
                       "attributes": {
                         "qos": {
                           "name": "qos",
@@ -834,7 +837,7 @@
                               "name": "required",
                               "description": "MQTT qos value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -852,20 +855,20 @@
                               "name": "value",
                               "description": "MQTT retain value template",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             },
                             "required": {
                               "name": "required",
                               "description": "MQTT retain value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
                         },
-                        "topic_name": {
-                          "name": "topic_name",
+                        "topic-name": {
+                          "name": "topic-name",
                           "description": "MQTT topic-name",
                           "type": "object",
                           "attributes": {
@@ -882,7 +885,7 @@
                               "name": "required",
                               "description": "MQTT topic-name value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -897,6 +900,7 @@
                       "name": "protocoloptions",
                       "description": "MQTT message metadata constraints",
                       "type": "object",
+                      "relaxednames": true,
                       "attributes": {
                         "qos": {
                           "name": "qos",
@@ -916,7 +920,7 @@
                               "name": "required",
                               "description": "MQTT qos value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -934,20 +938,20 @@
                               "name": "value",
                               "description": "MQTT retain value template",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             },
                             "required": {
                               "name": "required",
                               "description": "MQTT retain value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
                         },
-                        "topic_name": {
-                          "name": "topic_name",
+                        "topic-name": {
+                          "name": "topic-name",
                           "description": "MQTT topic-name",
                           "type": "object",
                           "attributes": {
@@ -964,7 +968,7 @@
                               "name": "required",
                               "description": "MQTT topic-name value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
@@ -987,13 +991,13 @@
                               "name": "required",
                               "description": "MQTT message-expiry-interval value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
                         },
-                        "response_topic": {
-                          "name": "response_topic",
+                        "response-topic": {
+                          "name": "response-topic",
                           "description": "MQTT response-topic",
                           "type": "object",
                           "attributes": {
@@ -1010,13 +1014,13 @@
                               "name": "required",
                               "description": "MQTT response-topic value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
                         },
-                        "correlation_data": {
-                          "name": "correlation_data",
+                        "correlation-data": {
+                          "name": "correlation-data",
                           "description": "MQTT correlation-data",
                           "type": "object",
                           "attributes": {
@@ -1033,13 +1037,13 @@
                               "name": "required",
                               "description": "MQTT correlation-data value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
                         },
-                        "content_type": {
-                          "name": "content_type",
+                        "content-type": {
+                          "name": "content-type",
                           "description": "MQTT content-type",
                           "type": "object",
                           "attributes": {
@@ -1056,13 +1060,13 @@
                               "name": "required",
                               "description": "MQTT content-type value required",
                               "type": "boolean",
-                              "serverrequired": true,
+                              "required": true,
                               "default": false
                             }
                           }
                         },
-                        "user_properties": {
-                          "name": "user_properties",
+                        "user-properties": {
+                          "name": "user-properties",
                           "description": "MQTT user-properties",
                           "type": "array",
                           "item": {
@@ -1136,7 +1140,7 @@
                                 "name": "required",
                                 "description": "The Apache Kafka header required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }
@@ -1146,7 +1150,7 @@
                           "name": "timestamp",
                           "description": "The Apache Kafka timestamp",
                           "type": "integer",
-                          "serverrequired": true,
+                          "required": true,
                           "default": 0
                         }
                       }
@@ -1185,7 +1189,7 @@
                                 "name": "required",
                                 "description": "The HTTP header required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }
@@ -1216,7 +1220,7 @@
                                 "name": "required",
                                 "description": "The HTTP query parameter required",
                                 "type": "boolean",
-                                "serverrequired": true,
+                                "required": true,
                                 "default": false
                               }
                             }

--- a/message/schemas/document-schema.json
+++ b/message/schemas/document-schema.json
@@ -126,7 +126,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "id": {
                       "type": "object",
@@ -145,7 +148,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "type": {
                       "type": "object",
@@ -164,7 +170,11 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "type",
+                        "required"
+                      ]
                     },
                     "source": {
                       "type": "object",
@@ -183,7 +193,10 @@
                         "required": {
                           "type": "boolean"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "subject": {
                       "type": "object",
@@ -203,7 +216,10 @@
                           "type": "boolean",
                           "description": "CloudEvents subject required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "time": {
                       "type": "object",
@@ -223,7 +239,10 @@
                           "type": "boolean",
                           "description": "The timestamp required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "dataschema": {
                       "type": "object",
@@ -244,7 +263,10 @@
                           "type": "boolean",
                           "description": "The uri required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     }
                   },
                   "additionalProperties": {
@@ -266,7 +288,10 @@
                         "type": "boolean",
                         "description": "Whether the extension is required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   }
                 },
                 "envelopeoptions": {
@@ -320,7 +345,7 @@
                     "properties": {
                       "type": "object",
                       "properties": {
-                        "message_id": {
+                        "message-id": {
                           "type": "object",
                           "description": "AMQP message-id",
                           "properties": {
@@ -339,9 +364,12 @@
                               "type": "boolean",
                               "description": "AMQP message-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "user_id": {
+                        "user-id": {
                           "type": "object",
                           "description": "AMQP user-id",
                           "properties": {
@@ -360,7 +388,10 @@
                               "type": "boolean",
                               "description": "AMQP user-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "to": {
                           "type": "object",
@@ -381,7 +412,10 @@
                               "type": "boolean",
                               "description": "AMQP to required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "subject": {
                           "type": "object",
@@ -402,9 +436,12 @@
                               "type": "boolean",
                               "description": "AMQP subject required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "reply_to": {
+                        "reply-to": {
                           "type": "object",
                           "description": "AMQP reply-to",
                           "properties": {
@@ -423,9 +460,12 @@
                               "type": "boolean",
                               "description": "AMQP reply-to required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "correlation_id": {
+                        "correlation-id": {
                           "type": "object",
                           "description": "AMQP correlation-id",
                           "properties": {
@@ -444,9 +484,12 @@
                               "type": "boolean",
                               "description": "AMQP correlation-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "content_type": {
+                        "content-type": {
                           "type": "object",
                           "description": "AMQP content-type",
                           "properties": {
@@ -465,9 +508,12 @@
                               "type": "boolean",
                               "description": "AMQP content-type required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "content_encoding": {
+                        "content-encoding": {
                           "type": "object",
                           "description": "AMQP content-encoding",
                           "properties": {
@@ -486,7 +532,10 @@
                               "type": "boolean",
                               "description": "AMQP content-encoding required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "absolute_expiry_time": {
                           "type": "object",
@@ -507,9 +556,12 @@
                               "type": "boolean",
                               "description": "AMQP absolute-expiry-time required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "group_id": {
+                        "group-id": {
                           "type": "object",
                           "description": "AMQP group-id",
                           "properties": {
@@ -528,9 +580,12 @@
                               "type": "boolean",
                               "description": "AMQP group-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
-                        "group_sequence": {
+                        "group-sequence": {
                           "type": "object",
                           "description": "AMQP group-sequence",
                           "properties": {
@@ -549,7 +604,10 @@
                               "type": "boolean",
                               "description": "AMQP group-sequence required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         },
                         "reply_to_group_id": {
                           "type": "object",
@@ -570,11 +628,14 @@
                               "type": "boolean",
                               "description": "AMQP reply-to-group-id required"
                             }
-                          }
+                          },
+                          "required": [
+                            "required"
+                          ]
                         }
                       }
                     },
-                    "application_properties": {
+                    "application-properties": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -594,10 +655,13 @@
                             "type": "boolean",
                             "description": "The application property required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
-                    "message_annotations": {
+                    "message-annotations": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -617,10 +681,13 @@
                             "type": "boolean",
                             "description": "Whether the message annotation is required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
-                    "delivery_annotations": {
+                    "delivery-annotations": {
                       "type": "object",
                       "additionalProperties": {
                         "type": "object",
@@ -640,7 +707,10 @@
                             "type": "boolean",
                             "description": "Whether the annotation is required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "header": {
@@ -663,7 +733,10 @@
                             "type": "boolean",
                             "description": "AMQP header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "footer": {
@@ -686,7 +759,10 @@
                             "type": "boolean",
                             "description": "AMQP footer required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     }
                   }
@@ -724,7 +800,10 @@
                           "type": "boolean",
                           "description": "MQTT qos value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "retain": {
                       "type": "object",
@@ -741,9 +820,13 @@
                           "type": "boolean",
                           "description": "MQTT retain value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "required"
+                      ]
                     },
-                    "topic_name": {
+                    "topic-name": {
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
@@ -758,7 +841,10 @@
                           "type": "boolean",
                           "description": "MQTT topic-name value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     }
                   }
                 }
@@ -795,7 +881,10 @@
                           "type": "boolean",
                           "description": "MQTT qos value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "retain": {
                       "type": "object",
@@ -812,9 +901,13 @@
                           "type": "boolean",
                           "description": "MQTT retain value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "value",
+                        "required"
+                      ]
                     },
-                    "topic_name": {
+                    "topic-name": {
                       "type": "object",
                       "description": "MQTT topic-name",
                       "properties": {
@@ -829,7 +922,10 @@
                           "type": "boolean",
                           "description": "MQTT topic-name value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
                     "message_expiry_interval": {
                       "type": "object",
@@ -846,9 +942,12 @@
                           "type": "boolean",
                           "description": "MQTT message-expiry-interval value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "response_topic": {
+                    "response-topic": {
                       "type": "object",
                       "description": "MQTT response-topic",
                       "properties": {
@@ -863,9 +962,12 @@
                           "type": "boolean",
                           "description": "MQTT response-topic value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "correlation_data": {
+                    "correlation-data": {
                       "type": "object",
                       "description": "MQTT correlation-data",
                       "properties": {
@@ -880,9 +982,12 @@
                           "type": "boolean",
                           "description": "MQTT correlation-data value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "content_type": {
+                    "content-type": {
                       "type": "object",
                       "description": "MQTT content-type",
                       "properties": {
@@ -897,9 +1002,12 @@
                           "type": "boolean",
                           "description": "MQTT content-type value required"
                         }
-                      }
+                      },
+                      "required": [
+                        "required"
+                      ]
                     },
-                    "user_properties": {
+                    "user-properties": {
                       "type": "array",
                       "description": "MQTT user-properties",
                       "items": {
@@ -972,14 +1080,20 @@
                             "type": "boolean",
                             "description": "The Apache Kafka header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "timestamp": {
                       "type": "integer",
                       "description": "The Apache Kafka timestamp"
                     }
-                  }
+                  },
+                  "required": [
+                    "timestamp"
+                  ]
                 }
               },
               "required": [
@@ -1020,7 +1134,10 @@
                             "type": "boolean",
                             "description": "The HTTP header required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "query": {
@@ -1044,7 +1161,10 @@
                             "type": "boolean",
                             "description": "The HTTP query parameter required"
                           }
-                        }
+                        },
+                        "required": [
+                          "required"
+                        ]
                       }
                     },
                     "path": {

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -1064,7 +1064,10 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "id": {
                 "type": "object",
@@ -1083,7 +1086,10 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "type": {
                 "type": "object",
@@ -1102,7 +1108,11 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "type",
+                  "required"
+                ]
               },
               "source": {
                 "type": "object",
@@ -1121,7 +1131,10 @@
                   "required": {
                     "type": "boolean"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "subject": {
                 "type": "object",
@@ -1141,7 +1154,10 @@
                     "type": "boolean",
                     "description": "CloudEvents subject required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "time": {
                 "type": "object",
@@ -1161,7 +1177,10 @@
                     "type": "boolean",
                     "description": "The timestamp required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "dataschema": {
                 "type": "object",
@@ -1182,7 +1201,10 @@
                     "type": "boolean",
                     "description": "The uri required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               }
             },
             "additionalProperties": {
@@ -1204,7 +1226,10 @@
                   "type": "boolean",
                   "description": "Whether the extension is required"
                 }
-              }
+              },
+              "required": [
+                "required"
+              ]
             }
           },
           "envelopeoptions": {
@@ -1254,7 +1279,7 @@
               "properties": {
                 "type": "object",
                 "properties": {
-                  "message_id": {
+                  "message-id": {
                     "type": "object",
                     "description": "AMQP message-id",
                     "properties": {
@@ -1273,9 +1298,12 @@
                         "type": "boolean",
                         "description": "AMQP message-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "user_id": {
+                  "user-id": {
                     "type": "object",
                     "description": "AMQP user-id",
                     "properties": {
@@ -1294,7 +1322,10 @@
                         "type": "boolean",
                         "description": "AMQP user-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "to": {
                     "type": "object",
@@ -1315,7 +1346,10 @@
                         "type": "boolean",
                         "description": "AMQP to required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "subject": {
                     "type": "object",
@@ -1336,9 +1370,12 @@
                         "type": "boolean",
                         "description": "AMQP subject required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "reply_to": {
+                  "reply-to": {
                     "type": "object",
                     "description": "AMQP reply-to",
                     "properties": {
@@ -1357,9 +1394,12 @@
                         "type": "boolean",
                         "description": "AMQP reply-to required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "correlation_id": {
+                  "correlation-id": {
                     "type": "object",
                     "description": "AMQP correlation-id",
                     "properties": {
@@ -1378,9 +1418,12 @@
                         "type": "boolean",
                         "description": "AMQP correlation-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "content_type": {
+                  "content-type": {
                     "type": "object",
                     "description": "AMQP content-type",
                     "properties": {
@@ -1399,9 +1442,12 @@
                         "type": "boolean",
                         "description": "AMQP content-type required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "content_encoding": {
+                  "content-encoding": {
                     "type": "object",
                     "description": "AMQP content-encoding",
                     "properties": {
@@ -1420,7 +1466,10 @@
                         "type": "boolean",
                         "description": "AMQP content-encoding required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "absolute_expiry_time": {
                     "type": "object",
@@ -1441,9 +1490,12 @@
                         "type": "boolean",
                         "description": "AMQP absolute-expiry-time required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "group_id": {
+                  "group-id": {
                     "type": "object",
                     "description": "AMQP group-id",
                     "properties": {
@@ -1462,9 +1514,12 @@
                         "type": "boolean",
                         "description": "AMQP group-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
-                  "group_sequence": {
+                  "group-sequence": {
                     "type": "object",
                     "description": "AMQP group-sequence",
                     "properties": {
@@ -1483,7 +1538,10 @@
                         "type": "boolean",
                         "description": "AMQP group-sequence required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   },
                   "reply_to_group_id": {
                     "type": "object",
@@ -1504,11 +1562,14 @@
                         "type": "boolean",
                         "description": "AMQP reply-to-group-id required"
                       }
-                    }
+                    },
+                    "required": [
+                      "required"
+                    ]
                   }
                 }
               },
-              "application_properties": {
+              "application-properties": {
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
@@ -1528,10 +1589,13 @@
                       "type": "boolean",
                       "description": "The application property required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
-              "message_annotations": {
+              "message-annotations": {
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
@@ -1551,10 +1615,13 @@
                       "type": "boolean",
                       "description": "Whether the message annotation is required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
-              "delivery_annotations": {
+              "delivery-annotations": {
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
@@ -1574,7 +1641,10 @@
                       "type": "boolean",
                       "description": "Whether the annotation is required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "header": {
@@ -1597,7 +1667,10 @@
                       "type": "boolean",
                       "description": "AMQP header required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "footer": {
@@ -1620,7 +1693,10 @@
                       "type": "boolean",
                       "description": "AMQP footer required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               }
             }
@@ -1658,7 +1734,10 @@
                     "type": "boolean",
                     "description": "MQTT qos value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "retain": {
                 "type": "object",
@@ -1675,9 +1754,13 @@
                     "type": "boolean",
                     "description": "MQTT retain value required"
                   }
-                }
+                },
+                "required": [
+                  "value",
+                  "required"
+                ]
               },
-              "topic_name": {
+              "topic-name": {
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
@@ -1692,7 +1775,10 @@
                     "type": "boolean",
                     "description": "MQTT topic-name value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               }
             }
           }
@@ -1729,7 +1815,10 @@
                     "type": "boolean",
                     "description": "MQTT qos value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "retain": {
                 "type": "object",
@@ -1746,9 +1835,13 @@
                     "type": "boolean",
                     "description": "MQTT retain value required"
                   }
-                }
+                },
+                "required": [
+                  "value",
+                  "required"
+                ]
               },
-              "topic_name": {
+              "topic-name": {
                 "type": "object",
                 "description": "MQTT topic-name",
                 "properties": {
@@ -1763,7 +1856,10 @@
                     "type": "boolean",
                     "description": "MQTT topic-name value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
               "message_expiry_interval": {
                 "type": "object",
@@ -1780,9 +1876,12 @@
                     "type": "boolean",
                     "description": "MQTT message-expiry-interval value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "response_topic": {
+              "response-topic": {
                 "type": "object",
                 "description": "MQTT response-topic",
                 "properties": {
@@ -1797,9 +1896,12 @@
                     "type": "boolean",
                     "description": "MQTT response-topic value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "correlation_data": {
+              "correlation-data": {
                 "type": "object",
                 "description": "MQTT correlation-data",
                 "properties": {
@@ -1814,9 +1916,12 @@
                     "type": "boolean",
                     "description": "MQTT correlation-data value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "content_type": {
+              "content-type": {
                 "type": "object",
                 "description": "MQTT content-type",
                 "properties": {
@@ -1831,9 +1936,12 @@
                     "type": "boolean",
                     "description": "MQTT content-type value required"
                   }
-                }
+                },
+                "required": [
+                  "required"
+                ]
               },
-              "user_properties": {
+              "user-properties": {
                 "type": "array",
                 "description": "MQTT user-properties",
                 "items": {
@@ -1906,14 +2014,20 @@
                       "type": "boolean",
                       "description": "The Apache Kafka header required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "timestamp": {
                 "type": "integer",
                 "description": "The Apache Kafka timestamp"
               }
-            }
+            },
+            "required": [
+              "timestamp"
+            ]
           }
         },
         "required": [
@@ -1954,7 +2068,10 @@
                       "type": "boolean",
                       "description": "The HTTP header required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "query": {
@@ -1978,7 +2095,10 @@
                       "type": "boolean",
                       "description": "The HTTP query parameter required"
                     }
-                  }
+                  },
+                  "required": [
+                    "required"
+                  ]
                 }
               },
               "path": {

--- a/schema/model.json
+++ b/schema/model.json
@@ -32,7 +32,7 @@
               "name": "validation",
               "type": "boolean",
               "description": "Verify compliance with specified schema 'format'",
-              "serverrequired": true,
+              "required": true,
               "default": true
             }
           }

--- a/tools/dict
+++ b/tools/dict
@@ -173,6 +173,7 @@ rawdata
 readonly
 redis
 registryid
+relaxednames
 repos
 resourceid
 resourcescount


### PR DESCRIPTION
- fix typos in doc/contributors.md
- get rid of `clientrequired` and rename `serverrequired` to just `required`.
  It now means "this attr MUST have a non-null value" without saying who
  provides it.
- mentioned we're http-only today but it might change in the future, and at
  that time we'll have a clean separation between core & http
- Add an "Implmentation Customizations" section to talk about adding authN/Z
  and other types of customization logic
- Allow ANY model changes as long as all entities are compliant with new model
  prior to completing the request. Server MAY choose to update data, or reject.
- Remove "maxmaxversions" capability
- Servers must accept "0" for maxversions but can prune at any time, even at 1.
- Add "relaxednames" aspect to "object" typed attributes, to allow "-" in names

Fixes: #267
Fixes: #230
Fixes: #264
Fixes: #270
Fixes: #271
Fixes: #273
Fixes: #272