### PR TITLE
Week of Apr 6

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -813,6 +813,10 @@
                       "doc": "Time of the object modification"
                     },
                     {
+                      "type": "string",
+                      "name": "format"
+                    },
+                    {
                       "name": "Extensions",
                       "type": {
                         "type": "map",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -2008,6 +2008,9 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
+          },
+          "format": {
+            "type": "string"
           }
         },
         "oneOf": [
@@ -2053,6 +2056,9 @@
               "schemaurl"
             ]
           }
+        ],
+        "required": [
+          "format"
         ]
       },
       "schema": {

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -5172,6 +5172,9 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
+          },
+          "format": {
+            "type": "string"
           }
         },
         "oneOf": [
@@ -5217,6 +5220,9 @@
               "schemaurl"
             ]
           }
+        ],
+        "required": [
+          "format"
         ]
       },
       "schema": {

--- a/core/model.md
+++ b/core/model.md
@@ -2,6 +2,7 @@
 
 <!-- words: compat validatecompatibility validateformat strictvalidation -->
 <!-- words: matchcase compatibilityvalidated formatvalidated -->
+<!-- words: consistentformat validators -->
 
 ## Abstract
 
@@ -134,9 +135,10 @@ The overall format of a model definition is as follows:
           "hasdocument": <BOOLEAN>, ?       # Has separate document. Default=true
           "versionmode": "<STRING>", ?      # 'ancestor' processing algorithm
           "singleversionroot": <BOOLEAN>, ? # Enforce single root. Default=false
-          "validatecompatibility": <BOOLEAN>, ? # Do Version compat checks. Default=true
-          "validateformat": <BOOLEAN>, ?    # Do Version format checks. Default=true
+          "validateformat": <BOOLEAN>, ?    # Do Version format checks. Default=false
+          "validatecompatibility": <BOOLEAN>, ? # Do Version compat checks. Default=false
           "strictvalidation": <BOOLEAN>, ?  # Block unknown format/compat. Default=false
+          "consistentformat": <BOOLEAN>, ?  # Same format for all Vers. Default=false
           "typemap": <MAP>, ?               # ContentType mappings
           "attributes": { ... }, ?          # Version attributes/extensions
           "resourceattributes": { ... }, ?  # Resource attributes/extensions
@@ -777,18 +779,49 @@ The following describes the attributes of the Registry model:
   Enforcement](./primer.md#singleversionroot-policy-enforcement) section of
   the Primer for more information.
 
+### `groups.<STRING>.resources.<STRING>.validateformat`
+- Type: Boolean (`true` or `false`, case-sensitive).
+- OPTIONAL.
+- Indicated whether the server MUST validate that all Versions of this
+  Resource type adhere to the rules as defined by the Version's `format`
+  value.
+- When not specified, the default value MUST be `false`.
+- The following rules clarify the "format" validation logic:
+  - When the validator is checking the Version's domain-specific document,
+    it is a format-specific decision as to whether an empty document is
+    valid or not.
+  - Validators MUST treat a Resource with its `hasdocument` model attribute
+    set to `false`, a Version with no domain-specific document even though
+    `hasdocument` is `true`, and a Version with an empty domain-specific
+    document as 3 different variants of "the domain-specific document is
+    empty (zero bytes in length)".
+  - When `hasdocument` is `true`, and a Version uses the `<RESOURCE>url`
+    attribute to reference the document in an external datastore, the
+    resulting [`formatvalidated`](spec.md#format-attribute) attribute on the
+    Version MUST be `"false"`.
+- A value of `true` indicates that the server MUST generate an error
+  ([format_violation](spec.md#format_violation)) if any Version of a Resource
+  instance of this Resource type does not adhere to the `format` value of that
+  Version. An absent `format` value on a Version MUST be treated as a request
+  to disable both "format" and "compatibility" verification logic for that
+  Version.
+- A value of `false` indicates that the server MUST NOT perform any `format`
+  checking for Versions of Resources of this Resource type.
+
 ### `groups.<STRING>.resources.<STRING>.validatecompatibility`
 - Type: Boolean (`true` or `false`, case-sensitive).
 - OPTIONAL.
 - Indicated whether the server MUST validate that all Versions of this
   Resource type adhere to its owning Resource's `meta.compatibility` value.
-- When not specified, the default value MUST be `true`.
+- When not specified, the default value MUST be `false`.
 - A value of `true` indicates that the server MUST generate an error
   [compatibility_violation](spec.md#compatibility_violation)) if any Version
   of a Resource instance of this Resource type does not adhere to the rules of
   the `meta.compatibility` value for that Resource's `format` value.
   See [`strictvalidation`](#groupsstringresourcesstringstrictvalidation) for
   exceptions to this requirement.
+- When a Version does not have a `format` value then compatibility verification
+  MUST NOT be done.
 - When this model attribute is `true` then its sibling `validateformat`
   attribute MUST also be `true`.
 - A value of `false` indicates that the server MUST NOT perform any
@@ -797,23 +830,6 @@ The following describes the attributes of the Registry model:
   the external entity that has performed the validation, a `label` MAY be
   added to the Resource's model or to the Resource instance itself with this
   information.
-
-### `groups.<STRING>.resources.<STRING>.validateformat`
-- Type: Boolean (`true` or `false`, case-sensitive).
-- OPTIONAL.
-- Indicated whether the server MUST validate that all Versions of this
-  Resource type adhere to the rules as defined by the Version's `format`
-  value.
-- When not specified, the default value MUST be `true`.
-- A value of `true` indicates that the server MUST generate an error
-  ([format_violation](spec.md#format_violation))if any Version of a Resource
-  instance of this Resource type does not adhere to the `format` value of that
-  Version. An absent `format` value MUST be treated as an error
-  ([format_missing](spec.md#format_missing)).
-  See [`strictvalidation`](#groupsstringresourcesstringstrictvalidation) for
-  exceptions to this requirement.
-- A value of `false` indicates that the server MUST NOT perform any `format`
-  checking for Versions of Resources of this Resource type.
 
 ### `groups.<STRING>.resources.<STRING>.strictvalidation`
 - Type: Boolean (`true` or `false`, case-sensitive)
@@ -825,9 +841,6 @@ The following describes the attributes of the Registry model:
   ignored by the server.
 - When not specified, the default value MUST be `false`.
 - A value of `true` indicates that:
-  - The `format` validation logic MUST generate an error
-    ([format_missing](spec.md#format_missing)) if the Version's `format` value
-    is absent.
   - The `format` validation logic MUST generate an error
     ([format_violation](spec.md#format_violation)) if the Version's `format`
     is an unsupported value.
@@ -843,6 +856,23 @@ The following describes the attributes of the Registry model:
     `false`.
   - If the Resource's `meta.compatibility` value is unsupported, then
     the Version's `compatibilityvalidated` attribute MUST be set to `false`.
+
+### `groups.<STRING>.resources.<STRING>.consistentformat`
+- Type: Boolean (`true` or `false`, case-sensitive)
+- OPTIONAL
+- Indicates whether all Versions of a Resource of this type are mandated to
+  have the same [`format`](spec.md#format-attribute) value.
+- This attribute's semantics apply regardless of the values of `validateformat`
+  and `validatecompatibility`.
+- When not specified, the default value MUST be `false`.
+- A value of `true` indicates that:
+  - The `format` attribute of all Versions of a Resource of this type MUST
+    have the same case-insensitive value (including the case of `format` being
+    an empty string). If a Version differs then an error
+    ([format_inconsistent](spec.md#format_inconsistent)) MUST be generated.
+- A value of `false` indicates that:
+  - The server MUST NOT check for a consistent (same) `format` value across
+    the Versions of a Resource of this type.
 
 ### `groups.<STRING>.resources.<STRING>.typemap`
 - Type: Map where the keys and values MUST be non-empty strings. The key

--- a/core/primer.md
+++ b/core/primer.md
@@ -1,6 +1,7 @@
 # xRegistry Primer
 
-<!-- words: validatecompatibility validateformat -->
+<!-- words: validatecompatibility validateformat strickvalidation -->
+<!-- words: strictvalidation -->
 
 <!-- no verify-specs -->
 
@@ -1022,3 +1023,17 @@ new APIs), care should be taken to limit the possibility of overlapping with
 any future xRegistry work. While it is impossible to predict the future, some
 steps can be taken to lessen the concern. For example, using domain, or
 company, specific terms when naming things.
+
+## Validation
+
+There is one scenario worth pointing out with respect to `format` and
+`compatibility` validation. If a Resource's model definition has both the
+`validateformat` and `strictvalidation` aspects set to `true`, and the
+Registry's `capabilities` does not define any `format` values, then any
+attempt to create a Resource of that Resource type with a non-empty `format`
+value will always be rejected with an "unknown format" type of error.
+
+This is being called out because for light-weight server implementations that
+do not support validation checks, a user might define a Resource type with
+those aspects enabled without realizing they're defining a potentially
+unusable Resource type - if clients use the `format` attribute.

--- a/core/spec.md
+++ b/core/spec.md
@@ -2,6 +2,7 @@
 
 <!-- words: validatecompatibility validateformat strictvalidation matchcase -->
 <!-- words: compat formatvalidated compatibilityvalidated -->
+<!-- words: consistentformat -->
 
 ## Abstract
 
@@ -513,9 +514,10 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "hasdocument": <BOOLEAN>, ?   # Has separate document. Default=true
             "versionmode": "<STRING>", ?  # 'ancestor' processing algorithm
             "singleversionroot": <BOOLEAN>, ? # Default=false"
-            "validatecompatibility": <BOOLEAN>, ? # Check version compatibility. Default=true
-            "validateformat": <BOOLEAN>, ?    # Check version format compliance. Default=true
+            "validateformat": <BOOLEAN>, ?    # Check version format compliance. Default=false
+            "validatecompatibility": <BOOLEAN>, ? # Check version compatibility. Default=false
             "strictvalidation": <BOOLEAN>, ?  # Block unknown format/compat. Default=false
+            "consistentformat": <BOOLEAN>, ?  # Same format for all Vers. Default=false
             "typemap": <MAP>, ?               # contenttype mappings
             "attributes": { ... }, ?          # Version attributes/extensions
             "resourceattributes": { ... }, ?  # Resource attributes/extensions
@@ -2481,7 +2483,9 @@ The overall processing of the request message is as follows:
     [`versionmode`](./model.md#groupsstringresourcesstringversionmode) value.
 4.  Process the `meta` sub-object, if present.
 5.  Update [`meta.defaultversionid`](#defaultversionid-attribute) as needed.
-6.  Enforce the [Version format checks](#format-attribute).
+6.  Enforce the [Version format checks](#format-attribute). Including the
+    enforcement of the Resource model's `consistentformat` aspect if set to
+    `true`.
 7.  Enforce the [Version compatibility checks](#compatibility-attribute).
 8.  Enforce the [Resource `maxversions`
     constraints](./model.md#groupsstringresourcesstringmaxversions). Note that
@@ -3187,10 +3191,8 @@ and the following Version-level attributes:
   [Message definitions](../message/spec.md).
 
   Managers of the xRegistry instance MAY enforce validation of the data within
-  the Registry by modifying the model to make this a mandatory attribute, by
-  defining a default value, or by setting the Resource's
-  [`validateformat`](./model.md#groupsstringresourcesstringvalidateformat)
-  model attribute to `true`.
+  the Registry by modifying the model to make this a mandatory attribute or
+  by defining a default value.
 
 - Constraints:
   - OPTIONAL.
@@ -3199,17 +3201,17 @@ and the following Version-level attributes:
     the name of the format and `<VERSION>` is the version of the format used
     by this Version.
   - RECOMMENDED that the same `<NAME>` be used for all Versions of a Resource.
-  - MUST be present if the Resource's
-   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)
-   model attribute is `true` and either
-   [`validateformat`](model.md#groupsstringresourcesstringvalidateformat) or
-   [`validatecompatibility`](model.md#groupsstringresourcesstringvalidatecompatibility)
-   model attributes are also `true`.
+  - When not present, `format` validation MUST NOT be performed for that
+    Version irrespective of the
+    [`validateformat`](model.md#groupsstringresourcesstringvalidateformat)
+    attribute's value.
 
 Note: an attempt to set this attribute to a value that differs from the other
 Version's values could result in the server rejecting the request due to
 the [`compatibility`](#compatibility-attribute) conformance checks, if
-`validatecompatibility` model attribute is `true`.
+`validatecompatibility` model attribute is `true`. See
+[`consistentformat`](model.md#groupsstringresourcesstringconsistentformat)
+for additional information.
 
 - Examples:
   - `JsonSchema/draft-07`
@@ -3218,24 +3220,50 @@ the [`compatibility`](#compatibility-attribute) conformance checks, if
   - `Avro/1.9`
 
 #### `formatvalidated` Attribute
-- Type: Boolean
+- Type: String
 - Description: When
   [`format` validation](./model.md#groupsstringresourcesstringvalidateformat)
   is enabled, this attribute will indicate whether or not the server has
-  validated that the Version conforms to the rules defined by its `format`
-  attribute's value.
+  attempted to validated that the Version conforms to the rules defined by
+  its `format` attribute's value.
 
-  A value of `true` indicates that the server has validated the Version and
-  it adheres to those rules.
+  The value MUST be a non-empty string in one of two forms:
+  - `"true"`
+  - `"false, <REASON>"`
 
-  A value of `false` indicates that the server has not validated the Version
-  due to the `format` attribute value not being supported. Note that this
-  attribute MUST only ever be `false` when the Resource's
+  A value of `"true"` indicates that the server has validated the Version and
+  it adheres to the `format` attribute's rules.
+
+  A value that starts with `false` indicates that the server did not attempt
+  to validated the Version. This can happen when
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
-  model attribute is set to `false`. If
-  [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation) is
-  `true`, then adding the unsupported `format` value would have generated an
-  error ([format_violation](spec.md#format_violation)) instead.
+  is set to `false` and:
+  - The `format` attribute value is not supported by the server.
+  - The Version uses the `<RESOURCE>url` attribute to reference a
+    domain-specific document stored outside of the Registry. In this case
+    the server implementation doesn't have access to the document, and
+    therefore can not verify it, nor does this specification mandate that it
+    be able to access that URL.
+
+ When
+ [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
+ is `true`, the above conditions MUST generate an error
+ ([format_unknown](#format_unknown) or [format_external](#format_external)) and
+ reject the update request instead.
+
+  When `"false"`, this value MUST include some additional text (the `<REASON>`)
+  indicating why the server was unable to attempt validation of the Version.
+  Additionally, when `"false"`, if `compatibility` validation is enabled,
+  the Version's
+  [`compatibilityvalidated`](#compatibility-attribute) attribute MUST also be
+  `"false"`.
+
+  Note that `"false"` MUST NOT be used for validation failure. In those cases
+  the write operation MUST generate an error
+  ([format_violation](#format_violation) and reject the request regardless
+  of the value of the
+  [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
+  model aspect.
 
   Due to this attribute being server managed, and influenced by the state of
   other Versions, as its value changes the Version itself MUST NOT be marked as
@@ -3244,33 +3272,62 @@ the [`compatibility`](#compatibility-attribute) conformance checks, if
 
 - Constraints:
   - OPTIONAL
+  - If present, MUST be non-empty.
   - MUST be a read-only attribute.
   - MUST be present if the Resource model's `validateformat` attribute is
     `true` and the Version's `format` attribute is present.
   - MUST NOT be present if the Resource model's `validateformat` attribute is
     `false` or the Version's `format` attribute is absent.
 
+- Examples:
+  - `"true"`
+  - `"false, unknown format"`
+
 #### `compatibilityvalidated` Attribute
-- Type: Boolean
+- Type: String
 - Description: When [`compatibility`
   validation](./model.md#groupsstringresourcesstringvalidateformat)
   is enabled, this attribute will indicate whether or not the server has
   validated that the Version conforms to the rules defined by its Resource's
   `meta.compatibility` attribute's value.
 
-  A value of `true` indicates that the server has validated the Version and
-  it adheres to those rules.
+  The value MUST be a non-empty string in one of two forms:
+  - `"true"`
+  - `"false, <REASON>"`
 
-  A value of `false` indicates that the server has not validated the Version
-  due to the `format` or `meta.compatibility` attribute values not being
-  supported. Note that this attribute MUST only ever be `false` when the
-  Resource's
-  [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)
-  model attribute is set to `false`. If
-  [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)
-  is `true`, then adding the unsupported `format` or `compatibility` values
-  would have generated an error ([format_violation](spec.md#format_violation)
-  or [compatibility_violation](spec.md#format_violation)) error instead.
+  A value of `"true"` indicates that the server has validated the Version and
+  it adheres to the `meta.compatibility` attribute's rules.
+
+  A value that starts with `"false"` indicates that the server did not attempt
+  to validate the Version. This can happen when
+  [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
+  is set to `false` and:
+  - The `formatvalidated` attribute is `"false"`.
+  - The `format` or `meta.compatibility` attributes not supported by the
+    server.
+  - The Version uses the `<RESOURCE>url` attribute to reference a
+    domain-specific document stored outside of the Registry. In this case
+    the server implementation doesn't have access to the document, and
+    therefore can not verify it, nor does this specification mandate that it
+    be able to access that URL.
+
+  When
+  [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
+  is `true`, the above conditions MUST generate an error
+  ([format_unknown](#format_unknown),
+  [compatibility_unknown](#compatibility_unknown) or
+  [format_external](#format_external)) and
+  reject the update request instead.
+
+  When `"false"`, this value MUST include some additional text (the `<REASON>`)
+  indicating why the server was unable to attempt validation of the Version.
+
+  Note that `"false"` MUST NOT be used for validation failure. In those cases
+  the write operation MUST generate an error
+  ([compatibility_violation](#compatibility_violation) and reject the request
+  regardless of the value of the
+  [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
+  model aspect.
 
   Due to this attribute being server managed, and influenced by the state of
   other Versions, as its value changes the Version itself MUST NOT be marked as
@@ -3279,6 +3336,7 @@ the [`compatibility`](#compatibility-attribute) conformance checks, if
 
 - Constraints:
   - OPTIONAL
+  - If present, MUST be non-empty.
   - MUST be a read-only attribute.
   - MUST be present if the Resource model's `validatecompatibility` attribute
     is `true`, the Version's `format` value is present, and the Resource's
@@ -4490,15 +4548,24 @@ field is just a substitution value and MUST NOT be empty.
 * Args:
   - `field`: The capability field being modified.
 
+### compatibility_unknown
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#compatibility_unknown`
+* Code: `400 Bad Request`
+* Subject: `<resource_xid>`
+* Title: `The compatibility value (<compat>) on Resource "<subject>" is not supported.`
+* Args:
+  - `compat`: The Resource's `meta.compatibility` value.
+
 ### compatibility_violation
 
 * Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#compatibility_violation`
 * Code: `400 Bad Request`
 * Subject: `<resource_xid>`
-* Title: `The request would cause one or more Versions of "<subject>" to violate its compatibility rule (<value>).`
+* Title: `The request would cause one or more Versions of "<subject>" to violate its compatibility rule (<compat>).`
 * Detail: Suggestion: list of `versionid` values that would be in violation.
 * Args:
-  - `value`: The Resource's `meta.compatibility` value.
+  - `compat`: The Resource's `meta.compatibility` value.
 
 ### data_retrieval_error
 
@@ -4517,12 +4584,28 @@ field is just a substitution value and MUST NOT be empty.
 * Args:
   - `name`: The name of the attribute in question.
 
-### format_missing
+### format_external
 
-* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_missing`
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_external`
+* Code: `400 Bad Request`
+* Subject: `<version_xid>`
+* Title: `Version "<subject>" references a document stored outside of the Registry, therefore no validation was performed.`
+
+### format_inconsistent
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_inconsistent`
 * Code: `400 Bad Request`
 * Subject: `<resource_xid>`
-* Title: `Version "<subject>" needs to have a "format" value due to its owning Resource model's "validateformat" being set.`
+* Title: `One or more Versions of Resource "<subject>" do not have the same "format" value as mandated by their owning Resource model's "consistentformat" attribute being set.`
+
+### format_unknown
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#format_unknown`
+* Code: `400 Bad Request`
+* Subject: `<version_xid>`
+* Title: `Version "<subject>" has a "format" value (<format>) that it not supported.`
+* Args:
+  - `format`: The Version's `format` value.
 
 ### format_violation
 

--- a/schema/model.json
+++ b/schema/model.json
@@ -18,8 +18,15 @@
           "singular": "schema",
           "modelversion": "1.0-rc2",
           "modelcompatiblewith": "https://xregistry.io/xreg/domains/schema/specs/model.json",
-
+          "validateformat": true,
+          "validatecompatibility": true,
+          "strictvalidation": false,
+          "consistentformat": true,
           "attributes": {
+            "format": {
+              "type": "string",
+              "required": true
+            },
             "*": {
               "name": "*",
               "type": "any"

--- a/schema/schemas/document-schema.avsc
+++ b/schema/schemas/document-schema.avsc
@@ -235,6 +235,10 @@
                       "doc": "Time of the object modification"
                     },
                     {
+                      "type": "string",
+                      "name": "format"
+                    },
+                    {
                       "name": "Extensions",
                       "type": {
                         "type": "map",

--- a/schema/schemas/document-schema.json
+++ b/schema/schemas/document-schema.json
@@ -62,6 +62,9 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
+          },
+          "format": {
+            "type": "string"
           }
         },
         "oneOf": [
@@ -107,6 +110,9 @@
               "schemaurl"
             ]
           }
+        ],
+        "required": [
+          "format"
         ]
       },
       "schema": {

--- a/schema/schemas/openapi.json
+++ b/schema/schemas/openapi.json
@@ -2112,6 +2112,9 @@
             "type": "string",
             "format": "date-time",
             "description": "Time of the object modification"
+          },
+          "format": {
+            "type": "string"
           }
         },
         "oneOf": [
@@ -2157,6 +2160,9 @@
               "schemaurl"
             ]
           }
+        ],
+        "required": [
+          "format"
         ]
       },
       "schema": {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -42,9 +42,14 @@ links: loadpython
 models:
 	@# Note this will use a local 'xr' if available so that local build/test
 	@# of 'xr' can be done
-	(which xr && xr model verify */model.json -v) || \
-	(docker run -t -v $$PWD:/xreg -w /xreg --entrypoint /bin/sh \
-		ghcr.io/xregistry/xr -c "/xr model verify */model.json -v")
+	if which xr ; then \
+	  echo Using local xr ; \
+	  xr model verify */model.json -v ; \
+	else \
+	  echo Using docker ghcr.io/xregistry/xr ; \
+	  docker run -t -v $$PWD:/xreg -w /xreg --entrypoint /bin/sh \
+		ghcr.io/xregistry/xr -c "/xr model verify */model.json -v" ; \
+	fi
 	@echo
 
 makeschema: loadpython


### PR DESCRIPTION
- add 'consistentformat' to Resource model
- make the default value for the validation flags 'false'
- make schema registry be true/strict wrt 3 format/compat flags (not strict)

Fixes #453 