### PR TITLE
Adding `dataschemaxid` to the `model.json`

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -368,6 +368,11 @@
                     },
                     {
                       "type": "string",
+                      "doc": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry.",
+                      "name": "dataschemaxid"
+                    },
+                    {
+                      "type": "string",
                       "doc": "The content type for the message payload",
                       "name": "datacontenttype"
                     }

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -88,6 +88,11 @@
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
           },
+          "dataschemaxid": {
+            "type": "string",
+            "format": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
           "datacontenttype": {
             "type": "string",
             "description": "The content type for the message payload"

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -4901,6 +4901,11 @@
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
           },
+          "dataschemaxid": {
+            "type": "string",
+            "format": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
           "datacontenttype": {
             "type": "string",
             "description": "The content type for the message payload"

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -368,6 +368,11 @@
                     },
                     {
                       "type": "string",
+                      "doc": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry.",
+                      "name": "dataschemaxid"
+                    },
+                    {
+                      "type": "string",
                       "doc": "The content type for the message payload",
                       "name": "datacontenttype"
                     }

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -82,6 +82,11 @@
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
           },
+          "dataschemaxid": {
+            "type": "string",
+            "format": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
           "datacontenttype": {
             "type": "string",
             "description": "The content type for the message payload"

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -3808,6 +3808,11 @@
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
           },
+          "dataschemaxid": {
+            "type": "string",
+            "format": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
           "datacontenttype": {
             "type": "string",
             "description": "The content type for the message payload"

--- a/message/model.json
+++ b/message/model.json
@@ -1360,7 +1360,7 @@
             "dataschemaxid": {
               "name": "dataschemaxid",
               "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry.",
-              "type": "string"
+              "type": "xid"
             },
             "datacontenttype": {
               "name": "datacontenttype",

--- a/message/model.json
+++ b/message/model.json
@@ -1357,6 +1357,11 @@
               "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry",
               "type": "uri"
             },
+            "dataschemaxid": {
+              "name": "dataschemaxid",
+              "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry.",
+              "type": "string"
+            },
             "datacontenttype": {
               "name": "datacontenttype",
               "description": "The content type for the message payload",

--- a/message/schemas/document-schema.avsc
+++ b/message/schemas/document-schema.avsc
@@ -368,6 +368,11 @@
                     },
                     {
                       "type": "string",
+                      "doc": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry.",
+                      "name": "dataschemaxid"
+                    },
+                    {
+                      "type": "string",
                       "doc": "The content type for the message payload",
                       "name": "datacontenttype"
                     }

--- a/message/schemas/document-schema.json
+++ b/message/schemas/document-schema.json
@@ -76,6 +76,11 @@
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
           },
+          "dataschemaxid": {
+            "type": "string",
+            "format": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
           "datacontenttype": {
             "type": "string",
             "description": "The content type for the message payload"

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -3057,6 +3057,11 @@
             "format": "uri",
             "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
           },
+          "dataschemaxid": {
+            "type": "string",
+            "format": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
           "datacontenttype": {
             "type": "string",
             "description": "The content type for the message payload"


### PR DESCRIPTION
The `dataschemaxid` as defined [here](https://xregistry.io/xreg/xregistryspecs/message-v1/docs/spec.html#dataschemaxid), was missing in `model.json`.