### PR TITLE
Week of July 28

### DIFF
--- a/core/events.md
+++ b/core/events.md
@@ -312,6 +312,22 @@ events.
     the `io.xregistry.resource.created` and `io.xregistry.resource.deleted`
     events would need to be examined.
 
+    This includes any updates to the `deprecated` sub-object, even
+    though a `io.xregistry.group.deprecation` event is also generated. And
+    in that situation just `deprecrated` would be included in `changed`,
+    if present. To see which specific top-level `deprecated` attributes were
+    changed, the `io.xregistry.group.deprecation` event would need to be
+    examined.
+
+- Action: `deprecation`
+  - MUST be generated when a Group's `deprecated` sub-object is set,
+    deleted or any of its attributes updated, where "changed", if present,
+    includes the list of top-level attribute names from the `deprecated`
+    sub-object that were modified.
+
+  - A `io.xregistry.group.updated` event will also be generated where the
+    `deprecated` attribute will be included in `changed`, if present.
+
 - Action: `deleted`
   - MUST be generated when a Group is deleted.
 

--- a/core/primer.md
+++ b/core/primer.md
@@ -635,7 +635,7 @@ sensitivity rules in the specification.
 
 Attribute names and key names are limited to 63 characters, so why are some
 Group and Resource names limited to less? Because when they appear as part of
-attribute names and they can be append with phrases like `url`, `count`
+attribute names and they can be appended with phrases like `url`, `count`
 or `base64`, and they still have to fit within the 63-character limit, and so
 we need to take into account the length of those phrases.
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -615,6 +615,16 @@ to be met while maintaining the interoperability goals of the specification.
 Implementations are encouraged to contact the xRegistry community if it is
 unclear if certain customizations would violate the specification.
 
