### PR TITLE
Week of Apr 14 changes

### DIFF
--- a/core/primer.md
+++ b/core/primer.md
@@ -813,3 +813,18 @@ This accommodation only applies to incoming messages. All server generated
 messages (aside from when special flags, like the `?doc` flag, is enabled)
 must include all required attributes, even if they are duplicated elsewhere
 in the message.
+
+# Deprecation of entities in an xRegistry
+
+The core specification defines a `deprecated` attribute that may appear
+under a Resource's `meta` sub-object. This attribute was added to the Resource
+itself rather than to the Version because it was determined that the most
+likely usage of this feature is to express the intent to deprecate the entire
+Resource rather than just one Version (or subset of Versions). This is not say
+that the use of this feature might not be useful at the Version-level or even
+at the Group-level. However, for those cases, custom models may define
+an extension at the appropriate location in the model to meet their needs.
+When doing so it is recommended to use the same attribute definition as
+defined in the core specification for consistency. It is worth noting that
+the Endpoint [specification](../endpoint/spec.md) does exactly this to
+indicate when an Endpoint (i.e. a Group) is deprecated.

--- a/core/samples/contoso-crm.cereg
+++ b/core/samples/contoso-crm.cereg
@@ -304,7 +304,6 @@
                             },
                             "subject": {
                                 "type": "string",
-                                "required": false,
                                 "description": "The subject of the event"
                             }
                         }

--- a/core/samples/contoso-crm.cereg.yaml
+++ b/core/samples/contoso-crm.cereg.yaml
@@ -232,7 +232,6 @@ definitionGroups:
               description: The source of the event
             subject:
               type: string
-              required: false
               description: The subject of the event
         schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerContactAddedEventData"
 schemagroups:

