### PR TITLE
Week of Mar2

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -15,4 +15,4 @@ jobs:
       - name: Install tools dependencies
         run: python -m pip install -r tools/requirements.txt
       - name: Verify Specification
-        run: make -f tools/Makefile verify makeschema
+        run: make -f tools/Makefile

--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -808,11 +808,6 @@
                       "doc": "Time of the object modification"
                     },
                     {
-                      "type": "string",
-                      "doc": "Schema format identifier for this schema version",
-                      "name": "format"
-                    },
-                    {
                       "name": "Extensions",
                       "type": {
                         "type": "map",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -2003,10 +2003,6 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
-          },
-          "format": {
-            "type": "string",
-            "description": "Schema format identifier for this schema version"
           }
         },
         "oneOf": [

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -5150,10 +5150,6 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
-          },
-          "format": {
-            "type": "string",
-            "description": "Schema format identifier for this schema version"
           }
         },
         "oneOf": [

--- a/core/model.md
+++ b/core/model.md
@@ -102,28 +102,28 @@ The overall format of a model definition is as follows:
   },
 
   "groups": {
-    "<STRING>": {                      # Key=plural name, e.g. "endpoints"
-      "plural": "<STRING>",            # E.g. "endpoints"
-      "singular": "<STRING>",          # E.g. "endpoint"
+    "<STRING>": {                        # Key=plural name, e.g. "endpoints"
+      "plural": "<STRING>",              # E.g. "endpoints"
+      "singular": "<STRING>",            # E.g. "endpoint"
       "description": "<STRING>", ?
       "documentation": "<URL>", ?
       "icon": "<URL>", ?
       "labels": { "<STRING>": "<STRING>" * }, ?
-      "modelversion": "<STRING>", ?    # Version of the group model
-      "compatiblewith": "<URI>", ?     # Statement of compatibility
-      "attributes": { ... }, ?         # See "attributes" above
+      "modelversion": "<STRING>", ?      # Version of the group model
+      "modelcompatiblewith": "<URI>", ?  # Statement of compatibility
+      "attributes": { ... }, ?           # See "attributes" above
       "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources
 
       "resources": {
-        "<STRING>": {                  # Key=plural name, e.g. "messages"
-          "plural": "<STRING>",        # E.g. "messages"
-          "singular": "<STRING>",      # E.g. "message"
+        "<STRING>": {                    # Key=plural name, e.g. "messages"
+          "plural": "<STRING>",          # E.g. "messages"
+          "singular": "<STRING>",        # E.g. "message"
           "description": "<STRING>", ?
           "documentation": "<URL>", ?
           "icon": "<URL>", ?
           "labels": { "<STRING>": "<STRING>" * }, ?
-          "modelversion": "<STRING>", ?  # Version of the resource model
-          "compatiblewith": "<URI>", ?   # Statement of compatibility
+          "modelversion": "<STRING>", ?     # Version of the resource model
+          "modelcompatiblewith": "<URI>", ? # Statement of compatibility
           "maxversions": <UINTEGER>, ?   # Num Vers(>=0). Default=0, 0=unlimited
           "setversionid": <BOOLEAN>, ?   # vid settable? Default=true
           "setdefaultversionsticky": <BOOLEAN>, ? # Sticky settable? Default=true
@@ -499,7 +499,7 @@ The following describes the attributes of the Registry model:
 - It is common to use a combination of major and minor version numbers.
 - Example: `1.2`
 
-### `groups.<STRING>.compatiblewith`
+### `groups.<STRING>.modelcompatiblewith`
 - Type: URI.
 - OPTIONAL.
 - References / represents an xRegistry model definition that
@@ -569,8 +569,8 @@ The following describes the attributes of the Registry model:
 - See [`modelversion`](#groupsstringmodelversion) above.
 - OPTIONAL.
 
-### `groups.<STRING>.resources.<STRING>.compatiblewith`
-- See [`modelversion`](#groupsstringcompatiblewith) above.
+### `groups.<STRING>.resources.<STRING>.modelcompatiblewith`
+- See [`modelversion`](#groupsstringmodelcompatiblewith) above.
 - OPTIONAL.
 
 ### `groups.<STRING>.resources.<STRING>.maxversions`

--- a/core/model.md
+++ b/core/model.md
@@ -1,5 +1,7 @@
 # xRegistry Service Model - Version 1.0-rc2
 
+<!-- words: compat validatecompatibility validateformat -->
+
 ## Abstract
 
 This document describes the xRegistry model definition language that is used
@@ -130,6 +132,8 @@ The overall format of a model definition is as follows:
           "hasdocument": <BOOLEAN>, ?       # Has separate document. Default=true
           "versionmode": "<STRING>", ?      # 'ancestor' processing algorithm
           "singleversionroot": <BOOLEAN>, ? # Enforce single root. Default=false
+          "validatecompatibility": <BOOLEAN>, ? # Enforce version compat checks
+          "validateformat": <BOOLEAN>, ?    # Enforce version format checks
           "typemap": <MAP>, ?               # Contenttype mappings
           "attributes": { ... }, ?          # Version attributes/extensions
           "resourceattributes": { ... }, ?  # Resource attributes/extensions
@@ -758,6 +762,40 @@ The following describes the attributes of the Registry model:
   [`singleversionroot` Policy
   Enforcement](./primer.md#singleversionroot-policy-enforcement) section of
   the Primer for more information.
+
+### `groups.<STRING>.resources.<STRING>.validatecompatibility`
+- Type: Boolean (`true` or `false`, case-sensitive).
+- OPTIONAL.
+- Indicated whether the server MUST validate that all Versions of this
+  Resource type adhere to its owning Resource's `meta.compatibility` value.
+- When not specified, the default value MUST be `false`.
+- A value of `true` indicates that the server MUST generate an error
+  ([compatibility_violation](spec.md#compatibility_violation)) if a Resource's
+  `meta.compatibility` value is not supported, or if any Version of that
+  Resource does not adhere to the rules as defined by the
+  `meta.compatibility` value. Additionally, if this model attribute is set
+  to `true` then the Resource model's `validateformat` MUST also be `true`.
+- A value of `false` indicates that the server MUST NOT perform any
+  `compatibility` checking for instances of this Resource type.
+- In cases where this attribute is `false`, but there is a desire to advertise
+  the entity that has performed the validation, a `label` MAY be added to
+  the Resource's model or to the Resource instance itself with this
+  information.
+
+### `groups.<STRING>.resources.<STRING>.validateformat`
+- Type: Boolean (`true` or `false`, case-sensitive).
+- OPTIONAL.
+- Indicated whether the server MUST validate that all Versions of this
+  Resource type adhere to the rules as defined by the Version's `format`
+  value.
+- When not specified, the default value MUST be `false`.
+- A value of `true` indicates that the server MUST generate an error
+  ([format_violation](spec.md#format_violation))if a Version of this Resource
+  type does not adhere to the `format` value of that Version. Note that a
+  missing (or empty) `format` value MUST be treated as non-compliant and
+  generate an error ([format_missing](spec.md#format_missing)).
+- A value of `false` indicates that the server MUST NOT perform any `format`
+  checking for Versions of this Resource type.
 
 ### `groups.<STRING>.resources.<STRING>.typemap`
 - Type: Map where the keys and values MUST be non-empty strings. The key

--- a/core/model.schema.json
+++ b/core/model.schema.json
@@ -63,7 +63,7 @@
               "type": "string",
               "description": "Version of the group model"
             },
-            "compatiblewith": {
+            "modelcompatiblewith": {
               "type": "string",
               "format": "uri",
               "description": "Statement of compatibility with model spec"
@@ -175,7 +175,7 @@
               "type": "string",
               "description": "Version of the resource model"
             },
-            "compatiblewith": {
+            "modelcompatiblewith": {
               "type": "string",
               "format": "uri",
               "description": "Statement of compatibility with model spec"

--- a/core/primer.md
+++ b/core/primer.md
@@ -1,5 +1,7 @@
 # xRegistry Primer
 
+<!-- words: validatecompatibility validateformat -->
+
 <!-- no verify-specs -->
 
 ## Abstract
@@ -799,20 +801,18 @@ Versions exist with the same `createdat` timestamp, those Versions are
 sorted in an descending alphabetical order, and the first is the newest
 Version.
 
-# What does the `compatibilityauthority` attribute convey?
+# Can `validatecompatibility` and `validateformat` be `true` for file-servers?
 
-The [`compatibility` attribute](./spec.md#compatibility-attribute) is a
-statement made by the authority managing the registry about the
-compatibility guarantees between Versions of the Resource. The authority is
-expected to guarantee the configured `compatibility`. The
-[`compatibilityauthority` attribute](./spec.md#compatibilityauthority-attribute)
-represents who the enforcing authority is. Any requests to set the authority
-to `server` when the server cannot perform compatibility checking will be
-refused. In cases where the hosting service isn't backed by an xRegistry
-implementation (e.g. blob-store), it is recommended that
-`compatibilityauthority` is set to `external` to accurately reflect the
-situation. However, there may be cases where it is appropriate to set it to
-`server`. For example, if the file-server based xRegistry is an alternative
+In general, the `validatecompatibility` and `validateformat` attributes are
+meant to enable server-side policy validation. However, they also convey to
+clients that the data within the Registry adheres to the specified
+`compatibility` and `format` values. In cases where the xRegistry is being
+hosted by a file-server, where such validation code does not exist, but the
+server would still like to indicate to its clients that the data has in fact
+been validated, it is appropriate for the xRegistry metadata to reflect this
+situation by exposing these attributes with a value of `true`.
+
+For example, if the file-server based xRegistry is an alternative
 mechanism to retrieve data from another xRegistry service that did validate
 the data (i.e. it was exported to the file-server), and there's a desire to
 not expose this implementation/deployment choice to the end-user. In other

--- a/core/primer.md
+++ b/core/primer.md
@@ -807,7 +807,7 @@ compatibility guarantees between Versions of the Resource. The authority is
 expected to guarantee the configured `compatibility`. The
 [`compatibilityauthority` attribute](./spec.md#compatibilityauthority-attribute)
 represents who the enforcing authority is. Any requests to set the authority
-to the server when the server cannot perform compatibility checking will be
+to `server` when the server cannot perform compatibility checking will be
 refused. In cases where the hosting service isn't backed by an xRegistry
 implementation (e.g. blob-store), it is recommended that
 `compatibilityauthority` is set to `external` to accurately reflect the

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -464,6 +464,7 @@
               "type": "string",
               "enum": [ "none", "backward", "backward_transitive", "forward",
                         "forward_transitive", "full", "full_transitive" ],
+              "strict": true,
               "required": true,
               "default": "none"
             },
@@ -471,6 +472,9 @@
               "name": "compatibilityauthority",
               "type": "string",
               "enum": [ "external", "server" ]
+              "strict": true,
+              "required": true,
+              "default": "external"
             },
             "deprecated": {
               "name": "deprecated",

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -319,6 +319,10 @@
               "name": "contenttype",
               "type": "string"
             },
+            "format": {
+              "name": "format",
+              "type": "string"
+            },
 
             "fileurl": {
               "name": "fileurl",
@@ -459,22 +463,24 @@
               "required": true,
               "default": false
             },
+            "formatauthority": {
+              "name": "formatauthority",
+              "type": "string",
+              "enum": [ "external", "server" ],
+              "strict": false
+            },
             "compatibility": {
               "name": "compatibility",
               "type": "string",
-              "enum": [ "none", "backward", "backward_transitive", "forward",
+              "enum": [ "backward", "backward_transitive", "forward",
                         "forward_transitive", "full", "full_transitive" ],
-              "strict": true,
-              "required": true,
-              "default": "none"
+              "strict": true
             },
             "compatibilityauthority": {
               "name": "compatibilityauthority",
               "type": "string",
-              "enum": [ "external", "server" ]
-              "strict": true,
-              "required": true,
-              "default": "external"
+              "enum": [ "external", "server" ],
+              "strict": false
             },
             "deprecated": {
               "name": "deprecated",

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -463,24 +463,12 @@
               "required": true,
               "default": false
             },
-            "formatauthority": {
-              "name": "formatauthority",
-              "type": "string",
-              "enum": [ "external", "server" ],
-              "strict": false
-            },
             "compatibility": {
               "name": "compatibility",
               "type": "string",
               "enum": [ "backward", "backward_transitive", "forward",
                         "forward_transitive", "full", "full_transitive" ],
               "strict": true
-            },
-            "compatibilityauthority": {
-              "name": "compatibilityauthority",
-              "type": "string",
-              "enum": [ "external", "server" ],
-              "strict": false
             },
             "deprecated": {
               "name": "deprecated",

--- a/core/spec.md
+++ b/core/spec.md
@@ -485,7 +485,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
         "icon": "<URL>", ?
         "labels": { "<STRING>": "<STRING>" * }, ?
         "modelversion": "<STRING>", ?     # Version of the group model
-        "compatiblewith": "<URI>", ?      # Statement of compatibility
+        "modelcompatiblewith": "<URI>", ? # Statement of compatibility
         "attributes": { ... }, ?          # Group-level attributes/extensions
         "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources
 
@@ -498,7 +498,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "icon": "<URL>", ?
             "labels": { "<STRING>": "<STRING>" * }, ?
             "modelversion": "<STRING>", ? # Version of the resource model
-            "compatiblewith": "<URI>", ?  # Statement of compatibility
+            "modelcompatiblewith": "<URI>", ?  # Statement of compatibility
             "maxversions": <UINTEGER>, ?  # Num Vers(>=0). Default=0(unlimited)
             "setversionid": <BOOLEAN>, ?  # vid settable? Default=true
             "setdefaultversionsticky": <BOOLEAN>, ? # sticky settable? Default=true

--- a/core/spec.md
+++ b/core/spec.md
@@ -578,8 +578,9 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "createdat": "<TIMESTAMP>",            # Resource's
             "modifiedat": "<TIMESTAMP>",           # Resource's
             "readonly": <BOOLEAN>,                 # Default=false
-            "compatibility": "<STRING>",           # Default=none
-            "compatibilityauthority": "<STRING>", ?  # Default=external
+            "formatauthority": "<STRING>", ?
+            "compatibility": "<STRING>", ?
+            "compatibilityauthority": "<STRING>", ?
             "deprecated": {
               "effective": "<TIMESTAMP>", ?
               "removal": "<TIMESTAMP>", ?
@@ -611,6 +612,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
               "modifiedat": "<TIMESTAMP>",
               "ancestor": "<STRING>",              # Ancestor's versionid
               "contenttype": "<STRING>", ?
+              "format": "<STRING>", ?
 
               "<RESOURCE>url": "<URL>", ?                # If not local
               "<RESOURCE>": ... Resource document ..., ? # If inlined & JSON
@@ -2356,8 +2358,9 @@ The overall processing of the request message is as follows:
     [`versionmode`](./model.md#groupsstringresourcesstringversionmode) value.
 4.  Process the `meta` sub-object, if present.
 5.  Update [`meta.defaultversionid`](#defaultversionid-attribute) as needed.
-6.  Enforce the [Version compatibility checks](#compatibility-attribute).
-7.  Enforce the [Resource `maxversions`
+6.  Enforce the [Version format checks](#format-attribute).
+7.  Enforce the [Version compatibility checks](#compatibility-attribute).
+8.  Enforce the [Resource `maxversions`
     constraints](./model.md#groupsstringresourcesstringmaxversions). Note that
     this might require updating the [`ancestor` values](#ancestor-attribute)
     again after some Versions have been deleted.
@@ -2512,7 +2515,6 @@ then the resulting serialization of the source Resource would be:
     "createdat": "2024-01-01-T12:00:00Z",
     "modifiedat": "2024-01-01-T12:01:00Z",
     "readonly": false,
-    "compatibility": "none",
     "defaultversionid": "v1",
     "defaultversionurl": "http://example.com/schemagroups/group1/schemas/mySchema/versions/v1",
     "defaultversionsticky": false
@@ -2649,8 +2651,8 @@ The serialization of the Meta entity MUST adhere to this form:
   "createdat": "<TIMESTAMP>",               # Resource's
   "modifiedat": "<TIMESTAMP>",              # Resource's
   "readonly": <BOOLEAN>,                    # Default=false
-  "compatibility": "<STRING>",              # Default=none
-  "compatibilityauthority": "<STRING>", ?   # Default=external
+  "compatibility": "<STRING>", ?
+  "compatibilityauthority": "<STRING>", ?
   "deprecated": { ... }, ?
 
   "defaultversionid": "<STRING>",
@@ -2720,6 +2722,34 @@ and the following Meta-level attributes:
     case the error MUST be silently ignored, and the Resource MUST remain
     unchanged.
 
+#### `formatauthority` Attribute
+- Type: String
+- Description: Indicates the authority that enforces compliance with the
+  `format` value specified on each Version of this Resource.
+
+  This specification defines the following enumeration values, implementations
+  MAY choose to extend this list:
+
+  - `external` - The validation is enforced by an external authority.
+    The server MUST NOT perform any `format` validation checking.
+
+  - `server` - The server MUST verify that all Versions of this Resource
+    adhere to the rules defined by the value of their respective `format`
+    attribute value, and generate an error
+    ([format_violation](#format_violation)) for any operation that would
+    result in non-compliance.
+
+   When not specified, there is no statement being made as to the enforcement
+   of the `format` attribute's semantics and the server MUST NOT perform any
+   `format` validation checking.
+
+- Constraints:
+  - OPTIONAL.
+  - If present, MUST be a case-insensitive non-empty string.
+  - If present, all Versions of the Resource MUST have their respective
+    `format` attribute set, otherwise an error
+    ([format_missing](#format_missing)) MUST be generated.
+
 #### `compatibility` Attribute
 - Type: String (with Resource-specified enumeration of possible values)
 - Description: States that Versions of this Resource adhere to a certain
@@ -2727,27 +2757,21 @@ and the following Meta-level attributes:
   indicate that all Versions of a Resource are backwards compatible with the
   next oldest Version, as determined by their `ancestor` attributes.
 
-  This specification makes no statement as to which parts of the data are
-  examined for compatibility (e.g. xRegistry metadata, domain-specific
+  This specification makes no statement as to which parts of the Version data
+  are examined for compatibility (e.g. xRegistry metadata, domain-specific
   document, etc.). This will be defined by the compatibility rules defined by
-  each Resource `format` value.
+  each Version's `format` value.
 
   The exact meaning of what each `compatibility` value means might vary based
-  on the data model of the Resource, therefore this specification only defines
-  a very high-level abstract meaning for each to ensure some degree of
-  consistency. However, domain-specific specifications are expected to
-  modify the `compatibility` enum values defined in the Resource's model to
-  limit the list of available values and to define the exact meaning of each.
-  Implementations MUST include `none` as one of the possible values and when
-  set to `none` then compatibility checking MUST NOT be performed.
+  on the `format` value, therefore this specification only defines a very
+  high-level abstract meaning for each to ensure some degree of consistency.
+  However, domain-specific specifications are expected to modify the
+  `compatibility` enum values defined in the Resource's model to limit the
+  list of available values and to define the exact meaning of each.
 
-  For `compatibility` strategies that require understanding the sequence in
-  which Versions need to be compatible, the server MUST use the
-  [`ancestor`](#ancestor-attribute) to determine the sequence of Versions.
-
-  Note that when `compatibilitystrategy` is set to `external`, the
-  `compatibility` attribute is not used by the server for any internal
-  processing.
+  For `compatibility` strategies that require understanding the lineage
+  relationship between the Versions, the [`ancestor`](#ancestor-attribute)
+  attribute on each Version MUST be used to determine that information.
 
   This specification defines the following enumeration values. Implementations
   MAY choose to extend this list, or use a subset of it.
@@ -2759,53 +2783,48 @@ and the following Meta-level attributes:
     Versions.
   - `full_transitive` - A Version is compatible with all older and all newer
     Versions.
-  - `none` - No compatibility checking is performed.
+
+  When not specified, there is no statement being made as to the compatibility
+  relationship between the Resource's Versions and the server MUST NOT perform
+  any `compatibility` checking.
 
 - Constraints:
-  - REQUIRED.
-  - It MUST be a case-sensitive value from the model-defined enumeration range.
-  - When not specified, the default value MUST be `none`.
-  - The enumeration range MUST include `none` as a valid value.
-  - If the `compatibilityauthority` attribute is set to `server`, when
-    changing the `compatibility` attribute, the server MUST validate whether
-    the new `compatibility` value can be enforced across all existing
-    Versions. If that's not the case, the server MUST generate an error
-    ([compatibility_violation](#compatibility_violation)).
+  - OPTIONAL.
+  - It MUST be a case-sensitive non-empty value from the Resource model's
+    enumeration range.
+  - When changing the value of this attribute, it MUST be applied to all
+    Versions of the Resource, and an error
+    ([compatibility_violation](#compatibility_violation)) MUST be generated
+    if any Version can not conform to the requirements of the specified
+    compatibility value.
 
 #### `compatibilityauthority` Attribute
-- Name: `compatibilityauthority`
 - Type: String
 - Description: Indicates the authority that enforces the `compatibility`
-  and `format` values defined by the owning Resource.
+  value specified by the owning Resource.
 
-  This specification defines the following enumeration values. Implementations
+  This specification defines the following enumeration values, implementations
   MAY choose to extend this list:
 
   - `external` - The compatibility is enforced by an external authority.
-    The server MUST NOT perform any compatibility checking and that the
-    compatibility checking is performed by an external authority.
+    The server MUST NOT perform any compatibility checking.
 
-  - `server` - The server MUST perform the following actions:
-    - Verify that each Version adheres to the rules associated with the
-      `format` value of its owning Resource.
-    - Verify that all Versions of a Resource adhere to the rules defined by
-      the current value of the `compatibility` attribute, if `compatibility`
-      is not `none`.
+  - `server` - The server MUST verify that all Versions of the Resource adhere
+    to the rules defined by the value of the `compatibility` attribute, and
+    generate an error
+    ([compatibility_violation](#compatibility_violation)) for any operation
+    that would result in non-compliance.
 
-  The server MUST generate an error
-  ([compatibility_violation](#compatibility_violation)) due to any
-  attempt to set this attribute to `server` if the server cannot enforce,
-  or validate, the compatibility for the Resource's existing Versions.
-
-  When set to `server`, the server MUST generate an error
-  ([compatibility_violation](#compatibility_violation)) following any
-  attempt to create/update a Resource (or its Versions) that would result in
-  those entities violating the stated `compatibility` value.
+   When not specified, there is no statement being made as to the enforcement
+   of the `compatibility` attribute's semantics and the server MUST NOT
+   perform any `compatibility` checking.
 
 - Constraints:
-  - REQUIRED
-  - When not specified, the default value MUST be `external`.
-  - If present, MUST be non-empty.
+  - OPTIONAL.
+  - If present, MUST be a case-insensitive non-empty string.
+  - If present with a value of `server`, then the Resource's
+    `meta.formatauthority` attribute MUST also be `server`.
+  - MUST be absent if `compatibility` is not set.
 
 #### `defaultversionid` Attribute
 - Type: String
@@ -3089,6 +3108,40 @@ and the following Version-level attributes:
 
 - Examples:
   - `application/json`
+
+#### `format` Attribute
+- Type: String
+- Description: Identifies what the Version represents. For example, in the
+  case of a Schema Registry, this value would identify the schema format of
+  the Version's domain-specific document. However, it MAY also be used to
+  identify the xRegistry metadata definitions/values for the Version. For
+  example, it could be used to indicate that the Versions are
+  [Message definitions](../message/spec.md).
+
+  Managers of the xRegistry instance MAY enforce validation of the data within
+  the Registry by modifying the model to make this a mandatory attribute, or
+  by defining a default value.
+
+- Constraints:
+  - OPTIONAL.
+  - If present, MUST be a non-empty case-insensitive string.
+  - SHOULD follow the naming convention `<NAME>/<VERSION>`, whereby `<NAME>` is
+    the name of the format and `<VERSION>` is the version of the format used
+    by this Version.
+  - RECOMMENDED that the same `<NAME>` be used for all Versions of a Resource.
+  - MUST be present if the `formatauthority` attribute is set.
+  - MUST be present if the `compatibilityauthority` attribute is set.
+
+Note: an attempt to set this attribute to a value that differs from the other
+Version's values could result in the server rejecting the request due to
+the [`compatibility`](#compatibility-attribute) conformance checks, if
+`compatibilityauthority` is set to `server`.
+
+- Examples:
+  - `JsonSchema/draft-07`
+  - `Protobuf/3`
+  - `XSD/1.1`
+  - `Avro/1.9`
 
 #### `<RESOURCE>url` Attribute
 - Type: URI
@@ -4301,6 +4354,22 @@ field is just a substitution value and MUST NOT be empty.
 * Title: `Attribute "<name>" is not allowed to be present since the Resource (<subject>) uses "xref".`
 * Args:
   - `name`: The name of the attribute in question.
+
+### format_missing
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_missing`
+* Code: `400 Bad Request`
+* Subject: `<resource_xid>`
+* Title: `Version "<subject>" needs to have a "format" value due to its owning Resource's "formatauthority" being set.`
+
+### format_violation
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_violation`
+* Code: `400 Bad Request`
+* Subject: `<version_xid>`
+* Title: `The request would cause Version "<subject>" to violate its adherence to its "format" (<format>).`
+* Args:
+  - `format`: The Version's `format` value.
 
 ### groups_only
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -1,5 +1,7 @@
 # xRegistry Service - Version 1.0-rc2
 
+<!-- words: validatecompatibility validateformat -->
+
 ## Abstract
 
 This specification defines an extensible model for managing metadata
@@ -578,9 +580,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "createdat": "<TIMESTAMP>",            # Resource's
             "modifiedat": "<TIMESTAMP>",           # Resource's
             "readonly": <BOOLEAN>,                 # Default=false
-            "formatauthority": "<STRING>", ?
             "compatibility": "<STRING>", ?
-            "compatibilityauthority": "<STRING>", ?
             "deprecated": {
               "effective": "<TIMESTAMP>", ?
               "removal": "<TIMESTAMP>", ?
@@ -2652,7 +2652,6 @@ The serialization of the Meta entity MUST adhere to this form:
   "modifiedat": "<TIMESTAMP>",              # Resource's
   "readonly": <BOOLEAN>,                    # Default=false
   "compatibility": "<STRING>", ?
-  "compatibilityauthority": "<STRING>", ?
   "deprecated": { ... }, ?
 
   "defaultversionid": "<STRING>",
@@ -2722,34 +2721,6 @@ and the following Meta-level attributes:
     case the error MUST be silently ignored, and the Resource MUST remain
     unchanged.
 
-#### `formatauthority` Attribute
-- Type: String
-- Description: Indicates the authority that enforces compliance with the
-  `format` value specified on each Version of this Resource.
-
-  This specification defines the following enumeration values, implementations
-  MAY choose to extend this list:
-
-  - `external` - The validation is enforced by an external authority.
-    The server MUST NOT perform any `format` validation checking.
-
-  - `server` - The server MUST verify that all Versions of this Resource
-    adhere to the rules defined by the value of their respective `format`
-    attribute value, and generate an error
-    ([format_violation](#format_violation)) for any operation that would
-    result in non-compliance.
-
-   When not specified, there is no statement being made as to the enforcement
-   of the `format` attribute's semantics and the server MUST NOT perform any
-   `format` validation checking.
-
-- Constraints:
-  - OPTIONAL.
-  - If present, MUST be a case-insensitive non-empty string.
-  - If present, all Versions of the Resource MUST have their respective
-    `format` attribute set, otherwise an error
-    ([format_missing](#format_missing)) MUST be generated.
-
 #### `compatibility` Attribute
 - Type: String (with Resource-specified enumeration of possible values)
 - Description: States that Versions of this Resource adhere to a certain
@@ -2797,34 +2768,6 @@ and the following Meta-level attributes:
     ([compatibility_violation](#compatibility_violation)) MUST be generated
     if any Version can not conform to the requirements of the specified
     compatibility value.
-
-#### `compatibilityauthority` Attribute
-- Type: String
-- Description: Indicates the authority that enforces the `compatibility`
-  value specified by the owning Resource.
-
-  This specification defines the following enumeration values, implementations
-  MAY choose to extend this list:
-
-  - `external` - The compatibility is enforced by an external authority.
-    The server MUST NOT perform any compatibility checking.
-
-  - `server` - The server MUST verify that all Versions of the Resource adhere
-    to the rules defined by the value of the `compatibility` attribute, and
-    generate an error
-    ([compatibility_violation](#compatibility_violation)) for any operation
-    that would result in non-compliance.
-
-   When not specified, there is no statement being made as to the enforcement
-   of the `compatibility` attribute's semantics and the server MUST NOT
-   perform any `compatibility` checking.
-
-- Constraints:
-  - OPTIONAL.
-  - If present, MUST be a case-insensitive non-empty string.
-  - If present with a value of `server`, then the Resource's
-    `meta.formatauthority` attribute MUST also be `server`.
-  - MUST be absent if `compatibility` is not set.
 
 #### `defaultversionid` Attribute
 - Type: String
@@ -3119,8 +3062,9 @@ and the following Version-level attributes:
   [Message definitions](../message/spec.md).
 
   Managers of the xRegistry instance MAY enforce validation of the data within
-  the Registry by modifying the model to make this a mandatory attribute, or
-  by defining a default value.
+  the Registry by modifying the model to make this a mandatory attribute, by
+  defining a default value, or by setting the Resource's `validateformat` model
+  attribute to `true`.
 
 - Constraints:
   - OPTIONAL.
@@ -3129,13 +3073,15 @@ and the following Version-level attributes:
     the name of the format and `<VERSION>` is the version of the format used
     by this Version.
   - RECOMMENDED that the same `<NAME>` be used for all Versions of a Resource.
-  - MUST be present if the `formatauthority` attribute is set.
-  - MUST be present if the `compatibilityauthority` attribute is set.
+  - MUST be present if the Resource's `validateformat` model attribute
+    is `true`.
+  - MUST be present if the Resource's `validatecompatibility` model attribute
+    is `true`.
 
 Note: an attempt to set this attribute to a value that differs from the other
 Version's values could result in the server rejecting the request due to
 the [`compatibility`](#compatibility-attribute) conformance checks, if
-`compatibilityauthority` is set to `server`.
+`validatecompatibility` model attribute is `true`.
 
 - Examples:
   - `JsonSchema/draft-07`
@@ -3538,7 +3484,6 @@ the following:
     "ancestor": "<STRING>",
     "readonly": <BOOLEAN>,
     "compatibility": "<STRING>",
-    "compatibilityauthority": "<STRING>", ?
     "deprecated": { ... }, ?
 
     "defaultversionid": "<STRING>",
@@ -4360,14 +4305,14 @@ field is just a substitution value and MUST NOT be empty.
 * Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_missing`
 * Code: `400 Bad Request`
 * Subject: `<resource_xid>`
-* Title: `Version "<subject>" needs to have a "format" value due to its owning Resource's "formatauthority" being set.`
+* Title: `Version "<subject>" needs to have a "format" value due to its owning Resource model's "validateformat" being set.`
 
 ### format_violation
 
 * Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_violation`
 * Code: `400 Bad Request`
 * Subject: `<version_xid>`
-* Title: `The request would cause Version "<subject>" to violate its adherence to its "format" (<format>).`
+* Title: `The request would cause Version "<subject>" to be non-compliant with its "format" (<format>).`
 * Args:
   - `format`: The Version's `format` value.
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -589,7 +589,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
 
             "defaultversionid": "<STRING>",
             "defaultversionurl": "<URL>",
-            "defaultversionsticky": <BOOLEAN>      # Default=false
+            "defaultversionsticky": <BOOLEAN> ?    # Default=false
           }, ?
           "versionsurl": "<URL>",
           "versionscount": <UINTEGER>,
@@ -2655,7 +2655,7 @@ The serialization of the Meta entity MUST adhere to this form:
 
   "defaultversionid": "<STRING>",
   "defaultversionurl": "<URL>",
-  "defaultversionsticky": <BOOLEAN>
+  "defaultversionsticky": <BOOLEAN> ?
 }
 ```
 
@@ -2729,7 +2729,9 @@ and the following Meta-level attributes:
 
   This specification makes no statement as to which parts of the data are
   examined for compatibility (e.g. xRegistry metadata, domain-specific
-  document, etc.). This SHOULD be defined by the `compatibility` values.
+  document, etc.). This will be defined by the compatibility rules defined by
+  each Resource `format` value.
+
   The exact meaning of what each `compatibility` value means might vary based
   on the data model of the Resource, therefore this specification only defines
   a very high-level abstract meaning for each to ensure some degree of
@@ -2739,17 +2741,13 @@ and the following Meta-level attributes:
   Implementations MUST include `none` as one of the possible values and when
   set to `none` then compatibility checking MUST NOT be performed.
 
-  If the `compatibilityauthority` attribute is set to `server` then
-  implementations of this specification are REQUIRED to perform the proper
-  compatibility checks to ensure that all Versions of a Resource adhere to the
-  rules defined by the current value of this attribute.
   For `compatibility` strategies that require understanding the sequence in
   which Versions need to be compatible, the server MUST use the
   [`ancestor`](#ancestor-attribute) to determine the sequence of Versions.
 
-  Note that, like all attributes, if a default value is defined as part of the
-  model, then this attribute MUST be populated with that value if no value
-  is provided.
+  Note that when `compatibilitystrategy` is set to `external`, the
+  `compatibility` attribute is not used by the server for any internal
+  processing.
 
   This specification defines the following enumeration values. Implementations
   MAY choose to extend this list, or use a subset of it.
@@ -2778,12 +2776,21 @@ and the following Meta-level attributes:
 - Name: `compatibilityauthority`
 - Type: String
 - Description: Indicates the authority that enforces the `compatibility`
-  value defined by the owning Resource.
+  and `format` values defined by the owning Resource.
 
   This specification defines the following enumeration values. Implementations
-  MAY choose to extend this list.
+  MAY choose to extend this list:
+
   - `external` - The compatibility is enforced by an external authority.
-  - `server` - The compatibility is enforced by the server.
+    The server MUST NOT perform any compatibility checking and that the
+    compatibility checking is performed by an external authority.
+
+  - `server` - The server MUST perform the following actions:
+    - Verify that each Version adheres to the rules associated with the
+      `format` value of its owning Resource.
+    - Verify that all Versions of a Resource adhere to the rules defined by
+      the current value of the `compatibility` attribute, if `compatibility`
+      is not `none`.
 
   The server MUST generate an error
   ([compatibility_violation](#compatibility_violation)) due to any
@@ -2793,17 +2800,11 @@ and the following Meta-level attributes:
   When set to `server`, the server MUST generate an error
   ([compatibility_violation](#compatibility_violation)) following any
   attempt to create/update a Resource (or its Versions) that would result in
-  those entities violating the stated compatibility statement.
-
-  A value of `external` indicates that the server MUST NOT perform any
-  compatibility checking and that the compatibility checking is performed by
-  an external authority.
+  those entities violating the stated `compatibility` value.
 
 - Constraints:
-  - MUST be present when `compatibility` is not `none`.
-  - MUST NOT be present when `compatibility` is `none`.
-  - When not specified, and `compatibility` is not `none`, the default value
-    MUST be `external`.
+  - REQUIRED
+  - When not specified, the default value MUST be `external`.
   - If present, MUST be non-empty.
 
 #### `defaultversionid` Attribute
@@ -3489,7 +3490,7 @@ the following:
 
     "defaultversionid": "<STRING>",
     "defaultversionurl": "<URL>"
-    "defaultversionsticky": <BOOLEAN>
+    "defaultversionsticky": <BOOLEAN> ?
   }
 }
 ```

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -7,7 +7,7 @@
     "endpoints": {
       "singular": "endpoint",
       "modelversion": "1.0-rc2",
-      "compatiblewith": "https://xregistry.io/xreg/domains/endpoint/specs/model.json",
+      "modelcompatiblewith": "https://xregistry.io/xreg/domains/endpoint/specs/model.json",
       "attributes": {
         "usage": {
           "name": "usage",

--- a/message/model.json
+++ b/message/model.json
@@ -4,7 +4,7 @@
     "messagegroups": {
       "singular": "messagegroup",
       "modelversion": "1.0-rc2",
-      "compatiblewith": "https://xregistry.io/xreg/domains/message/specs/model.json",
+      "modelcompatiblewith": "https://xregistry.io/xreg/domains/message/specs/model.json",
       "attributes": {
         "envelope": {
           "name": "envelope",
@@ -29,7 +29,7 @@
           "setdefaultversionsticky": false,
           "hasdocument": false,
           "modelversion": "1.0-rc2",
-          "compatiblewith": "https://xregistry.io/xreg/domains/message/specs/model.json",
+          "modelcompatiblewith": "https://xregistry.io/xreg/domains/message/specs/model.json",
           "attributes": {
             "basemessageurl": {
               "name": "basemessageurl",

--- a/message/spec.md
+++ b/message/spec.md
@@ -705,7 +705,7 @@ Illustrating example:
 
 - Type: String
 - Description: Identifies the schema format applicable to the message payload,
-  equivalent to the schema ['format'](../schema/spec.md#422-format)
+  equivalent to the schema ['format'](../core/spec.md#format-attribute)
   attribute.
 - Constraints:
   - OPTIONAL.

--- a/schema/model.json
+++ b/schema/model.json
@@ -20,23 +20,9 @@
           "compatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
 
           "attributes": {
-            "format": {
-              "name": "format",
-              "type": "string",
-              "description": "Schema format identifier for this schema version"
-            },
             "*": {
               "name": "*",
               "type": "any"
-            }
-          },
-          "metaattributes": {
-            "validation": {
-              "name": "validation",
-              "type": "boolean",
-              "description": "Verify compliance with specified schema 'format'",
-              "required": true,
-              "default": false
             }
           }
         }

--- a/schema/model.json
+++ b/schema/model.json
@@ -4,7 +4,7 @@
     "schemagroups": {
       "singular": "schemagroup",
       "modelversion": "1.0-rc2",
-      "compatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
+      "modelcompatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
 
       "attributes": {
         "*": {
@@ -17,7 +17,7 @@
         "schemas": {
           "singular": "schema",
           "modelversion": "1.0-rc2",
-          "compatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
+          "modelcompatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
 
           "attributes": {
             "*": {

--- a/schema/schemas/document-schema.avsc
+++ b/schema/schemas/document-schema.avsc
@@ -235,11 +235,6 @@
                       "doc": "Time of the object modification"
                     },
                     {
-                      "type": "string",
-                      "doc": "Schema format identifier for this schema version",
-                      "name": "format"
-                    },
-                    {
                       "name": "Extensions",
                       "type": {
                         "type": "map",

--- a/schema/schemas/document-schema.json
+++ b/schema/schemas/document-schema.json
@@ -62,10 +62,6 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
-          },
-          "format": {
-            "type": "string",
-            "description": "Schema format identifier for this schema version"
           }
         },
         "oneOf": [

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -2095,10 +2095,6 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
-          },
-          "format": {
-            "type": "string",
-            "description": "Schema format identifier for this schema version"
           }
         },
         "oneOf": [

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -427,7 +427,7 @@ the core xRegistry Resource [attributes][xRegistry attributes-and-extensions]:
     the name of the schema format and `<VERSION>` is the Version of the schema
     format in the format defined by the schema format itself.
   - MUST be present if the `compatibility` attribute is set to a value other
-    than `None` and when the `compatibilityauthority` attribute is set to
+    than `none` and when the `compatibilityauthority` attribute is set to
     `server`, to enable validation of the schema document.
 - Examples:
   - `JsonSchema/draft-07`

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -25,8 +25,6 @@ allows for the storage, management and discovery of schema documents.
   - [4. Schema Registry](#4-schema-registry)
     - [4.1. Schema Groups](#41-schema-groups)
     - [4.2. Schema Resources](#42-schema-resources)
-      - [4.2.1. `validation`](#421-validation)
-      - [4.2.2. `format`](#422-format)
     - [4.3. Schema Formats](#43-schema-formats)
       - [4.3.1. JSON Schema](#431-json-schema)
       - [4.3.2. XML Schema](#432-xml-schema)
@@ -272,18 +270,13 @@ this form:
           "modifiedat": "<TIMESTAMP>",
           "ancestor": "<STRING>",
 
-          "format": "<STRING>", ?                  # schema extension attr
-
           "schemaurl": "<URL>", ?
           "schema": <ANY> ?
           "schemabase64": "<STRING>", ?
           #  End of default Version's attributes
 
           "metaurl": "<URL>",                      # Resource level attrs
-          "meta": {
-            ... core spec metadata attributes ...
-            "validation": <BOOLEAN> ?              # schema extension attr
-          }, ?
+          "meta": { ... }, ?
 
           "versionsurl": "<URL>",
           "versionscount": <UINTEGER>,
@@ -352,7 +345,7 @@ container for one or more `versions`, which hold the concrete schema documents
 or schema document references.
 
 All Versions of a single Schema Resource MUST adhere to the semantic rules of
-the schema's [`compatibility`][xRegistry compatibility] attribute.
+the schema's [`compatibility`][xRegistry compatibility] attribute, if specified.
 
 Implementations of this specification MAY choose to support any of the
 [`compatibility`][xRegistry compatibility] values defined in the core xRegistry
@@ -379,56 +372,14 @@ to exist, and allows for implementations to determine the Version lineage. See
 the [`ancestor`][xRegistry ancestor] attribute in the core xRegistry
 specification for more information.
 
-The following extensions are defined for the `schema` Resource in addition to
-the core xRegistry Resource [attributes][xRegistry attributes-and-extensions]:
+### 4.3. Schema Formats
 
-#### 4.2.1. `validation`
+This specification further refines the
+[core specification's `format`](../core/spec.md#format-attribute) for use
+in a Schema Registry by defining a set of common schema format names that MUST
+be used for the given formats, but applications MAY define extensions for
+other formats on their own.
 
-- Type: Boolean
-- Description: Indicates whether or not the server will validate the Resource's
-  document(s) against the specified `format` attribute. A value of `true`
-  indicates that the server MUST reject any request that would cause any Version
-  of this Resource to be invalid per the rules as defined by the `format`
-  specification. Note, this includes a request to set this attribute to `true`.
-  This means that before validation can be enabled, all existing Versions of the
-  Resource MUST be compliant.
-
-  A value of `false` indicates that the server MUST NOT do any validation.
-
-  If `format` is not specified, or if the value is not known by the server (but
-  is an allowable value), then the server MUST NOT perform any validation.
-- Constraints:
-  - OPTIONAL.
-  - When not specified, the default value MUST be `false`.
-
-#### 4.2.2. `format`
-
-- Type: String
-- Description: Identifies the schema format. In absence of formal media-type
-  definitions for several important schema formats, we define a convention here
-  to reference schema formats by name and version as `<NAME>/<VERSION>`. This
-  specification defines a set of common [schema format
-  names](#43-schema-formats) that MUST be used for the given formats, but
-  applications MAY define extensions for other formats on their own.
-
-  For many schema registry use cases this attribute is important for schema
-  validation purposes, and as such implementations can choose to modify the
-  model to make this attribute mandatory.
-
-  It is RECOMMENDED that the same schema format `<NAME>` be used for all
-  Versions of a schema Resource.
-
-  Managers of the xRegistry instance can set a default value for this
-  attribute, making it a REQUIRED attribute.
-- Constraints:
-  - OPTIONAL.
-  - If present, MUST be a non-empty case-insensitive string.
-  - MUST follow the naming convention `<NAME>/<VERSION>`, whereby `<NAME>` is
-    the name of the schema format and `<VERSION>` is the Version of the schema
-    format in the format defined by the schema format itself.
-  - MUST be present if the `compatibility` attribute is set to a value other
-    than `none` and when the `compatibilityauthority` attribute is set to
-    `server`, to enable validation of the schema document.
 - Examples:
   - `JsonSchema/draft-07`
   - `Protobuf/3`
@@ -509,15 +460,10 @@ Versions for a schema named `com.example.telemetrydata`:
 }
 ```
 
-### 4.3. Schema Formats
-
-This section defines a set of common schema `format` values that MUST be used
-for the given formats, but applications MAY define extensions for other formats
-on their own.
-
 #### 4.3.1. JSON Schema
 
-The [`format`](#422-format) identifier for JSON Schema is `JsonSchema`.
+The [`format`](../core/spec.md/#format-attribute) identifier for JSON Schema is
+`JsonSchema`.
 
 When the `format` attribute is set to `JsonSchema`, the `schema` attribute of
 the schema Resource is a JSON object representing a JSON Schema document
@@ -550,9 +496,9 @@ version number.
 
 #### 4.3.2. XML Schema
 
-The [`format`](#422-format) identifier for XML Schema is `XSD`. The version of
-the XML Schema format is the version of the W3C XML Schema specification that is
-used to define the schema.
+The [`format`](../core/spec.md/#format-attribute) identifier for XML Schema is
+`XSD`. The version of the XML Schema format is the version of the W3C XML
+Schema specification that is used to define the schema.
 
 When the `format` attribute is set to `XSD`, the `schema` attribute of schema
 Resource is a string containing an XML Schema document conformant with the
@@ -575,9 +521,9 @@ are defined as follows:
 
 #### 4.3.3. Apache Avro Schema
 
-The [`format`](#422-format) identifier for Apache Avro Schema is `Avro`. The
-version of the Apache Avro Schema format is the version of the Apache Avro
-Schema release that is used to define the schema.
+The [`format`](../core/spec.md/#format-attribute) identifier for Apache Avro
+Schema is `Avro`. The version of the Apache Avro Schema format is the version
+of the Apache Avro Schema release that is used to define the schema.
 
 When the `format` attribute is set to `Avro`, the `schema` attribute of the
 schema Resource is a JSON object representing an Avro schema document conformant
@@ -609,9 +555,9 @@ appended separated with a colon, for instance
 
 #### 4.3.4. Protobuf Schema
 
-The [`format`](#422-format) identifier for Protobuf Schema is `Protobuf`. The
-version of the Protobuf Schema format is the version of the Protobuf syntax that
-is used to define the schema.
+The [`format`](../core/spec.md/#format-attribute) identifier for Protobuf Schema
+is `Protobuf`. The version of the Protobuf Schema format is the version of the
+Protobuf syntax that is used to define the schema.
 
 When the `format` attribute is set to `Protobuf`, the `schema` attribute of the
 schema Resource is a string containing a Protobuf schema document conformant

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,7 @@ all: models docker
 		( echo "schema files have been updated, make sure you commit them" ; \
 		  exit 1 )
 
-verify: spellcheck tabcheck errorcheck samplescheck links ticks
+verify: spellcheck tabcheck errorcheck samplescheck testpython links ticks
 
 spellcheck:
 	tools/spellcheck */README.md */spec.md core/*.md \
@@ -26,12 +26,16 @@ samplescheck:
 	tools/samplescheck */model.json */samples/*json */samples/*/*json
 	@echo
 
-links:
+loadpython:
 	@echo Loading python deps
 	@python -m pip install -qq -r tools/requirements.txt
-	@echo Testing our link verification tool
+
+testpython: loadpython
+	@echo Testing our python tools
 	@pytest tools/
-	@echo Verifying our docs
+
+links: loadpython
+	@echo Verifying links in our docs
 	@python tools/verify.py .
 	@echo
 
@@ -43,7 +47,7 @@ models:
 		ghcr.io/xregistry/xr -c "/xr model verify */model.json -v")
 	@echo
 
-makeschema:
+makeschema: loadpython
 	@echo Rebuilding the schemas...
 	@python tools/schema-generator.py --type json-schema --schema-id https://xregistry.io/xreg/xregistryspecs/schema-v1/schemas/document-schema.json --output schema/schemas/document-schema.json schema/model.json
 	@python tools/schema-generator.py --type avro-schema --output schema/schemas/document-schema.avsc schema/model.json

--- a/tools/dict
+++ b/tools/dict
@@ -43,7 +43,6 @@ collectionscount
 collectionsurl
 commonattributes
 compatibilityauthority
-compatiblewith
 config
 configendpoints
 connectionproperties
@@ -113,7 +112,7 @@ groupsgidresourcesrid
 groupsgidresourcesridmeta
 groupsgidresourcesridversions
 groupsgidresourcesridversionsvid
-groupsstringcompatiblewith
+groupsstringmodelcompatiblewith
 groupsstringmodelversion
 groupsstringresourcesstringmetaattributes
 groupsstringresourcesstringresourceattributes
@@ -169,6 +168,7 @@ metaschemas
 metaurl
 microsoft
 middleware
+modelcompatiblewith
 modelsource
 modelversion
 modifiedat

--- a/tools/dict
+++ b/tools/dict
@@ -98,6 +98,7 @@ files
 filescount
 filesurl
 filesystem
+formatauthority
 gid
 github
 githubusercontent

--- a/tools/errorcheck
+++ b/tools/errorcheck
@@ -27,7 +27,7 @@ first="UNUSED ERRORS:\n"
 for err in "${err_array[@]}"; do
   # ref=$(echo "$err" | tr '[:upper:]' '[:lower:]' | sed "s/ /-/g")
   # grep -e "(#$ref)" -e "(\./[a-z]*\.md#$ref)" $* > /dev/null && continue
-  grep -e "(#$err)" -e "(\./[a-z]*\.md#$err)" $* > /dev/null && continue
+  grep -e "(.*#$err)" -e "(\./[a-z]*\.md#$err)" $* > /dev/null && continue
 
   # special case this one
   [[ "$err" == "server_error" ]] && continue

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -9,4 +9,4 @@ jsonpointer
 pytest
 avro
 jsonschema
-openapi-spec-validator
+openapi-spec-validator==0.8.0

--- a/tools/test_schema_generator.py
+++ b/tools/test_schema_generator.py
@@ -330,7 +330,6 @@ class TestSchemaGenerator:
     def test_makefile_endpoint_openapi(self, endpoint_model, tools_dir):
         """Test endpoint model OpenAPI generation (matches Makefile)."""
         schema_data = self.generate_schema(endpoint_model, 'openapi', tools_dir)
-        print(f"{json.dumps(schema_data)}")
         # Validate with OpenAPI spec validator
         validate_spec(schema_data)
         # Check nested structure

--- a/tools/test_schema_generator.py
+++ b/tools/test_schema_generator.py
@@ -330,6 +330,7 @@ class TestSchemaGenerator:
     def test_makefile_endpoint_openapi(self, endpoint_model, tools_dir):
         """Test endpoint model OpenAPI generation (matches Makefile)."""
         schema_data = self.generate_schema(endpoint_model, 'openapi', tools_dir)
+        print(f"{json.dumps(schema_data)}")
         # Validate with OpenAPI spec validator
         validate_spec(schema_data)
         # Check nested structure


### PR DESCRIPTION
- minor tweaks and typos
- add 'formatauth' and 'format' to core spec/model, remove 'format' from schema
- compatiblewith -> modelcompatiblewith
- s/formatauth/validateformat/ and moved it into the Resource model
- s/compatibilityauth/validatecompatibility/ and moved it into the Reource model