+Implementations MAY (but are NOT REQUIRED) to validate cross-entity
+constraints that might be violated due to changes in a referenced entity.
+For example, [Endpoint's `envelope`](../endpoint/spec.md#envelope) attribute
+mandates that all Messages in that Endpoint use that same `envelope` value.
+One of those Messages might have a `basemessage` value that points to a
+ Message that breaks that rule. For a variety of reasons (e.g. authorization
+ constraints), server implementations might not be able to verify this
+ constraint. Likewise, the same situation might occur via the use of `xref`.
+Clients need to be aware of these possibilities.
+
 ### Attributes and Extensions
 
 Unless otherwise noted, all attributes and extensions MUST be mutable and MUST
@@ -654,9 +664,10 @@ be one of the following data types:
   information.  Its value MUST start with a `/`.
 - `xidtype` - MUST be a URL reference to an xRegistry model type. The
    reference MUST point to one of: the Registry itself (`/`), a Group type
-   (`/<GROUPS>`), a Resource type (`/<GROUPS>/<RESOURCE>`) or Version type for
+   (`/<GROUPS>`), a Resource type (`/<GROUPS>/<RESOURCES>`) or Version type for
    a Resource (`/<GROUPS>/<RESOURCES>/versions`). Its value MUST reference a
-   defined/valid type in the Registry.
+   defined/valid type in the Registry. It MUST use the plural name of the
+   referenced type, if it is a Group, Resource or Version.
 - `string` - sequence of Unicode characters.
 - `timestamp` - an [RFC3339](https://tools.ietf.org/html/rfc3339) timestamp.
   Use of a `time-zone` notation is RECOMMENDED. All timestamps returned by

--- a/core/spec.md
+++ b/core/spec.md
@@ -1524,7 +1524,7 @@ semantics defined above with the following exceptions:
     operations, any missing REQUIRED attributes MUST generate an error
     ([required_attribute_missing](#required_attribute_missing)).
 
-The `PATCH`, variant when directed at an xRegistry collection, MUST adhere to
+The `PATCH` variant when directed at an xRegistry collection, MUST adhere to
 the following:
   - The HTTP body MUST contain a JSON map where the key MUST be the
     `<SINGULAR>id` of each entity in the map. Note, that in the case of a map

--- a/core/spec.md
+++ b/core/spec.md
@@ -229,6 +229,12 @@ pseudo JSON form:
       "labels": { "<STRING>": "<STRING>" * }, ?
       "createdat": "<TIMESTAMP>",
       "modifiedat": "<TIMESTAMP>",
+      "deprecated": {
+        "effective": "<TIMESTAMP>", ?
+        "removal": "<TIMESTAMP>", ?
+        "alternative": "<URL>", ?
+        "documentation": "<URL>"?
+      }, ?
 
       # Repeat for each Resource type in the Group
       "<RESOURCES>url": "<URL>",                   # e.g. "messagesurl"
@@ -620,9 +626,9 @@ constraints that might be violated due to changes in a referenced entity.
 For example, [Endpoint's `envelope`](../endpoint/spec.md#envelope) attribute
 mandates that all Messages in that Endpoint use that same `envelope` value.
 One of those Messages might have a `basemessage` value that points to a
- Message that breaks that rule. For a variety of reasons (e.g. authorization
- constraints), server implementations might not be able to verify this
- constraint. Likewise, the same situation might occur via the use of `xref`.
+Message that breaks that rule. For a variety of reasons (e.g. authorization
+constraints), server implementations might not be able to verify this
+constraint. Likewise, the same situation might occur via the use of `xref`.
 Clients need to be aware of these possibilities.
 
 ### Attributes and Extensions
@@ -791,6 +797,7 @@ form:
 - `"labels": { "<STRING>": "<STRING>" * }`
 - `"createdat": "<TIMESTAMP>"`
 - `"modifiedat": "<TIMESTAMP>"`
+- `"deprecated": "<OBJECT>"`
 
 The definition of each attribute is defined below:
 
@@ -1131,6 +1138,55 @@ of the existing entity. Then the existing entity would be deleted.
 
 - Examples:
   - `2030-12-19T06:00:00Z`
+
+#### `deprecated` Attribute
+
+- Type: Object containing the following properties:
+  - `effective`<br>
+    An OPTIONAL property indicating the time when the entity entered, or will
+    enter, a deprecated state. The date MAY be in the past or future. If this
+    property is not present the entity is already in a deprecated state.
+    If present, this MUST be an [RFC3339][rfc3339] timestamp.
+
+  - `removal`<br>
+    An OPTIONAL property indicating the time when the entity MAY be removed.
+    The entity MUST NOT be removed before this time. If this property is not
+    present, the client cannot make any assumptions as to when the entity
+    might be removed. Note: as with most properties, this property is mutable.
+    If present, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT be
+    sooner than the `effective` time if present.
+
+  - `alternative`<br>
+    An OPTIONAL property specifying the URL to an alternative entity the
+    client can consider as a replacement for this entity. There is no
+    guarantee that the referenced entity is an exact replacement, rather the
+    client is expected to investigate the entity to determine if it is
+    appropriate.
+
+  - `docs`<br>
+    An OPTIONAL property specifying the URL to additional information about
+    the deprecation of the entity. This specification does not mandate any
+    particular format or information, however some possibilities include:
+    reasons for the deprecation or additional information about likely
+    alternative entities. The URL MUST support an HTTP(s) GET request.
+
+  Note that an implementation is not mandated to use this attribute in
+  advance of removing an entity, but is it RECOMMENDED that they do so.
+
+  This attribute can appear on Groups and Resources, however, this
+  specification makes no statement as to the relationship, or validity, of the
+  values of each with respect to how they might impact each other.
+
+- Constraints:
+  - OPTIONAL
+- Examples:
+  - `"deprecated": {}`
+  - ```
+    "deprecated": {
+      "removal": "2030-12-19T00:00:00Z",
+      "alternative": "https://example.com/entities-v2/myentity"
+    }
+    ```
 
 ---
 
@@ -2845,6 +2901,12 @@ The following describes the attributes of the Registry model:
     the `ifvalues` key (case-sensitive), then the `siblingattributes` MUST be
     included in the model as siblings to this attribute.
 
+    While the properties of a map will automatically prevent two entries
+    with the same value, they will not prevent two entries that only differ
+    in case. Therefore, during a model update, servers MUST ensure that no
+    two entries are the same irrespective of case, otherwise an
+    error ([model_error](#model_error)) MUST be generated.
+
     If `enum` is not empty and `strict` is `true` then this map MUST NOT
     contain any value that is not specified in the `enum` array.
 
@@ -3829,6 +3891,12 @@ The serialization of a Group entity adheres to this form:
   "labels": { "<STRING>": "<STRING>" * }, ?
   "createdat": "<TIMESTAMP>",
   "modifiedat": "<TIMESTAMP>",
+  "deprecated": {
+    "effective": "<TIMESTAMP>", ?
+    "removal": "<TIMESTAMP>", ?
+    "alternative": "<URL>", ?
+    "documentation": "<URL>"?
+  }, ?
 
   # Repeat for each Resource type in the Group
   "<RESOURCES>url": "<URL>",                  # e.g. "messagesurl"
@@ -3858,6 +3926,7 @@ Groups include the following
   OPTIONAL in requests.
 - [`modifiedat`](#modifiedat-attribute) - REQUIRED in API and document views.
   OPTIONAL in requests.
+- [`deprecated`](#deprecated-attribute) - OPTIONAL.
 
 and the following Group-level attributes:
 
@@ -3902,6 +3971,7 @@ Link: <URL>;rel=next;count=<UINTEGER> ?
     "labels": { "<STRING>": "<STRING>" * }, ?
     "createdat": "<TIMESTAMP>",
     "modifiedat": "<TIMESTAMP>",
+    "deprecated": { ... }, ?
 
     # Repeat for each Resource type in the Group
     "<RESOURCES>url": "<URL>",                  # e.g. "messagesurl"
@@ -4011,6 +4081,7 @@ MUST adhere to the following:
   "labels": { "<STRING>": "<STRING>" * }, ?
   "createdat": "<TIMESTAMP>", ?
   "modifiedat": "<TIMESTAMP>", ?
+  "deprecated": { ... }, ?
 
   # Repeat for each Resource type in the Group
   "<RESOURCES>": { Resources collection } ?
@@ -4033,6 +4104,7 @@ Each individual Group in a successful response MUST adhere to the following:
   "labels": { "<STRING>": "<STRING>" * }, ?
   "createdat": "<TIMESTAMP>",
   "modifiedat": "<TIMESTAMP>",
+  "deprecated": { ... }, ?
 
   # Repeat for each Resource type in the Group
   "<RESOURCES>url": "<URL>",                    # e.g. "messagesurl"
@@ -4129,6 +4201,7 @@ Content-Type: application/json; charset=utf-8
   "labels": { "<STRING>": "<STRING>" * }, ?
   "createdat": "<TIMESTAMP>",
   "modifiedat": "<TIMESTAMP>",
+  "deprecated": { ... }, ?
 
   # Repeat for each Resource type in the Group
   "<RESOURCES>url": "<URL>",                   # e.g. "messagesurl"
@@ -4402,6 +4475,7 @@ The Resource-level attributes include the following
   based on the `shortself` capability. OPTIONAL/ignored in requests.
 - [`xid`](#xid-attribute) - REQUIRED in API and document views.
   OPTIONAL/ignored in requests.
+- [`deprecated`](#deprecated-attribute) - OPTIONAL.
 
 and the following Resource-level attributes:
 
@@ -4520,50 +4594,6 @@ and the following Resource-level attributes:
   - When not specified, and `compatibility` is not `none`, the default value
     MUST be `external`.
   - If present, MUST be non-empty.
-
-#### `deprecated`
-
-- Type: Object containing the following properties:
-  - `effective`<br>
-    An OPTIONAL property indicating the time when the Resource entered, or will
-    enter, a deprecated state. The date MAY be in the past or future. If this
-    property is not present the Resource is already in a deprecated state.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp.
-
-  - `removal`<br>
-    An OPTIONAL property indicating the time when the Resource MAY be removed.
-    The Resource MUST NOT be removed before this time. If this property is not
-    present, the client cannot make any assumptions as to when the Resource
-    might be removed. Note: as with most properties, this property is mutable.
-    If present, this MUST be an [RFC3339][rfc3339] timestamp and MUST NOT be
-    sooner than the `effective` time if present.
-
-  - `alternative`<br>
-    An OPTIONAL property specifying the URL to an alternative Resource the
-    client can consider as a replacement for this Resource. There is no
-    guarantee that the referenced Resource is an exact replacement, rather the
-    client is expected to investigate the Resource to determine if it is
-    appropriate.
-
-  - `docs`<br>
-    An OPTIONAL property specifying the URL to additional information about
-    the deprecation of the Resource. This specification does not mandate any
-    particular format or information, however some possibilities include:
-    reasons for the deprecation or additional information about likely
-    alternative Resources. The URL MUST support an HTTP(s) GET request.
-
-  Note that an implementation is not mandated to use this attribute in
-  advance of removing a Resource, but is it RECOMMENDED that they do so.
-- Constraints:
-  - OPTIONAL
-- Examples:
-  - `"deprecated": {}`
-  - ```
-    "deprecated": {
-      "removal": "2030-12-19T00:00:00Z",
-      "alternative": "https://example.com/entities-v2/myentity"
-    }
-    ```
 
 ##### `defaultversionid` Attribute
 - Type: String
@@ -5088,11 +5118,11 @@ Resource type from another Group type definition MUST be used. See
 [`ximportresources`](#reuse-of-resource-definitions) for more information.
 
 An `xref` value that points to a non-existing Resource, either because
-it was deleted or never existed, is not an error and is not a condition
-that a server is REQUIRED to detect. In these "dangling xref" situations, the
-serialization of the source Resource will not include any target Resource
-attributes or nested collections. Rather, it will only show the `<RESOURCE>id`
-and `xref` attributes.
+it was deleted, never existed or the current client does not have permission
+to see it, is not an error and is not a condition that a server is REQUIRED to
+detect. In these "dangling xref" situations, the serialization of the source
+Resource will not include any target Resource attributes or nested collections.
+Rather, it will only show the `<RESOURCE>id` and `xref` attributes.
 
 ---
 

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -12,8 +12,8 @@ document format and API [specification](../core/spec.md).
 - [Notations and Terminology](#notations-and-terminology)
   - [Notational Conventions](#notational-conventions)
   - [Terminology](#terminology)
-- [Endpoint Registry](#endpoint-registry)
-  - [Endpoints](#endpoints)
+- [Endpoint Registry](#endpoint-registry-model)
+  - [Endpoints](#endpoints-groups)
 
 ## Overview
 
@@ -183,7 +183,7 @@ An "endpoint" is a logical or physical network location to which messages can
 be produced, from which messages can be consumed, or which makes messages
 available via subscription for delivery to a consumer-designated endpoint.
 
-## Endpoint Registry
+## Endpoint Registry Model
 
 The Endpoint Registry is a registry of metadata definitions for abstract and
 concrete network endpoints to which messages can be produced, from which
@@ -197,14 +197,17 @@ MAY contain inlined messages. Therefore, the Resources in the meta-model for
 the Endpoint Registry are likewise `messages` as defined in the
 [message catalog specification](../message/spec.md).
 
-The resource model for endpoints can be found in [model.json](model.json).
+The formal xRegistry extension model of the Endpoints Registry
+resides in the [model.json](model.json) file.
 
-### Endpoints
+### Endpoints Groups
 
-Endpoints are a Group type with a plural name (`<GROUPS>`) of `endpoints`, and
-a singular name (`<GROUP>`) of `endpoint`.
+The Group plural name (`<GROUPS.`) is `endpoints`, and the Group singular
+name (`<GROUP>`) is `endpoint`.
 
-The following attributes are defined for Endpoints:
+The following attributes are defined for the `endpoint` object in addition
+to the xRegistry-defined core
+[attributes](../core/spec.md#attributes-and-extensions):
 
 #### `usage`
 
@@ -274,7 +277,7 @@ The following attributes are defined for Endpoints:
     - "producer"
   - MUST be an array of at least one.
 
-### `channel`
+#### `channel`
 
 - Type: String
 - Description: A string that can be used to correlate Endpoints. Any Endpoints
@@ -312,12 +315,12 @@ The following attributes are defined for Endpoints:
 - Examples:
   - `queue1`
 
-### `deprecated`
+#### `deprecated`
 
 See the [deprecated](../core/spec.md#deprecated) attribute in the core
 [xRegistry](../core/spec.md#deprecated) specification.
 
-### `envelope`
+#### `envelope`
 
 - Type: String
 - Description: The name of the specification that defines the Resource
@@ -346,7 +349,7 @@ See the [deprecated](../core/spec.md#deprecated) attribute in the core
 - Examples:
   - `CloudEvents/1.0`
 
-### `envelopeoptions`
+#### `envelopeoptions`
 
 - Type: Map
 - Description: Configuration details of the endpoint with respect to the
@@ -361,7 +364,7 @@ See the [deprecated](../core/spec.md#deprecated) attribute in the core
 This specification defines the following envelope options for the indicated
 `envelope` values:
 
-#### `CloudEvents/1.0`
+##### `CloudEvents/1.0`
 
 - `mode` : indicates whether the CloudEvent will use `binary` or `structured`
   (mode)[https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message].
@@ -372,7 +375,7 @@ This specification defines the following envelope options for the indicated
   used MUST match the expected content type of the message (e.g. for HTTP the
   `Content-Type` header value).
 
-### `protocol`
+#### `protocol`
 
 - Type: String
 - Description: The transport or application protocol used by the endpoint. This
@@ -419,7 +422,7 @@ This specification defines the following envelope options for the indicated
 - Constraints:
   - OPTIONAL.
 
-#### `protocoloptions.endpoints`
+##### `protocoloptions.endpoints`
 
 - Type: Array of Objects
 - Description: An array of objects map where each object contains a `uri`
@@ -455,7 +458,7 @@ This specification defines the following envelope options for the indicated
     ]
     ```
 
-#### `protocoloptions.authorization`
+##### `protocoloptions.authorization`
 
 - Type: Map
 - Description: OPTIONAL authorization configuration details of the endpoint.
@@ -468,7 +471,7 @@ This specification defines the following envelope options for the indicated
   - MUST only be used for authorization configuration.
   - MUST NOT be used for credential configuration.
 
-#### `protocoloptions.authorization.type`
+###### `protocoloptions.authorization.type`
 
 - Type: String
 - Description: The type of the authorization configuration. The value SHOULD be
@@ -484,7 +487,7 @@ This specification defines the following envelope options for the indicated
   - OPTIONAL.
   - MUST be a non-empty string if used.
 
-#### `protocoloptions.authorization.resourceuri`
+###### `protocoloptions.authorization.resourceuri`
 
 - Type: URI
 - Description: The URI of the resource for which the authorization is
@@ -494,7 +497,7 @@ This specification defines the following envelope options for the indicated
   - OPTIONAL.
   - MUST be a non-empty URI if used.
 
-#### `protocoloptions.authorization.authorityuri`
+###### `protocoloptions.authorization.authorityuri`
 
 - Type: URI
 - Description: The URI of the authorization authority from which the
@@ -505,7 +508,7 @@ This specification defines the following envelope options for the indicated
   - OPTIONAL.
   - MUST be a non-empty URI if used.
 
-#### `protocoloptions.authorization.grant_types`
+###### `protocoloptions.authorization.grant_types`
 
 - Type: Array of Strings
 - Description: The supported authorization grant types. The value SHOULD be a
@@ -515,7 +518,7 @@ This specification defines the following envelope options for the indicated
   - OPTIONAL.
   - MUST be a non-empty array if used.
 
-#### `protocoloptions.deployed`
+##### `protocoloptions.deployed`
 
 - Type: Boolean
 - Description: If `true`, the endpoint metadata represents a public, live
@@ -525,7 +528,7 @@ This specification defines the following envelope options for the indicated
   - OPTIONAL.
   - When not specified, the default value is MUST be `false`.
 
-#### `protocoloptions.options`
+##### `protocoloptions.options`
 
 - Type: Map
 - Description: Additional configuration options for the endpoint. The
@@ -665,7 +668,7 @@ Example:
 }
 ```
 
-#### AMQP options
+##### AMQP options
 
 The [endpoint URIs](#protocoloptionsendpoints) for "AMQP" endpoints MUST be
 valid AMQP URIs using the "amqp" or "amqps" scheme. If the path portion of the
@@ -716,7 +719,7 @@ Example:
 }
 ```
 
-#### MQTT options
+##### MQTT options
 
 The [endpoint URIs](#protocoloptionsendpoints) for "MQTT" endpoints MUST be
 valid MQTT URIs using the (informal) "mqtt" or "mqtts" scheme. If the path
@@ -774,7 +777,7 @@ Example:
 }
 ```
 
-#### KAFKA options
+##### KAFKA options
 
 The [endpoint URIs](#protocoloptionsendpoints) for "Kafka" endpoints MUST be
 valid Kafka bootstrap server addresses. The scheme follows Kafka configuration
@@ -818,7 +821,7 @@ Example:
 }
 ```
 
-#### NATS options
+##### NATS options
 
 The [endpoint URIs](#protocoloptionsendpoints) for "NATS" endpoints MUST be
 valid NATS URIs. The scheme MUST be "nats" or "tls" or "ws" and the URI MUST
@@ -841,8 +844,6 @@ Example:
   }
 }
 ```
-
-## References
 
 [JSON Pointer]: https://www.rfc-editor.org/rfc/rfc6901
 [CloudEvents Types]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -56,15 +56,10 @@ this form:
       "labels": { "<STRING>": "<STRING>" * }, ?
       "createdat": "<TIMESTAMP>",
       "modifiedat": "<TIMESTAMP>",
+      "deprecated": { ... }, ?
 
       "usage": [ "<STRING>" + ] ,                 # subscriber, consumer, producer
       "channel": "<STRING>", ?
-      "deprecated": {
-        "effective": "<TIMESTAMP>", ?
-        "removal": "<TIMESTAMP>", ?
-        "alternative": "<URL>", ?
-        "docs": "<URL>"?
-      }, ?
 
       # Start of Endpoint extension attributes
       "envelope": "<STRING>", ?                   # e.g. CloudEvents/1.0
@@ -313,11 +308,6 @@ to the xRegistry-defined core
 - Examples:
   - `queue1`
 
-#### `deprecated`
-
-See the [deprecated](../core/spec.md#deprecated) attribute in the core
-[xRegistry](../core/spec.md#deprecated) specification.
-
 #### `envelope`
 
 - Type: String
@@ -327,11 +317,11 @@ See the [deprecated](../core/spec.md#deprecated) attribute in the core
   provides a mechanism by which it can be determined without examination of
   the Resource at all.
 - Constraints:
-  - MUST be a non-empty string of the form `<SPEC>[/<VERSION>]`,
+  - MUST be a non-empty case-insensitive string of the form
+    `<SPEC>[/<VERSION>]`,
     where `<SPEC>` is the non-empty string name of the specification that
     defines the Resource. An OPTIONAL `<VERSION>` value SHOULD be included if
     there are multiple versions of the specification available.
-  - For comparison purposes, this attribute MUST be considered case-sensitive.
   - If a `<VERSION>` is specified at the Group level, all Resources within that
     Group MUST have a `<VERSION>` value that is at least as precise as its
     Group, and MUST NOT expand it. For example, if a Group had a
@@ -341,8 +331,8 @@ See the [deprecated](../core/spec.md#deprecated) attribute in the core
     of `myspec/2.0` or just `myspec`. Additionally, if a Group does not have
     a `envelope` attribute then there are no constraints on its Resources
     `envelope` attributes.
-  - This specification places no restriction on the case of the `<SPEC>` value
-    or on the syntax of the `<VERSION>` value.
+  - This specification places no restriction on the syntax of the
+    `<VERSION>` value.
 - Examples:
   - `CloudEvents/1.0`
 
@@ -400,7 +390,7 @@ This specification defines the following envelope options for the indicated
 
   All messages inside an Endpoint MUST use this same protocol.
 - Constraints:
-  - MUST be a non-empty string.
+  - MUST be a non-empty case-insensitive string.
   - SHOULD follow the naming convention `<NAME>/<VERSION>`,
     whereby `<NAME>` is the name of the protocol and `<VERSION>` is the
     version of protocol.

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -45,7 +45,7 @@ this form:
   "endpointsurl": "<URL>",
   "endpointscount": <UINTEGER>,
   "endpoints": {
-    "<KEY": {
+    "<KEY>": {
       "endpointid": "<STRING>",                   # xRegistry core attributes
       "self": "<URL>",
       "xid": "<XID>",
@@ -140,7 +140,7 @@ this form:
       "messagesurl": "<URL>", ?
       "messagescount": <UINTEGER>, ?
       "messages": {
-        "<KEY": {                                # messageid
+        "<KEY>": {                                # messageid
           # See Message Definition spec for details
         } *
       } ?
@@ -190,7 +190,7 @@ concrete network endpoints to which messages can be produced, from which
 messages can be consumed, or which makes messages available via subscription
 and delivery to a consumer-designated endpoint.
 
-As discussed in [CloudEvents Registry overview](../cloudevents/spec.md),
+As discussed in the [CloudEvents Registry overview](../cloudevents/spec.md),
 endpoints are supersets of
 [message definition groups](../message/spec.md#message-definition-groups) and
 MAY contain inlined messages. Therefore, the Resources in the meta-model for
@@ -202,7 +202,7 @@ resides in the [model.json](model.json) file.
 
 ### Endpoints Groups
 
-The Group plural name (`<GROUPS.`) is `endpoints`, and the Group singular
+The Group plural name (`<GROUPS>`) is `endpoints`, and the Group singular
 name (`<GROUP>`) is `endpoint`.
 
 The following attributes are defined for the `endpoint` object in addition
@@ -307,8 +307,6 @@ to the xRegistry-defined core
   comparison algorithm of two `channel` values might need to be more
   complicated than a "string compare" in those cases.
 
-  When this property has no value it MUST either be serialized as an empty
-  string or excluded from the serialization entirely.
 - Constraints:
   - OPTIONAL.
   - When specified, the value MUST be a non-empty string.
@@ -329,7 +327,6 @@ See the [deprecated](../core/spec.md#deprecated) attribute in the core
   provides a mechanism by which it can be determined without examination of
   the Resource at all.
 - Constraints:
-  - At least one of `envelope` and `protocol` MUST be specified.
   - MUST be a non-empty string of the form `<SPEC>[/<VERSION>]`,
     where `<SPEC>` is the non-empty string name of the specification that
     defines the Resource. An OPTIONAL `<VERSION>` value SHOULD be included if
@@ -368,8 +365,9 @@ This specification defines the following envelope options for the indicated
 
 - `mode` : indicates whether the CloudEvent will use `binary` or `structured`
   (mode)[https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message].
-  When specified, its value MUST be one of: `binary` or `structured`. When not
-  specified, the endpoint is indicating that either mode is acceptable.
+  When specified, its value MUST be one of: `binary` or `structured`, case
+  sensitive. When not specified, the endpoint is indicating that either mode
+  is acceptable.
 - `format` : indicates the format of the CloudEvent when sent in `structured`
   mode. This attribute MUST NOT be specified when `mode` is `binary`. The value
   used MUST match the expected content type of the message (e.g. for HTTP the
@@ -402,7 +400,6 @@ This specification defines the following envelope options for the indicated
 
   All messages inside an Endpoint MUST use this same protocol.
 - Constraints:
-  - At least one of `envelope` and `protocol` MUST be specified.
   - MUST be a non-empty string.
   - SHOULD follow the naming convention `<NAME>/<VERSION>`,
     whereby `<NAME>` is the name of the protocol and `<VERSION>` is the
@@ -433,8 +430,7 @@ This specification defines the following envelope options for the indicated
   a resource managed by the network host is protocol specific.
 - Constraints:
   - OPTIONAL.
-  - Each object key MUST contain a `uri` attribute with a valid, absolute
-    URI (URL).
+  - Each object MUST contain a `uri` attribute with a valid, absolute URI (URL).
 - Examples:
   - `[ {"uri": "https://example.com" } ]`
   - ```
@@ -526,6 +522,7 @@ This specification defines the following envelope options for the indicated
   the liveness of the endpoint.
 - Constraints:
   - OPTIONAL.
+  - If present, MUST be either `true` or `false`, case-sensitive.
   - When not specified, the default value is MUST be `false`.
 
 ##### `protocoloptions.options`

--- a/message/spec.md
+++ b/message/spec.md
@@ -24,8 +24,8 @@ event envelopes, and logical grouping of related messages and events.
 
 Managing the description of the payloads of those messages and events is not in
 scope, but delegated to the [schema registry extension](../schema/spec.md) for
-xRegistry. Schemas are linked to messages and event declarations through a URI
-reference.
+xRegistry. Schemas are linked from messages and event declarations through a
+URI reference.
 
 For easy reference, the JSON serialization of a Message Registry adheres to
 this form:
@@ -183,14 +183,15 @@ A similar transport protocol-independent message metadata convention is, for
 example, the [W3C SOAP 1.2 envelope][SOAP] for which support could be added by
 an extension.
 
-This specification uses **protocol** to refer to a transport protocol-specific
-message metadata convention. When a known protocol is explicitly specified for
-a message definition, the "protocoloptions" section MAY contain constraints
-for the protocol-specific metadata.
+This specification uses **protocol** as a selector into the protocol-specific
+message metadata that is defined under the `protocol.ifvalues` section of the
+model. When a known protocol is explicitly specified for a message definition,
+the "protocoloptions" section MAY contain constraints for the
+protocol-specific metadata.
 
 ## Message Definitions Registry
 
-The Message Definitions Registry (or "Message Catalog") is a registry of
+The Message Definitions Registry (or "Message Registry") is a collection of
 metadata definitions for messages and events. The entries in the registry
 describe constraints for the metadata of messages and events, for instance the
 concrete values and patterns for the `type`, `source`, and `subject` attributes
@@ -236,8 +237,8 @@ resides in the [model.json](model.json) file.
 
 ### Message Definition Groups
 
-The Group (`<GROUP>`) name is `messagegroups`. The type of a group is
-`messagegroup`.
+The Group plural name (`<GROUPS.`) is `messagegroups`, and the Group singular
+name (`<GROUP>`) is `messagegroup`.
 
 The following attributes are defined for the `messagegroup` object in addition
 to the xRegistry-defined core
@@ -251,9 +252,9 @@ to the xRegistry-defined core
   version as `<NAME>/<VERSION>`. This specification defines a set of common
   [metadata envelope names](#metadata-envelopes) that MUST be used for the
   given envelopes, but applications MAY define extensions for other envelopes
-  on their own. All definitions inside a group MUST use this same envelope.
+  on their own. All messages inside a group MUST use this same envelope.
 - Constraints:
-  - At least one of `envelopemetadata` and `protocol` MUST be specified.
+  - At least one of `envelope` or `protocol` MUST be specified.
   - If present, MUST be a non-empty string.
   - If present, MUST follow the naming convention `<NAME>/<VERSION>`, whereby
     `<NAME>` is the name of the metadata envelope and `<VERSION>` is the
@@ -271,7 +272,7 @@ to the xRegistry-defined core
   applications MAY define extensions for other protocols on their own. All
   messages inside a group MUST use this same protocol.
 - Constraints:
-  - At least one of `envelopemetadata` and `protocol` MUST be specified.
+  - At least one of `envelope` or `protocol` MUST be specified.
   - If present, MUST be a non-empty string.
   - If present, MUST follow the naming convention `<NAME>` or
     `<NAME>/<VERSION>`, whereby `<NAME>` is the name of the protocol and
@@ -285,8 +286,8 @@ to the xRegistry-defined core
 
 ### Message Definitions
 
-The Resource (`<RESOURCE>`) collection name inside `messagegroup` is
-`messages`. The Resource name is `message`.
+The Resource plural name (`<RESOURCES>`) is `messages`, and the Resource
+singular name (`<RESOURCE>`) is `message`.
 
 Different from schemas, message definitions do not contain a
 version history. If the metadata of two messages differs, they are considered
@@ -309,10 +310,11 @@ the core xRegistry Resource
 - Description: if present, the XID points to a message definition that is the
   base for this message definition. By following the XID, the base message
   can be retrieved and extended with the properties of this message. This is
-  useful for defining variants of messages that only differ in minor aspects to
-  avoid repetition, or messages that only have a `envelope` with associated
-  `envelopemetadata` to be bound to various protocols.
+  useful for defining variants of messages that only differ in minor additive
+  aspects to avoid repetition, or messages that only have a `envelope` with
+  associated `envelopemetadata` to be bound to various protocols.
   Attributes defined in this message fully override the attributes of the base
+  message, and there is no mechanism to delete attributes from the base
   message.
 - Constraints:
   - OPTIONAL.
@@ -1072,7 +1074,6 @@ Example:
 }
 ```
 
-
 [CloudEvents Types]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system
 [AMQP 1.0]: https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-overview-v1.0-os.html
 [AMQP 1.0 Message Format]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
@@ -1085,7 +1086,6 @@ Example:
 [MQTT 5.0]: https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html
 [MQTT 3.1.1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
 [CloudEvents]: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
-[CloudEvents Subscriptions API]: https://github.com/cloudevents/spec/blob/main/subscriptions/spec.md
 [NATS]: https://docs.nats.io/reference/reference-protocols/nats-protocol
 [Apache Kafka]: https://kafka.apache.org/protocol
 [Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html

--- a/message/spec.md
+++ b/message/spec.md
@@ -66,6 +66,7 @@ this form:
       "labels": { "<STRING>": "<STRING>" * }, ?
       "createdat": "<TIMESTAMP>",
       "modifiedat": "<TIMESTAMP>",
+      "deprecated": { ... }, ?
 
       # MessageGroup extension attributes
       "envelope": "<STRING>", ?                 # e.g. CloudEvents/1.0
@@ -254,7 +255,7 @@ to the xRegistry-defined core
   given envelopes, but applications MAY define extensions for other envelopes
   on their own. All messages inside a group MUST use this same envelope.
 - Constraints:
-  - If present, MUST be a non-empty string.
+  - If present, MUST be a non-empty case-insensitive string.
   - If present, MUST follow the naming convention `<NAME>/<VERSION>`, whereby
     `<NAME>` is the name of the metadata envelope and `<VERSION>` is the
     version of the metadata envelope.
@@ -271,7 +272,7 @@ to the xRegistry-defined core
   applications MAY define extensions for other protocols on their own. All
   messages inside a group MUST use this same protocol.
 - Constraints:
-  - If present, MUST be a non-empty string.
+  - If present, MUST be a non-empty case-insensitive string.
   - If present, MUST follow the naming convention `<NAME>` or
     `<NAME>/<VERSION>`, whereby `<NAME>` is the name of the protocol and
     `<VERSION>` is the version of protocol. The version is REQUIRED if
@@ -322,7 +323,7 @@ the core xRegistry Resource
   "merge" operation of the next message's attributes. Note in the case of an
   inherited attribute being a complex type (e.g. map, object), and the
   overlaying attribute is scalar, then the entire inherited attribute (and
-  nested values) are replace by that scalar value.
+  nested values) are replaced by that scalar value.
 
   If the referenced message can not be found then an error MUST NOT be
   generated.
@@ -401,8 +402,12 @@ Illustrating example:
 
 #### `envelopeoptions`
 
-See [`envelopeoptions`](../endpoint/spec.md#envelopeoptions) in the Endpoint
-specification.
+- Type: Map
+- Description: Configuration details of the Message with respect to the
+  envelope format used to format the messages. See
+  [Metadata Envelopes](#metadata-envelopes) for more details.
+- Constraints:
+  - OPTIONAL.
 
 #### `protocol`
 
@@ -429,7 +434,7 @@ specification.
   attribute.
 - Constraints:
   - OPTIONAL.
-  - If present, MUST be a non-empty string.
+  - If present, MUST be a non-empty case-insensitive string.
   - If present, MUST follow the naming convention `<NAME>/<VERSION>`, whereby
     `<NAME>` is the name of the schema format and `<VERSION>` is the version of
     the schema format in the format defined by the schema format itself.

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -12,7 +12,7 @@ allows for the storage, management and discovery of schema documents.
 - [Notations and Terminology](#notations-and-terminology)
   - [Notational Conventions](#notational-conventions)
   - [Terminology](#terminology)
-- [Schema Registry](#schema-registry)
+- [Schema Registry](#schema-registry-model)
   - [Schema Groups](#schema-groups)
   - [Schema Resources](#schema-resources)
 
@@ -154,73 +154,24 @@ MUST be created, to indicate the breaking change.
 
 ## Schema Registry Model
 
-The formal xRegistry extension model of the Schema Registry resides in the
-[model.json](model.json) file.
+The formal xRegistry extension model of the Schema Registry
+resides in the [model.json](model.json) file.
 
-#### Schema Group
+#### Schema Groups
 
 A schema Group is a container for schemas that are related to each other in
 some application-defined way. This specification does not impose any
 restrictions on what schemas can be contained in a schema Group.
 
-## Schema Registry
+The Group plural name (`<GROUPS.`) is `schemagroups`, and the Group singular
+name (`<GROUP>`) is `schemagroup`.
 
-The Schema Registry is a metadata store for organizing schemas and schema
-Versions of any kind; it is a document store.
-
-The xRegistry API extension model of the Schema Registry, which is defined in
-detail below, is as follows:
-
-```yaml
-{
-  "groups": [
-    {
-      "singular": "schemagroup",
-      "plural": "schemagroups",
-
-      "resources": [
-        {
-          "singular": "schema",
-          "plural": "schemas",
-          "versions": 0,
-
-          "attributes": {
-            "format": {
-              "name": "format",
-              "type": "string",
-              "description": "Schema format identifier for this schema version"
-            }
-          },
-          "metaattributes": {
-            "validation": {
-              "name": "validation",
-              "type": "boolean",
-              "description": "Verify compliance with specified 'format'"
-            }
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-Implementations of this specification MAY include additional extension
-attributes, including the `*` attribute of type `any`.
-
-Since the Schema Registry is an application of the xRegistry specification, all
-attributes for Groups, Resources, and Resource Version objects are inherited
-from there.
-
-### Schema Groups
-
-The Group (`<GROUP>`) name for the Schema Registry is `schemagroups`. The
-Group does not have any specific extension attributes.
+The Group does not have any specific extension attributes.
 
 A schema Group is a collection of schemas that are related to each other in
 some application-defined way. A schema Group does not impose any restrictions
 on the contained schemas, meaning that a schema Group MAY contain schemas of
-different formats. Every schema MUST reside inside a schema Group.
+different formats. Every schema Resource MUST reside inside a schema Group.
 
 Example:
 
@@ -248,10 +199,11 @@ containing 5 schemas.
 
 ### Schema Resources
 
-The Resources (`<RESOURCE>`) collection inside of schema Groups is named
-`schemas`. The type of the Resource is `schema`. Any single `schema` is a
-container for one or more `Versions`, which hold the concrete schema
-documents or schema document references.
+The Resource plural name (`<RESOURCES>`) is `schemas`, and the Resource
+singular name (`<RESOURCE>`) is `schema`.
+
+Any single `schema` is a container for one or more `Versions`, which hold the
+concrete schema documents or schema document references.
 
 All Versions of a schema MUST adhere to the semantic rules of the schema's
 `compatibility` attribute. This specification defines "compatibility" for
@@ -304,8 +256,6 @@ the core xRegistry Resource
 - Constraints:
   - OPTIONAL.
   - When not specified, the default value MUST be `false`.
-  - MUST be a Resource level attribute defined within the `metaattributes`
-    section of the model.
 
 #### `format`
 
@@ -321,6 +271,9 @@ the core xRegistry Resource
   validation purposes, and as such implementations can choose to modify the
   model to make this attribute mandatory.
 
+  It is RECOMMENDED that the same schema format `<NAME>` be used for all
+  Versions of a schema Resource.
+
   Managers of the xRegistry instance can set a default value for this
   attribute, making it a REQUIRED attribute.
 - Constraints:
@@ -329,8 +282,6 @@ the core xRegistry Resource
   - MUST follow the naming convention `<NAME>/<VERSION>`, whereby `<NAME>` is
     the name of the schema format and `<VERSION>` is the Version of the schema
     format in the format defined by the schema format itself.
-  - MUST be a Version level attribute defined within the `attributes` section
-    of the model.
   - MUST be present if the `compatibility` attribute is set to a value other
     than `None` and when the `compatibilityauthority` attribute is set to
     `server`, to enable validation of the schema document.
@@ -428,11 +379,11 @@ When the `format` attribute is set to `JsonSchema`, the `schema` attribute of
 the schema Resource is a JSON object representing a JSON Schema document
 conformant with the declared version.
 
-A URI-reference, like
-[`schemauri`](../message/spec.md#dataschemauri) that points
-to a JSON Schema document MAY use a [JSON pointer][JSON pointer]  expression
-to deep link into the schema document to reference a particular type
-definition. Otherwise the top-level object definition of the schema is used.
+When a URI-reference, like [`schemauri`](../message/spec.md#dataschemauri),
+points to a JSON Schema document it MAY use a [JSON pointer][JSON pointer]
+expression to deep link into the schema document to reference a particular
+type definition. Otherwise the top-level object definition of the schema is
+used.
 
 The version of the JSON Schema format is the version of the JSON
 Schema specification that is used to define the schema. The version of the JSON
@@ -465,11 +416,11 @@ When the `format` attribute is set to `XSD`, the `schema` attribute of
 schema Resource is a string containing an XML Schema document conformant with
 the declared version.
 
-A URI-reference, like
-[`schemauri`](../message/spec.md#dataschemauri) that points
-to a XSD Schema document MAY use an XPath expression to deep link into the
-schema document to reference a particular type definition. Otherwise the root
-element definition of the schema is used.
+When a URI-reference, like [`schemauri`](../message/spec.md#dataschemauri),
+points to a JSON Schema document it MAY use an XPath
+expression to deep link into the schema document to reference a particular
+type definition. Otherwise the top-level object definition of the schema is
+used.
 
 The identifiers for the following XML Schema versions:
 
@@ -496,17 +447,19 @@ Examples:
 - `Avro/1.8.2` is the identifier for the Apache Avro release 1.8.2.
 - `Avro/1.11.0` is the identifier for the Apache Avro release 1.11.0
 
-A URI-reference, like
-[`schemauri`](../message/spec.md#dataschemauri) that points
-to an Avro Schema document MUST reference an Avro record declaration contained
-in the schema document using a URI fragment suffix `[:]{record-name}`. The ':'
-character is used as a separator when the URI already contains a fragment.
+When a URI-reference, like [`schemauri`](../message/spec.md#dataschemauri),
+points to a JSON Schema document it MAY use a URI fragment suffix
+`[:]{record-name}` to deep link into the schema document to reference a
+particular type definition. Otherwise the top-level object definition of the
+schema is used. The ':' character is used as a separator when the URI already
+contains a fragment.
 
 Examples:
 
 - If the Avro schema document is referenced using the URI
-`https://example.com/avro/telemetry.avsc`, the URI fragment `#TelemetryEvent`
-references the record declaration of the `TelemetryEvent` record.
+`https://example.com/avro/telemetry.avsc#TelemetryEvent`, the URI fragment
+`#TelemetryEvent` references the record declaration of the `TelemetryEvent`
+record.
 - If the Avro schema document is a local Schema Registry reference like
 `#/schemagroups/com.example.telemetry/schemas/com.example.telemetrydata`, in
 the which the reference is already in the form of a URI fragment, the suffix is

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -56,6 +56,7 @@ this form:
       "labels": { "<STRING>": "<STRING>" * }, ?
       "createdat": "<TIMESTAMP>",
       "modifiedat": "<TIMESTAMP>",
+      "deprecated": { ... }, ?
 
       "schemasurl": "<URL>",                       # Schemas collection
       "schemascount": <UINTEGER>,
@@ -278,7 +279,7 @@ the core xRegistry Resource
   attribute, making it a REQUIRED attribute.
 - Constraints:
   - OPTIONAL.
-  - If present, MUST be a non-empty string.
+  - If present, MUST be a non-empty case-insensitive string.
   - MUST follow the naming convention `<NAME>/<VERSION>`, whereby `<NAME>` is
     the name of the schema format and `<VERSION>` is the Version of the schema
     format in the format defined by the schema format itself.


### PR DESCRIPTION
- More tweaks
- Explain why some constraints might not be enforced when using xref or basemessage
- treat unauthorized xref references the same as "dangling" references
- add "deprecated" as a group level attribute too. Now it's a "common" attribute
- make envelope/format/... and ifvalue case-insensitive

fixes: #398 
fixes: #397
