### PR TITLE
Message spec review

### DIFF
--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -98,8 +98,8 @@ enumerated and explained in [protocol options](#protocol-options).
 
 Each endpoint MAY also define an `envelope` selector which allows for defining
 particular `envelopeoptions` at the endpoint level. For CloudEvents, this
-permits definition the serialization mode (binary or structured) and the event
-format for structured mode.
+permits the definition of the serialization mode (binary or structured) and the
+event format for structured mode.
 
 ### Message Groups
 
@@ -156,7 +156,7 @@ For clarity, OPTIONAL attributes (specification-defined and extensions) are
 OPTIONAL for clients to use, but the servers' responsibility will vary.
 Server-unknown extension attributes MUST be silently stored in the backing
 datastore. Specification-defined, and server-known extension, attributes MUST
-generate an error if corresponding feature is not supported or enabled.
+generate an error if the corresponding feature is not supported or enabled.
 However, as with all attributes, if accepting the attribute would result in a
 bad state (such as exceeding a size limit, or results in a security issue),
 then the server MAY choose to reject the request.

--- a/tools/dict
+++ b/tools/dict
@@ -5,6 +5,7 @@ api
 apicur
 apicurio
 apikey
+aprime
 asc
 asyncapi
 attr
@@ -20,9 +21,13 @@ avsc
 aws
 backend
 basemessage
+bbase
+bprime
 bson
 bunnymq
 capabilitiesoffered
+cashierdesk
+cdid
 cereg
 charset
 checkedin
@@ -66,6 +71,7 @@ definitiongroupsurl
 definitionscount
 definitionsurl
 deploymentid
+derivedmqtt
 deviceid
 dirid
 dirs
@@ -82,6 +88,7 @@ envelopeoptions
 erp
 etag
 eventing
+eventtype
 fabrikam
 files
 filescount
@@ -172,6 +179,8 @@ myattribute
 myendpoint
 myentity
 myevent
+myevents
+myeventsmqtt
 mygroup
 mygroupid
 mygroups
@@ -267,6 +276,7 @@ src
 ssl
 stickyversions
 stringified
+storeid
 svg
 targetregistry
 tcp

--- a/tools/verify.py
+++ b/tools/verify.py
@@ -55,7 +55,8 @@ _PHRASES_THAT_MUST_BE_CAPITALIZED_PATTERN = re.compile(
     # and ignore `required` cases (attribute name is `required`)
     # and ignore .required cases (attribute name is "required")
     # and ignore -required cases (href has "required")
-    r'(?<![-.`"_])REQUIRED(?![`"_])|'
+    # and ignore #required cases (href has "required")
+    r'(?<![-.`"_#])REQUIRED(?![`"_])|'
     r"(?<!`)\bSHALL(\s+NOT)?\b|"  # ignore the word "marshall"
     r"(?<!`)SHOULD(\s+NOT)?|"
     r"(?<!`)RECOMMENDED|"


### PR DESCRIPTION
- _Fixes #406_
- _Replaces https://github.com/xregistry/spec/pull/407_

## Proposed Changes

- typos, cleanup
- Explain how "basemessage" can be leveraged to reuse/extend an existing msgDef
- Explain "context attributes" in the message spec
  - how they can have "templates" that are filled-in with environment provided data
  - how they can be used to help convert message - e.g. to turn an event into a CloudEvent
- Document why the message spec recommends a single message definition version
  - and why "on the wire" edits should be avoided]
  - and recommendation on how to map incoming msg to its msgDef (use CE 'type' -> msgID)