### PR TITLE
Week of March 16

### DIFF
--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -3936,6 +3936,15 @@
             "default": [],
             "description": "List of supported flags (query parameters)."
           },
+          "ignore": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "An ignore flag value. Values are case insensitive and may include extension values."
+            },
+            "default": [],
+            "description": "List of supported ignore flag values."
+          },
           "mutable": {
             "type": "array",
             "items": {

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -4171,6 +4171,14 @@
             "minimum": 0,
             "description": "The epoch value for the meta sub-object."
           },
+          "labels": {
+            "type": "object",
+            "description": "A map of label key/value pairs.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "createdat": {
             "type": "string",
             "format": "date-time",

--- a/core/http.md
+++ b/core/http.md
@@ -413,7 +413,7 @@ apply:
 - When `labels` is serialized as an HTTP header, see
   [Serializing Resource Domain-Specific Documents](#serializing-resource-domain-specific-documents), then
   each map entry MUST appear as a separate HTTP header using a name of
-  `xRegistry-labels-<KEYNAME>`.
+  `xRegistry-labels.<KEYNAME>`.
 
 ##### `contenttype` Attribute
 
@@ -1553,9 +1553,9 @@ values will appear in the HTTP body.
 
 Top-level map attributes whose values are of scalar types SHOULD also appear as
 HTTP headers (each key having its own HTTP header) and in those cases the
-HTTP header names will be of the form: `xRegistry-<MAPNAME>-<KEYNAME>`.
-Note that map keys MAY contain the `-` character, so any `-` after the 2nd `-`
-is part of the key name. See
+HTTP header names will be of the form: `xRegistry-<MAPNAME>.<KEYNAME>`.
+Note that map keys MAY contain the `.` character, so any `.` after the
+`<MAPNAME>` is part of the key name. See
 [HTTP Header Values](#http-header-values) for additional information and
 [`labels`](#labels-attribute) for an example of one such attribute.
 
@@ -1598,7 +1598,7 @@ xRegistry-isdefault: true
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
 xRegistry-ancestor: <STRING>
@@ -1643,7 +1643,7 @@ xRegistry-isdefault: <BOOLEAN>
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
 xRegistry-ancestor: <STRING>
@@ -1920,7 +1920,7 @@ xRegistry-isdefault: true
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
 xRegistry-ancestor: <STRING>
@@ -2025,7 +2025,7 @@ xRegistry-name: <STRING> ?
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP> ?
 xRegistry-modifiedat: <TIMESTAMP> ?
 xRegistry-ancestor: <STRING> ?
@@ -2056,7 +2056,7 @@ xRegistry-isdefault: true
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
 xRegistry-ancestor: <STRING>
@@ -2202,7 +2202,7 @@ xRegistry-name: <STRING> ?
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP> ?
 xRegistry-modifiedat: <TIMESTAMP> ?
 xRegistry-ancestor: <STRING> ?
@@ -2230,7 +2230,7 @@ xRegistry-isdefault: <BOOLEAN>
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
 xRegistry-ancestor: <STRING>
@@ -2737,7 +2737,7 @@ xRegistry-isdefault: <BOOLEAN>
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
 xRegistry-ancestor: <STRING>
@@ -2854,7 +2854,7 @@ xRegistry-isdefault: <BOOLEAN>
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP> ?
 xRegistry-modifiedat: <TIMESTAMP> ?
 xRegistry-ancestor: <STRING> ?
@@ -2885,7 +2885,7 @@ xRegistry-isdefault: <BOOLEAN>
 xRegistry-description: <STRING> ?
 xRegistry-documentation: <URL> ?
 xRegistry-icon: <URL> ?
-xRegistry-labels-<KEY>: <STRING> *
+xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
 xRegistry-ancestor: <STRING>

--- a/core/model.md
+++ b/core/model.md
@@ -1,6 +1,6 @@
 # xRegistry Service Model - Version 1.0-rc2
 
-<!-- words: compat validatecompatibility validateformat -->
+<!-- words: compat validatecompatibility validateformat matchcase -->
 
 ## Abstract
 
@@ -81,6 +81,7 @@ The overall format of a model definition is as follows:
       "description": "<STRING>", ?
       "enum": [ <VALUE> * ], ?         # Array of scalars of type "<TYPE>"
       "strict": <BOOLEAN>, ?           # Just "enum" values or not. Default=true
+      "matchcase": <BOOLEAN>, ?        # Strings case-sensitive? Default=false
       "readonly": <BOOLEAN>, ?         # From client's POV. Default=false
       "immutable": <BOOLEAN>, ?        # Once set, can't change. Default=false
       "required": <BOOLEAN>, ?         # Default=false
@@ -308,6 +309,15 @@ The following describes the attributes of the Registry model:
   ([invalid_attribute](./spec.md#invalid_attribute)).
   This attribute has no impact when `enum` is absent or an empty array.
 - When not specified, the default value MUST be `true`.
+
+### `attributes.<STRING>.matchcase`
+- Type: Boolean.
+- OPTIONAL.
+- Indicates whether the `string` attribute's value MUST be compared with
+  a matching value in a case-sensitive way, or not.
+- This attribute MUST NOT be `true` if the owning attribute's `type` (or
+  `item.type` for non-scalars) is not `"string"`.
+- When not specified, the default value MUST be `false`.
 
 ### `attributes.<STRING>.readonly`
 - Type: Boolean.

--- a/core/model.md
+++ b/core/model.md
@@ -273,6 +273,7 @@ The following describes the attributes of the Registry model:
     defined for all map key names - see [Attributes and
     Extensions](./spec.md#attributes-and-extensions).
 - When not specified, the default value is `strict`.
+- The value of this attribute MUST be case-insensitive.
 - Implementations MAY define additional character sets, however, an attempt
   to define a model that uses an unknown character set name MUST generate an
   error ([model_error](./spec.md#model_error)). There is currently no
@@ -424,7 +425,7 @@ The following describes the attributes of the Registry model:
 - This map can be used to conditionally include additional
   attribute definitions based on the runtime value of the current attribute.
   If the string serialization of the runtime value of this attribute matches
-  the `ifvalues` key (case-sensitive), then the `siblingattributes` MUST be
+  the `ifvalues` key (case-insensitive), then the `siblingattributes` MUST be
   included in the model as siblings to this attribute.
 
   While the properties of a map will automatically prevent two entries
@@ -672,6 +673,7 @@ The following describes the attributes of the Registry model:
   Resource might change if its `defaultversionsticky` attribute is `false`.
 - When not specified, the default value MUST be `manual`.
 - Implementations MUST support at least `manual`.
+- The value of this attribute MUST be case-insensitive.
 - This specification defines the following `versionmode` algorithms:
   - `manual`
     - Newest Version: MUST be determined by finding all Versions that are

--- a/core/model.schema.json
+++ b/core/model.schema.json
@@ -308,6 +308,11 @@
           "default": true,
           "description": "Whether to restrict values to enum only"
         },
+        "matchcase": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether string value comparisons are case-sensitive"
+        },
         "readonly": {
           "type": "boolean",
           "default": false,

--- a/core/primer.md
+++ b/core/primer.md
@@ -429,8 +429,8 @@ variable or structure property names - they're usually just stored as
   will match what was used in the request (either explicitly or implicity).
   So GET resource?meta or GET group?inline both ask for metadata
 - xRegistry- headers: first "-" separates xRegistry from attribute name,
-  next "-" separates attribute name from key, any subsequent "-" is part
-  of the key name. E.g. xRegistry-labels-abc-def:xxx => labels["abc-def"]=xxx
+  next "." separates attribute name from key, any subsequent "." is part
+  of the key name. E.g. xRegistry-labels.abc.def:xxx => labels["abc.def"]=xxx
 - impact of "\*required" flags at multiple levels
 - why we don't use underscore in our property names, tho legal to do so
   - not all http proxies (e.g. nginx) pass them along by default

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -446,6 +446,13 @@
               "readonly": true,
               "required": true
             },
+            "labels": {
+              "name": "labels",
+              "type": "map",
+              "item": {
+                "type": "string"
+              }
+            },
             "createdat": {
               "name": "createdat",
               "type": "timestamp",

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -10,8 +10,9 @@
     "registryid": {
       "name": "registryid",
       "type": "string",
-      "immutable": true,
+      "matchcase": true,
       "readonly": true,
+      "immutable": true,
       "required": true
     },
     "self": {
@@ -138,6 +139,7 @@
         "dirid": {
           "name": "dirid",
           "type": "string",
+          "matchcase": true,
           "immutable": true,
           "required": true
         },
@@ -234,12 +236,14 @@
             "fileid": {
               "name": "fileid",
               "type": "string",
+              "matchcase": true,
               "immutable": true,
               "required": true
             },
             "versionid": {
               "name": "versionid",
               "type": "string",
+              "matchcase": true,
               "immutable": true,
               "required": true
             },
@@ -313,6 +317,7 @@
             "ancestor": {
               "name": "ancestor",
               "type": "string",
+              "matchcase": true,
               "required": true
             },
             "contenttype": {
@@ -341,6 +346,7 @@
             "fileid": {
               "name": "fileid",
               "type": "string",
+              "matchcase": true,
               "immutable": true,
               "required": true
             },
@@ -413,6 +419,7 @@
             "fileid": {
               "name": "fileid",
               "type": "string",
+              "matchcase": true,
               "immutable": true,
               "required": true
             },
@@ -506,6 +513,7 @@
             "defaultversionid": {
               "name": "defaultversionid",
               "type": "string",
+              "matchcase": true,
               "required": true
             },
             "defaultversionurl": {

--- a/core/spec.md
+++ b/core/spec.md
@@ -507,6 +507,8 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "hasdocument": <BOOLEAN>, ?   # Has separate document. Default=true
             "versionmode": "<STRING>", ?  # 'ancestor' processing algorithm
             "singleversionroot": <BOOLEAN>, ? # Default=false"
+            "validatecompatibility": <BOOLEAN>, ? # Enforce version compat
+            "validateformat": <BOOLEAN>, ?    # Enforce version format checks
             "typemap": <MAP>, ?               # contenttype mappings
             "attributes": { ... }, ?          # Version attributes/extensions
             "resourceattributes": { ... }, ?  # Resource attributes/extensions
@@ -2761,8 +2763,8 @@ and the following Meta-level attributes:
 
 - Constraints:
   - OPTIONAL.
-  - It MUST be a case-sensitive non-empty value from the Resource model's
-    enumeration range.
+  - If present, MUST be a case-insensitive non-empty value from the Resource
+    model's enumeration range.
   - When changing the value of this attribute, it MUST be applied to all
     Versions of the Resource, and an error
     ([compatibility_violation](#compatibility_violation)) MUST be generated

--- a/core/spec.md
+++ b/core/spec.md
@@ -424,12 +424,12 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
   "capabilities": {                     # Supported capabilities/options
     "apis": [ "/capabilities",? "/export",? "/model"? ],
     "flags": [                          # e.g. Query parameters
-      "binary",? "collections",? "doc",? "epoch",? "filter",?  "ignore".?
+      "binary",? "collections",? "doc",? "epoch",? "filter",?  "ignore",?
       "inline",? "setdefaultversionid",?  "sort",?  "specversion",?
       "<STRING>" *
     ],
     "ignore": [ "capabilities",? "defaultversionid",? "defaultversionsticky",?
-      "epoch",? "modelsource",? "readonly"? ],
+      "id",? "epoch",? "modelsource",? "readonly"? ],
     "mutable": [                        # What is mutable in the Registry
       "capabilities",? "entities",? "model",? "<STRING>"*
     ], ?
@@ -1729,6 +1729,7 @@ The JSON serialization of capabilities map MUST be of the form:
 {
   "apis": [ "<STRING>" * ], ?
   "flags": [ "<STRING>" * ], ?
+  "ignore": [ "<STRING>" * ], ?
   "mutable": [ "<STRING>" * ], ?
   "pagination": <BOOLEAN>, ?
   "shortself": <BOOLEAN>, ?
@@ -1815,7 +1816,22 @@ The following defines the specification-defined capabilities:
   are supported.
 - Examples:
   - `"flags": [ "filter", "inline" ]`    # Just these 2
-  - `"flags": [ "*" ]`                   # All supported flags, for update only
+  - `"flags": [ "*" ]`                   # All supported flags (requests only)
+
+#### `ignore`
+- Name: `ignore`
+- Type: Array of strings
+- Description: The list of supported [Ignore Flag](#ignore-flag) values.
+- Defined values:
+    `capabilities`, `defaultversionid`, `defaultversionsticky`, `id`, `epoch`,
+    `modelsource`, `readonly`.
+- When not specified, or an empty list, the `ignore` flag is not supported
+  and `ignore` MUST NOT appear in the `flags` capability.
+- When specified with a non-empty list, the `ignore` flag MUST appear in the
+ `flags` capability.
+- Examples:
+  - `"ignore": [ "epoch", "id" ]`        # Just these 2
+  - `"ignore": [ "*" ]`                  # All supported values (requests only)
 
 #### `mutable`
 - Name `mutable`
@@ -1955,10 +1971,10 @@ Where:
 - When `"type"` is `array`, `"item.type"` MUST be one of `boolean`, `string`,
   `integer`, `decimal`, `uinteger`, otherwise `"item"` MUST be absent.
 - `"enum"`, when specified, contains a list of zero or more `<VALUE>`s whose
-  type MUST match either `"type"` or `"item.type"` if `"item"` is `"array"`.
+  type MUST match either `"type"` or `"item.type"` if `"type"` is `"array"`.
   This indicates the list of allowable values for this capability.
 - `"min"` and `"max"`, when specified, MUST match the same type as either
-  `"type"` or `"item.type"` if `"item"` is `"array"`. These indicate the
+  `"type"` or `"item.type"` if `"type"` is `"array"`. These indicate the
   minimum or maximum (inclusive) value range of this capability. When not
   specified, there is no stated lower (or upper) limit. These MUST only be
   used when "type" is a numeric type.
@@ -1996,6 +2012,15 @@ in the serialization of its capabilities offering map.
     "type": "string",
     "enum": [ "binary", "collections", "doc", "epoch", "filter", "ignore",
       "inline", "setdefaultversionid", "sort", "specversion" ]
+  },
+  "ignore": {
+    "type": "string",
+    "enum": [ "capabilities", "defaultversionid", "defaultversionsticky",
+      "epoch", "modelsource", "readonly" ]
+  },
+  "mutable": {
+    "type": "string",
+    "enum": [ "
   },
   "pagination": {
     "type": "boolean",
@@ -3757,6 +3782,22 @@ message to ignore. This specification defines the following values:
 
   This value indicates that any `epoch` attribute included in the request MUST
   be ignored.
+
+- `id`
+
+  When this value is used then any `<SINGULAR>id` present in the root entity
+  MUST be ignored, and any validation to ensure it matches the targeted
+  entity's existing `<SINGULAR>id` value MUST NOT be performed.
+
+  This feature MUST only apply in cases where the request is targeted to a
+  single entity not a collection.
+
+  This features is design for cases where an entity is exported and then used
+  as input for another entity where that targeted entity needs to use a
+  different `<SINGULAR>id`, without needing to transform the exported data.
+
+  In cases where the target entity is a Version, then the flag MUST apply to
+  both the Resource's `<SINGULAR>id` and the `versionid`.
 
 - `modelsource`
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -507,8 +507,8 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "hasdocument": <BOOLEAN>, ?   # Has separate document. Default=true
             "versionmode": "<STRING>", ?  # 'ancestor' processing algorithm
             "singleversionroot": <BOOLEAN>, ? # Default=false"
-            "validatecompatibility": <BOOLEAN>, ? # Enforce version compat
-            "validateformat": <BOOLEAN>, ?    # Enforce version format checks
+            "validatecompatibility": <BOOLEAN>, ? # Check version compatibility
+            "validateformat": <BOOLEAN>, ?    # Check version format compliance
             "typemap": <MAP>, ?               # contenttype mappings
             "attributes": { ... }, ?          # Version attributes/extensions
             "resourceattributes": { ... }, ?  # Resource attributes/extensions
@@ -578,7 +578,8 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "shortself": "<URL>", ?
             "xid": "<XID>",
             "xref": "<XID>", ?                     # xid of linked Resource
-            "epoch": <UINTEGER>,                   # Resource's epoch
+            "epoch": <UINTEGER>,                   # Resource's
+            "labels": { "<STRING>": "<STRING>" * }, ? # Resource's
             "createdat": "<TIMESTAMP>",            # Resource's
             "modifiedat": "<TIMESTAMP>",           # Resource's
             "readonly": <BOOLEAN>,                 # Default=false
@@ -609,7 +610,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
               "description": "<STRING>", ?
               "documentation": "<URL>", ?
               "icon": "<URL>", ?
-              "labels": { "<STRING>": "<STRING>" * }, ?
+              "labels": { "<STRING>": "<STRING>" * }, ? # Version's labels
               "createdat": "<TIMESTAMP>",
               "modifiedat": "<TIMESTAMP>",
               "ancestor": "<STRING>",              # Ancestor's versionid
@@ -2650,6 +2651,7 @@ The serialization of the Meta entity MUST adhere to this form:
   "xid": "<XID>",                           # Relative URI to this "meta"
   "xref": "<XID>", ?                        # Ptr to linked Resource
   "epoch": <UINTEGER>,                      # Resource's epoch
+  "labels": { "<STRING>": "<STRING>" * }, ?
   "createdat": "<TIMESTAMP>",               # Resource's
   "modifiedat": "<TIMESTAMP>",              # Resource's
   "readonly": <BOOLEAN>,                    # Default=false
@@ -2681,6 +2683,7 @@ The Meta entity includes the following
   not of one particular Version. And, it adheres to the normal `epoch`
   processing rules - its value is only updated when the Meta attributes
   are updated, but also when a Version is added/removed.
+- [`labels`](#labels-attribute) - OPTIONAL in API and document views..
 - [`createdat`](#createdat-attribute) - REQUIRED in API and document views.
   OPTIONAL in requests. Creation date of the Resource/Meta entity.
 - [`modifiedat`](#modifiedat-attribute) - REQUIRED in API and document views.
@@ -3481,6 +3484,7 @@ the following:
     "xref": "<XID>" ?
     # The following attributes are absent if 'xref' is set
     "epoch": <UINTEGER>,
+    "labels": { "<STRING>": "<STRING>" * }, ?
     "createdat": "<TIMESTAMP>",
     "modifiedat": "<TIMESTAMP>",
     "ancestor": "<STRING>",

--- a/core/spec.md
+++ b/core/spec.md
@@ -1,6 +1,6 @@
 # xRegistry Service - Version 1.0-rc2
 
-<!-- words: validatecompatibility validateformat -->
+<!-- words: validatecompatibility validateformat matchcase -->
 
 ## Abstract
 
@@ -456,6 +456,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
         "description": "<STRING>", ?
         "enum": [ <VALUE> * ], ?        # Array of scalars of type `"type"`
         "strict": <BOOLEAN>, ?          # Just "enum" values? Default=true
+        "matchcase": <BOOLEAN>, ?       # Strings case-sensitive? Def=false
         "readonly": <BOOLEAN>, ?        # From client's POV. Default=false
         "immutable": <BOOLEAN>, ?       # Once set, can't change. Default=false
         "required": <BOOLEAN>, ?        # Default=false

--- a/core/templates/xregistry_openapi_template.json
+++ b/core/templates/xregistry_openapi_template.json
@@ -1901,6 +1901,14 @@
                         "minimum": 0,
                         "description": "The epoch value for the meta sub-object."
                     },
+                    "labels": {
+                        "type": "object",
+                        "description": "A map of label key/value pairs.",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "nullable": true
+                    },
                     "createdat": {
                         "type": "string",
                         "format": "date-time",

--- a/core/templates/xregistry_openapi_template.json
+++ b/core/templates/xregistry_openapi_template.json
@@ -1730,6 +1730,15 @@
                         "default": [],
                         "description": "List of supported flags (query parameters)."
                     },
+                    "ignore": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "description": "An ignore flag value. Values are case insensitive and may include extension values."
+                        },
+                        "default": [],
+                        "description": "List of supported ignore flag values."
+                    },
                     "mutable": {
                         "type": "array",
                         "items": {

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -2867,6 +2867,15 @@
             "default": [],
             "description": "List of supported flags (query parameters)."
           },
+          "ignore": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "An ignore flag value. Values are case insensitive and may include extension values."
+            },
+            "default": [],
+            "description": "List of supported ignore flag values."
+          },
           "mutable": {
             "type": "array",
             "items": {

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -3084,6 +3084,14 @@
             "minimum": 0,
             "description": "The epoch value for the meta sub-object."
           },
+          "labels": {
+            "type": "object",
+            "description": "A map of label key/value pairs.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "createdat": {
             "type": "string",
             "format": "date-time",

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -1997,6 +1997,14 @@
             "minimum": 0,
             "description": "The epoch value for the meta sub-object."
           },
+          "labels": {
+            "type": "object",
+            "description": "A map of label key/value pairs.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "createdat": {
             "type": "string",
             "format": "date-time",

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -1798,6 +1798,15 @@
             "default": [],
             "description": "List of supported flags (query parameters)."
           },
+          "ignore": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "An ignore flag value. Values are case insensitive and may include extension values."
+            },
+            "default": [],
+            "description": "List of supported ignore flag values."
+          },
           "mutable": {
             "type": "array",
             "items": {

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -1997,6 +1997,14 @@
             "minimum": 0,
             "description": "The epoch value for the meta sub-object."
           },
+          "labels": {
+            "type": "object",
+            "description": "A map of label key/value pairs.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "createdat": {
             "type": "string",
             "format": "date-time",

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -1798,6 +1798,15 @@
             "default": [],
             "description": "List of supported flags (query parameters)."
           },
+          "ignore": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "An ignore flag value. Values are case insensitive and may include extension values."
+            },
+            "default": [],
+            "description": "List of supported ignore flag values."
+          },
           "mutable": {
             "type": "array",
             "items": {

--- a/tools/test-openapi.json
+++ b/tools/test-openapi.json
@@ -1798,6 +1798,15 @@
             "default": [],
             "description": "List of supported flags (query parameters)."
           },
+          "ignore": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "An ignore flag value. Values are case insensitive and may include extension values."
+            },
+            "default": [],
+            "description": "List of supported ignore flag values."
+          },
           "mutable": {
             "type": "array",
             "items": {

--- a/tools/test-openapi.json
+++ b/tools/test-openapi.json
@@ -2006,6 +2006,14 @@
             "minimum": 0,
             "description": "The epoch value for the meta sub-object."
           },
+          "labels": {
+            "type": "object",
+            "description": "A map of label key/value pairs.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
           "createdat": {
             "type": "string",
             "format": "date-time",


### PR DESCRIPTION
- replace "-" with "." in xRegistry- HTTP headers. e.g. xRegistry-labels-foo: bar -> xRegistry-labels.foo: bar
- misc clean-up
- make meta.compatibility case-insensitive
- add support for 'labels' in meta
- support ?ignore=id
- make more fields case-insensitive (ifvalues values, namecharset, versionmode)
- add 'matchcase' to string attribute definitions in the model

fixes: #443 #444 #439 #446 