--- a/core/samples/doc-store-model.json
+++ b/core/samples/doc-store-model.json
@@ -1,12 +1,10 @@
 {
   "groups": {
     "dirs": {
-      "plural": "dirs",
       "singular": "dir",
 
       "resources": {
         "files": {
-          "plural": "files",
           "singular": "file"
         }
       }

--- a/core/samples/formatted-doc-store-model.json
+++ b/core/samples/formatted-doc-store-model.json
@@ -1,12 +1,10 @@
 {
   "groups": {
     "docs": {
-      "plural": "docs",
       "singular": "doc",
 
       "resources": {
         "formats": {
-          "plural": "formats",
           "singular": "format"
         }
       }

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -2,7 +2,6 @@
   "groups": {
     "endpoints": {
       "singular": "endpoint",
-      "plural": "endpoints",
       "modelversion": "1.0-rc1",
       "compatiblewith": "https://xregistry.io/xreg/domains/endpoint/specs/model.json",
       "attributes": {
@@ -15,8 +14,7 @@
             "consumer",
             "producer"
           ],
-          "strict": true,
-          "required": false
+          "strict": true
         },
         "channel": {
           "name": "channel",
@@ -111,8 +109,7 @@
                           "url": {
                             "name": "url",
                             "type": "url",
-                            "description": "AMQP Addressing URL",
-                            "required": false
+                            "description": "AMQP Addressing URL"
                           },
                           "*": {
                             "name": "*",
@@ -131,8 +128,7 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "required": false
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
                           "resourceuri": {
                             "name": "resourceuri",
@@ -169,8 +165,7 @@
                     "node": {
                       "name": "node",
                       "type": "string",
-                      "description": "The AMQP node name. Commonly the name of a queue or a topic. Corresponds to the 'address' in source or target of the attach frame.",
-                      "required": false
+                      "description": "The AMQP node name. Commonly the name of a queue or a topic. Corresponds to the 'address' in source or target of the attach frame."
                     },
                     "durable": {
                       "name": "durable",
@@ -247,8 +242,7 @@
                           "uri": {
                             "name": "uri",
                             "type": "uri",
-                            "description": "MQTT URI (mqtt, mqtts, or ws scheme)",
-                            "required": false
+                            "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                           },
                           "*": {
                             "name": "*",
@@ -267,8 +261,7 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "required": false
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -305,8 +298,7 @@
                     "topic": {
                       "name": "topic",
                       "type": "string",
-                      "description": "The MQTT topic path that is used for communication with the endpoint unless overridden by the message",
-                      "required": false
+                      "description": "The MQTT topic path that is used for communication with the endpoint unless overridden by the message"
                     },
                     "qos": {
                       "name": "qos",
@@ -337,14 +329,12 @@
                     "willtopic": {
                       "name": "willtopic",
                       "type": "string",
-                      "description": "The MQTT will topic to configure for publishers on this endpoint",
-                      "required": false
+                      "description": "The MQTT will topic to configure for publishers on this endpoint"
                     },
                     "willmessage": {
                       "name": "willmessage",
                       "type": "xid",
-                      "description": "The MQTT will message definition to configure for publishers on this endpoint. This MUST be a reference to a message definition",
-                      "required": false
+                      "description": "The MQTT will message definition to configure for publishers on this endpoint. This MUST be a reference to a message definition"
                     },
                     "*": {
                       "name": "*",
@@ -371,8 +361,7 @@
                           "uri": {
                             "name": "uri",
                             "type": "uri",
-                            "description": "MQTT URI (mqtt, mqtts, or ws scheme)",
-                            "required": false
+                            "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                           },
                           "*": {
                             "name": "*",
@@ -391,8 +380,7 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "required": false
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -429,8 +417,7 @@
                     "topic": {
                       "name": "topic",
                       "type": "string",
-                      "description": "MQTT topic path that is used for communication with the endpoint unless overridden by the message",
-                      "required": false
+                      "description": "MQTT topic path that is used for communication with the endpoint unless overridden by the message"
                     },
                     "qos": {
                       "name": "qos",
@@ -461,14 +448,12 @@
                     "willtopic": {
                       "name": "willtopic",
                       "type": "string",
-                      "description": "The MQTT will topic to configure for publishers on this endpoint",
-                      "required": false
+                      "description": "The MQTT will topic to configure for publishers on this endpoint"
                     },
                     "willmessage": {
                       "name": "willmessage",
                       "type": "xid",
-                      "description": "The MQTT will message definition to configure for publishers on this endpoint. This MUST be a reference to a message definition",
-                      "required": false
+                      "description": "The MQTT will message definition to configure for publishers on this endpoint. This MUST be a reference to a message definition"
                     },
                     "*": {
                       "name": "*",
@@ -495,8 +480,7 @@
                           "uri": {
                             "name": "uri",
                             "type": "uri",
-                            "description": "HTTP URI",
-                            "required": false
+                            "description": "HTTP URI"
                           },
                           "*": {
                             "name": "*",
@@ -515,8 +499,7 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "required": false
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -573,8 +556,7 @@
                           "value": {
                             "name": "value",
                             "type": "string",
-                            "description": "HTTP header value",
-                            "required": false
+                            "description": "HTTP header value"
                           }
                         }
                       }
@@ -649,8 +631,7 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "required": false
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -687,8 +668,7 @@
                     "topic": {
                       "name": "topic",
                       "type": "string",
-                      "description": "Apache Kafka topic name",
-                      "required": false
+                      "description": "Apache Kafka topic name"
                     },
                     "acks": {
                       "name": "acks",
@@ -759,8 +739,7 @@
                           "uri": {
                             "name": "uri",
                             "type": "uri",
-                            "description": "NATS URI",
-                            "required": false
+                            "description": "NATS URI"
                           },
                           "*": {
                             "name": "*",
@@ -779,8 +758,7 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined",
-                            "required": false
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
                           },
                           "resourceurl": {
                             "name": "resourceurl",
@@ -817,8 +795,7 @@
                     "subject": {
                       "name": "subject",
                       "type": "string",
-                      "description": "The NATS subject",
-                      "required": false
+                      "description": "The NATS subject"
                     },
                     "*": {
                       "name": "*",

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -310,52 +310,8 @@ The following attributes are defined for Endpoints:
 
 ### `deprecated`
 
-- Type: Object containing the following properties:
-  - `effective`<br>
-    An OPTIONAL property indicating the time when the Endpoint entered, or will
-    enter, a deprecated state. The date MAY be in the past or future. If this
-    property is not present the Endpoint is already in a deprecated state.
-    When specified, this MUST be an [RFC3339][rfc3339] timestamp.
-
-  - `removal`<br>
-    An OPTIONAL property indicating the time when the Endpoint MAY be removed.
-    The Endpoint MUST NOT be removed before this time. If this property is not
-    present then client can not make any assumption as to when the Endpoint
-    might be removed. Note: as with most properties, this property is mutable.
-    When specified, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT
-    be sooner than the `effective` time.
-
-  - `alternative`<br>
-    An OPTIONAL property specifying the URL to an alternative Endpoint the
-    client can consider as a replacement for this Endpoint. There is no
-    guarantee that the referenced Endpoint is an exact replacement, rather the
-    client is expected to investigate the Endpoint to determine if it is
-    appropriate.
-
-  - `docs`<br>
-    An OPTIONAL property specifying the URL to additional information about
-    the deprecation of the Endpoint. This specification does not mandate any
-    particular format or information, however some possibilities include:
-    reasons for the deprecation or additional information about likely
-    alternative Endpoints. The URL MUST support an HTTP GET request.
-
-- Description: This specification makes no statement as to whether any
-  existing secondary resources (such as subscriptions) will still be valid and
-  usable after the Endpoint is removed. However, it is expected that new
-  requests to create a secondary resource will likely be rejected.
-
-  Note that an implementation is not mandated to use this attribute in
-  advance of removing an Endpoint, but is it RECOMMENDED that they do so.
-- Constraints:
-  - OPTIONAL
-- Examples:
-  - `"deprecated": {}`
-  - ```
-    "deprecated": {
-      "removal": "2030-12-19T00:00:00-00:00",
-      "alternative": "https://example.com/endpoints/123"
-    }
-    ```
+See the [deprecated](../core/spec.md#deprecated) attribute in the core
+[xRegistry](../core/spec.md#deprecated) specification.
 
 ### `envelope`
 
@@ -587,7 +543,7 @@ Example:
 ```yaml
 {
   "protocol": "HTTP/1.1",
-  "options": {
+  "protocoloptions": {
     "method": "POST"
   },
   "messagegroups": [
@@ -608,7 +564,7 @@ Example:
 ```yaml
 {
   "protocol": "HTTP/1.1",
-  "options": {
+  "protocoloptions": {
     "method": "POST"
   },
 
@@ -688,7 +644,7 @@ Example:
 ```yaml
 {
   "protocol": "HTTP/1.1",
-  "options": {
+  "protocoloptions": {
     "method": "POST",
     "headers": [
       {

--- a/message/model.json
+++ b/message/model.json
@@ -2,7 +2,6 @@
   "groups": {
     "messagegroups": {
       "singular": "messagegroup",
-      "plural": "messagegroups",
       "modelversion": "1.0-rc1",
       "compatiblewith": "https://xregistry.io/xreg/domains/message/specs/model.json",
       "attributes": {
@@ -25,7 +24,6 @@
       "resources": {
         "messages": {
           "singular": "message",
-          "plural": "messages",
           "maxversions": 1,
           "setdefaultversionsticky": false,
           "hasdocument": false,

--- a/message/spec.md
+++ b/message/spec.md
@@ -88,13 +88,6 @@ this form:
           "modifiedat": "TIMESTAMP",
           "ancestor": "STRING",
 
-          "deprecated": {
-            "effective": "TIMESTAMP", ?
-            "removal": "TIMESTAMP", ?
-            "alternative": "URL", ?
-            "docs": "URL"?
-          }, ?
-
           "basemessageurl": "URL", ?           # Message being extended
 
           "envelope": "STRING", ?              # e.g. CloudEvents/1.0
@@ -299,50 +292,6 @@ the look-up value (id) of messages with their related events.
 The following extensions are defined for the `message` Resource in addition to
 the core xRegistry Resource
 [attributes](../core/spec.md#attributes-and-extensions):
-
-#### `deprecated`
-
-- Type: Object containing the following properties:
-  - `effective`<br>
-    An OPTIONAL property indicating the time when the message entered, or will
-    enter, a deprecated state. The date MAY be in the past or future. If this
-    property is not present the message is already in a deprecated state.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp.
-
-  - `removal`<br>
-    An OPTIONAL property indicating the time when the message MAY be removed.
-    The message MUST NOT be removed before this time. If this property is not
-    present then client can not make any assumption as to when the message
-    might be removed. Note: as with most properties, this property is mutable.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT be
-    sooner than the `effective` time if present.
-
-  - `alternative`<br>
-    An OPTIONAL property specifying the URL to an alternative message the
-    client can consider as a replacement for this message. There is no
-    guarantee that the referenced message is an exact replacement, rather the
-    client is expected to investigate the message to determine if it is
-    appropriate.
-
-  - `docs`<br>
-    An OPTIONAL property specifying the URL to additional information about
-    the deprecation of the message. This specification does not mandate any
-    particular format or information, however some possibilities include:
-    reasons for the deprecation or additional information about likely
-    alternative messages. The URL MUST support an HTTP GET request.
-
-  Note that an implementation is not mandated to use this attribute in
-  advance of removing an message, but is it RECOMMENDED that they do so.
-- Constraints:
-  - OPTIONAL
-- Examples:
-  - `"deprecated": {}`
-  - ```
-    "deprecated": {
-      "removal": "2030-12-19T00:00:00-00:00",
-      "alternative": "https://example.com/messages/popped"
-    }
-    ```
 
 #### `basemessageurl`
 
@@ -628,7 +577,7 @@ placeholders MUST be replaced with valid values. For example, the value
 message.
 
 If the `type` property has the value `timestamp` and the `value` property is
-set to a value of `01-01-0000T00:00:00Z`, the value MUST be replaced with the
+set to a value of `0000-01-01T00:00:00Z`, the value MUST be replaced with the
 current timestamp when creating a message.
 
 #### Metadata Envelopes
@@ -669,7 +618,7 @@ The following rules apply to the attribute declarations:
 - The `type`, `id`, and `source` attributes implicitly have the `required` flag
   set to `true` and MUST NOT be declared as `required: false`.
 - The `id` attribute's `value` SHOULD NOT be defined.
-- The `time` attribute's `value` default value MUST be `01-01-0000T00:00:00Z`
+- The `time` attribute's `value` default value MUST be `0000-01-01T00:00:00Z`
   ("current time") and SHOULD NOT be declared with a different value.
 - The `datacontenttype` attribute's `value` is inferred from the
   [`dataschemaformat`](#dataschemaformat) attribute of the message definition

--- a/schema/model.json
+++ b/schema/model.json
@@ -2,7 +2,6 @@
   "groups": {
     "schemagroups": {
       "singular": "schemagroup",
-      "plural": "schemagroups",
       "modelversion": "1.0-rc1",
       "compatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
 
@@ -16,7 +15,6 @@
       "resources": {
         "schemas": {
           "singular": "schema",
-          "plural": "schemas",
           "modelversion": "1.0-rc1",
           "compatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
 
@@ -37,7 +35,7 @@
               "type": "boolean",
               "description": "Verify compliance with specified schema 'format'",
               "required": true,
-              "default": true
+              "default": false
             }
           }
         }

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -75,13 +75,6 @@ this form:
           "modifiedat": "TIMESTAMP",
           "ancestor": "STRING",
 
-          "deprecated": {
-            "effective": "TIMESTAMP", ?
-            "removal": "TIMESTAMP", ?
-            "alternative": "URL", ?
-            "docs": "URL"?
-          }, ?
-
           "format": "STRING", ?
 
           "schemaurl": "URL", ?
@@ -307,53 +300,9 @@ the core xRegistry Resource
   (but it an allowable value), then the server MUST NOT perform any validation.
 - Constraints:
   - OPTIONAL
-  - When not specified, the default value MUST be `true`.
+  - When not specified, the default value MUST be `false`.
   - MUST be a Resource level attribute defined within the `metaattributes`
     section of the model.
-
-#### `deprecated`
-
-- Type: Object containing the following properties:
-  - `effective`<br>
-    An OPTIONAL property indicating the time when the schema entered, or will
-    enter, a deprecated state. The date MAY be in the past or future. If this
-    property is not present the schema is already in a deprecated state.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp.
-
-  - `removal`<br>
-    An OPTIONAL property indicating the time when the schema MAY be removed.
-    The schema MUST NOT be removed before this time. If this property is not
-    present then client can not make any assumption as to when the schema
-    might be removed. Note: as with most properties, this property is mutable.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT be
-    sooner than the `effective` time if present.
-
-  - `alternative`<br>
-    An OPTIONAL property specifying the URL to an alternative schema the
-    client can consider as a replacement for this schema. There is no
-    guarantee that the referenced schema is an exact replacement, rather the
-    client is expected to investigate the schema to determine if it is
-    appropriate.
-
-  - `docs`<br>
-    An OPTIONAL property specifying the URL to additional information about
-    the deprecation of the schema. This specification does not mandate any
-    particular format or information, however some possibilities include:
-    reasons for the deprecation or additional information about likely
-    alternative schema. The URL MUST support an HTTP GET request.
-
-  Note that an implementation is not mandated to use this attribute in
-  advance of removing an schema, but is it RECOMMENDED that they do so.
-- Constraints:
-  - OPTIONAL
-- Examples:
-  - `"deprecated": {}`
-  - ```
-    "deprecated": {
-      "removal": "2030-12-19T00:00:00-00:00",
-      "alternative": "https://example.com/schema/myschema"
-    }
-    ```
 
 #### `format`
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,7 +5,7 @@ all: verify makeschema
 
 verify: text links
 
-text: spellcheck tabcheck errorcheck
+text: spellcheck tabcheck errorcheck samplescheck
 
 spellcheck:
 	tools/spellcheck */spec.md core/primer.md */README.md \
@@ -18,6 +18,10 @@ tabcheck:
 
 errorcheck:
 	tools/errorcheck core/spec.md
+	@echo
+
+samplescheck:
+	tools/samplescheck */model.json */samples/*json */samples/*/*json
 	@echo
 
 links: test_tools

--- a/tools/samplescheck
+++ b/tools/samplescheck
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Look samples or our models being too verbose
+
+set -e
+
+badPatterns=(
+  "required.*false"
+  "hasdoc.*true"
+  "plural"
+)
+
+for f in $* ; do
+  echo "> " $f
+  for pattern in "${badPatterns[@]}" ; do
+    if ( grep "$pattern" "$f" > /dev/null ); then
+	  echo Found "'$pattern'" in $f
+	  rc=1
+	fi
+  done
+done
+
+exit $rc 

--- a/tools/schema-generator.py
+++ b/tools/schema-generator.py
@@ -478,7 +478,8 @@ def generate_json_schema(model_definition, for_openapi=False) -> dict:
         schema_definitions = schema["definitions"]
 
 
-    for _, group in model_definition.get("groups", {}).items():
+    for key, group in model_definition.get("groups", {}).items():
+        if "plural" not in group: group["plural"] = key
         groups_name = group["plural"]
         group_name = group["singular"]
         groups_schema = {
@@ -489,7 +490,8 @@ def generate_json_schema(model_definition, for_openapi=False) -> dict:
         document_properties[groups_name] = groups_schema
         resource_collection_properties = {}
 
-        for _, resource in group.get("resources", {}).items():
+        for rKey, resource in group.get("resources", {}).items():
+            if "plural" not in resource: resource["plural"] = rKey
             resource = resolve_resource(group, resource)
             resource_name = resource["singular"]
             props = {}
@@ -730,12 +732,14 @@ def generate_avro_schema(model_definition) -> dict:
     }
     document_properties = document_type["fields"]
 
-    for _, group in model_definition.get("groups", {}).items():
+    for key, group in model_definition.get("groups", {}).items():
+        if "plural" not in group: group["plural"] = key
         groups_name = group["plural"]
         group_name = group["singular"]
         resource_collection_fields = []
 
-        for _, resource in group.get("resources", {}).items():
+        for rKey, resource in group.get("resources", {}).items():
+            if "plural" not in resource: resource["plural"] = rKey
             resource = resolve_resource(group, resource)
             resource_name = resource["singular"]
             if resource_name in record_types:


### PR DESCRIPTION
Week of Apr 14 changes

- minor wording fixes
- move "deprecated" into core spec. Removed from message and schema. Endpoint points to core, on endpoint/group.
- treat a missing 'ancestor' on PUT/POST as a request to leave it unchanged
- allow for `$schema` to appear in request xReg metadata messages
- add a `?collection` flag for GET / and GET /GROUPS/gID (turns on `?inline=*`)
- remove unnecessary stuff from our model and samples - to reduce noise

Fixes: #297
Fixes: #302
Fixes: #307
Fixes: #318
Fixes: #321
Fixes: #325