### PR TITLE
Clarify format and how it relates to compatibility

### DIFF
--- a/core/primer.md
+++ b/core/primer.md
@@ -829,13 +829,13 @@ defined in the core specification for consistency. It is worth noting that
 the Endpoint [specification](../endpoint/spec.md) does exactly this to
 indicate when an Endpoint (i.e. a Group) is deprecated.
 
-## The `format`-attribute in the Schema spec
+## The `format` attribute in the Schema spec
 
-The `format`-attribute in the Schema spec is required when the
-`compatibility`-attribute is set to a value other than `None`. This may
+The `format` attribute in the Schema spec is required when the
+`compatibility` attribute is set to a value other than `none`. This may
 appear to be overly restrictive, especially if your Registry implementation
 only supports a single format. The reason for making this field required, is
 to ease interoperability of registries through export-import functionality.
 That means that when exporting a Schema Registry that only supports a single
-format, the `format`-attribute will already be set, avoiding issues when
+format, the `format` attribute will already be set, avoiding issues when
 importing this Registry into a server that may support multiple formats.

--- a/core/primer.md
+++ b/core/primer.md
@@ -828,3 +828,14 @@ When doing so it is recommended to use the same attribute definition as
 defined in the core specification for consistency. It is worth noting that
 the Endpoint [specification](../endpoint/spec.md) does exactly this to
 indicate when an Endpoint (i.e. a Group) is deprecated.
+
+## The `format`-attribute in the Schema spec
+
+The `format`-attribute in the Schema spec is required when the
+`compatibility`-attribute is set to a value other than `None`. This may
+appear to be overly restrictive, especially if your Registry implementation
+only supports a single format. The reason for making this field required, is
+to ease interoperability of registries through export-import functionality.
+That means that when exporting a Schema Registry that only supports a single
+format, the `format`-attribute will already be set, avoiding issues when
+importing this Registry into a server that may support multiple formats.

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -321,7 +321,7 @@ the core xRegistry Resource
   model to make this attribute mandatory.
 
   Managers of the xRegistry instance can set a default value for this
-  attribute, making it a required attribute.
+  attribute, making it a REQUIRED attribute.
 - Constraints:
   - If present, MUST be a non-empty string
   - MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -146,11 +146,10 @@ Versions of a single **schema** MUST adhere to the rules defined by the
 `compatibility` attribute. Any breaking change MUST result in a new **schema**
 being created.
 
-In "Semantic Versioning" terms, you can think of a **schema** as a "major
-version" and the **schema Versions** as "minor versions", although the
-semantics are, of course, quite different (e.g. a minor version in Semantic
-Versioning does not allow removing public properties, whereas in a schema with
-backward compatibility, deleting a field is allowed).
+In terms of versioning, you can think of a **schema** as a collection of
+versions that are compatible according to the selected `compatibility` mode.
+When that compatibility is broken across versions, a completely new **schema**
+MUST be created, to indicate the breaking change.
 
 ## Schema Registry Model
 

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -329,8 +329,8 @@ the core xRegistry Resource
     format in the format defined by the schema format itself.
   - MUST be a Version level attribute defined within the `attributes` section
     of the model.
-  - MUST be present if the `compatibility`-attribute is set to a value other
-    than `None` and when the `compatibilityauthority`-attribute is set to
+  - MUST be present if the `compatibility` attribute is set to a value other
+    than `None` and when the `compatibilityauthority` attribute is set to
     `server`, to enable validation of the schema document.
 - Examples:
   - `JsonSchema/draft-07`

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -146,8 +146,11 @@ Versions of a single **schema** MUST adhere to the rules defined by the
 `compatibility` attribute. Any breaking change MUST result in a new **schema**
 being created.
 
-In "semantic Versioning" terms, you can think of a **schema** as a "major
-version" and the **schema Versions** as "minor versions".
+In "Semantic Versioning" terms, you can think of a **schema** as a "major
+version" and the **schema Versions** as "minor versions", although the
+semantics are, of course, quite different (e.g. a minor version in Semantic
+Versioning does not allow removing public properties, whereas in a schema with
+backward compatibility, deleting a field is allowed).
 
 ## Schema Registry Model
 
@@ -317,6 +320,9 @@ the core xRegistry Resource
   For many schema registry use cases this attribute is important for schema
   validation purposes, and as such implementations can choose to modify the
   model to make this attribute mandatory.
+
+  Managers of the xRegistry instance can set a default value for this
+  attribute, making it a required attribute.
 - Constraints:
   - If present, MUST be a non-empty string
   - MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is
@@ -324,6 +330,9 @@ the core xRegistry Resource
     format in the format defined by the schema format itself.
   - MUST be a Version level attribute defined within the `attributes` section
     of the model.
+  - MUST be present if the `compatibility`-attribute is set to a value other
+    than `None` and when the `compatibilityauthority`-attribute is set to
+    `server`, to enable validation of the schema document.
 - Examples:
   - `JsonSchema/draft-07`
   - `Protobuf/3`


### PR DESCRIPTION
Fixes #295

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Makes format requires when `compatibility` != `None` and `compatibilityauthority` = `server`
- Specifies that xRegistry managers can set a default value for `format`
- Clarifies the difference between Semantic Versioning and schema versioning to avoid confusion

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note

```
