### PR TITLE
Week of Apr 20

### DIFF
--- a/core/http.md
+++ b/core/http.md
@@ -1372,6 +1372,10 @@ The processing of this API is defined in the [Creating or Updating
 Entities](#creating-or-updating-entities) section - see the discussion of the
 `POST <PATH-TO-ENTITY>` variant.
 
+A request that isn't a map of Resource types (e.g. it contains other Group
+level attributes) MUST generate an error
+([resources_only](./spec.md#resources_only)).
+
 The request MUST be of the form:
 
 ```yaml

--- a/core/model.md
+++ b/core/model.md
@@ -877,7 +877,7 @@ The following describes the attributes of the Registry model:
 ### `groups.<STRING>.resources.<STRING>.typemap`
 - Type: Map where the keys and values MUST be non-empty strings. The key
   MAY include at most one `*` to act as a wildcard to mean zero or more
-  instance of any character at that position in the string - similar to a
+  instances of any character at that position in the string - similar to a
   `.*` in a regular expression. The key MUST be a case-insensitive string.
 - OPTIONAL.
 - When a Resource's metadata is serialized in a response and the

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -328,6 +328,22 @@
               "name": "format",
               "type": "string"
             },
+            "formatvalidated": {
+              "name": "formatvalidated",
+              "type": "boolean"
+            },
+            "formatvalidatedreason": {
+              "name": "formatvalidatedreason",
+              "type": "string"
+            },
+            "compatibilityvalidated": {
+              "name": "compatibilityvalidated",
+              "type": "boolean"
+            },
+            "compatibilityvalidatedreason": {
+              "name": "compatibilityvalidatedreason",
+              "type": "string"
+            },
 
             "fileurl": {
               "name": "fileurl",
@@ -479,10 +495,7 @@
             },
             "compatibility": {
               "name": "compatibility",
-              "type": "string",
-              "enum": [ "backward", "backward_transitive", "forward",
-                        "forward_transitive", "full", "full_transitive" ],
-              "strict": true
+              "type": "string"
             },
             "deprecated": {
               "name": "deprecated",

--- a/core/spec.md
+++ b/core/spec.md
@@ -947,6 +947,11 @@ following rules:
 - Unless otherwise stated, requests to update read-only attributes MUST be
   silently ignored by servers, even if the contents of those attributes are
   invalid.
+- <a id="read-only-changed"></a>Unless otherwise stated, server managed changes
+  to read-only attributes MUST NOT be treated the same as user initiated
+  changes to non-read-only attributes with respect to updating attributes such
+  as `modifiedat` and `epoch`. In other words, as these read-only attributes
+  are changed, the entity MUST NOT be considered "updated".
 
 #### Extensions
 
@@ -1204,7 +1209,7 @@ of the existing entity. Then the existing entity would be deleted.
 
 - Constraints:
   - REQUIRED.
-  - MUST be a read-only attribute.
+  - MUST be a [read-only](#read-only-changed) attribute.
   - MUST be an unsigned integer equal to or greater than zero.
   - MUST increase in value each time the entity is updated.
 
@@ -1691,7 +1696,7 @@ and the following Registry-level attributes:
     [Inline Flag](#inline-flag).
   - MUST be included in API and document views if requested via the
     [Inline Flag](#inline-flag).
-  - MUST be a read-only attribute.
+  - MUST be a [read-only](#read-only-changed) attribute.
 
 #### `modelsource` Attribute
 - Type: [Registry Model](./model.md#registry-model).
@@ -2855,7 +2860,7 @@ and the following Meta-level attributes:
 
 - Constraints:
   - REQUIRED.
-  - SHOULD be a read-only attribute.
+  - SHOULD be a [read-only](#read-only-changed) attribute.
   - When not specified, the default value MUST be `false`.
   - It MUST be a case-sensitive `true` or `false`.
   - A request to update a read-only Resource SHOULD generate an error
@@ -3123,11 +3128,7 @@ and the following Version-level attributes:
 #### `isdefault` Attribute
 - Type: Boolean
 - Description: Indicates whether this Version is the "default" Version of the
-  owning Resource. This value is different from other attributes in that it
-  might often be a calculated value rather than persisted in a datastore.
-  Thus, when its value changes due to the default Version of a Resource
-  changing, the Version itself does not change - meaning attributes such as
-  `modifiedat` remains unchanged.
+  owning Resource.
 
   See [Creating or Updating Resources and
   Versions](#creating-or-updating-resources-and-versions) for additional
@@ -3135,7 +3136,7 @@ and the following Version-level attributes:
 
 - Constraints:
   - REQUIRED.
-  - MUST be a read-only attribute.
+  - MUST be a [read-only](#read-only-changed) attribute.
   - When not specified, the default value MUST be `false`.
   - When specified, MUST be either `true` or `false`, case-sensitive.
 
@@ -3239,7 +3240,7 @@ for additional information.
 - Description: When
   [`format` validation](./model.md#groupsstringresourcesstringvalidateformat)
   is enabled, this attribute will indicate whether or not the server has
-  attempted to validated that the Version conforms to the rules defined by
+  attempted to validate that the Version conforms to the rules defined by
   its `format` attribute's value.
 
   A value of `true` indicates that the server has validated the Version and
@@ -3247,7 +3248,7 @@ for additional information.
   [`formatvalidatedreason`](#formatvalidatedreason-attribute) MUST NOT be
   present.
 
-  A value of `false` indicates that the server did not attempt to validated
+  A value of `false` indicates that the server did not attempt to validate
   the Version. This can happen when
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
   is set to `false` and:
@@ -3265,7 +3266,7 @@ for additional information.
  reject the update request instead.
 
   When `false`, the
-  [`formatvalidatedreason`](#formatvalidatedreason-attribute) MUST attribute
+  [`formatvalidatedreason`](#formatvalidatedreason-attribute)
   MUST be present with an explanation as to why the server was unable to
   attempt validation of the Version. Additionally, when `false`, if
   `compatibility` validation is enabled, the Version's
@@ -3279,15 +3280,10 @@ for additional information.
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
   model aspect.
 
-  Due to this attribute being server managed, and influenced by the state of
-  other Versions, as its value changes the Version itself MUST NOT be marked as
-  changed - meaning, attributes such as `modifiedat` and `epoch` remain
-  unchanged.
-
 - Constraints:
   - OPTIONAL
   - When specified, MUST be either `true` or `false`, case-sensitive.
-  - MUST be a read-only attribute.
+  - MUST be a [read-only](#read-only-changed) attribute.
   - MUST be present if the Resource model's `validateformat` attribute is
     `true` and the Version's `format` attribute is present.
   - MUST NOT be present if the Resource model's `validateformat` attribute is
@@ -3299,19 +3295,14 @@ for additional information.
   value of `false`, this attribute MUST provide information as to why the
   format validation check was not performed.
 
-  Due to this attribute being server managed, and influenced by the state of
-  other Versions, as its value changes the Version itself MUST NOT be marked as
-  changed - meaning, attributes such as `modifiedat` and `epoch` remain
-  unchanged.
-
 - Constraints:
   - OPTIONAL
   - When specified, MUST be a non-empty string.
-  - MUST be a read-only attribute.
+  - MUST be a [read-only](#read-only-changed) attribute.
   - MUST be present when [`formatvalidated`](#formatvalidated-attribute) is
     present with a value of `false`.
   - MUST NOT be present when [`formatvalidated`](#formatvalidated-attribute) is
-    absent.
+    absent or has a value of `true`.
 
 #### `compatibilityvalidated` Attribute
 - Type: Boolean
@@ -3346,7 +3337,7 @@ for additional information.
   reject the update request instead.
 
   When `false`, the
-  [`formatvalidatedreason`](#formatvalidatedreason-attribute) MUST attribute
+  [`compatibilityvalidatedreason`](#compatibilityvalidatedreason-attribute)
   MUST be present with an explanation as to why the server was unable to
   attempt validation of the Version.
 
@@ -3357,15 +3348,10 @@ for additional information.
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
   model aspect.
 
-  Due to this attribute being server managed, and influenced by the state of
-  other Versions, as its value changes the Version itself MUST NOT be marked as
-  changed - meaning, attributes such as `modifiedat` and `epoch` remain
-  unchanged.
-
 - Constraints:
   - OPTIONAL
-  - When specified, MUST be a non-empty string.
-  - MUST be a read-only attribute.
+  - When specified, MUST be either `true` or `false`, case-sensitive.
+  - MUST be a [read-only](#read-only-changed) attribute.
   - MUST be present if the Resource model's `validatecompatibility` attribute
     is `true`, the Version's `format` value is present, and the Resource's
     `meta.compatibility` attribute is present.
@@ -3380,22 +3366,16 @@ for additional information.
   value of `false`, this attribute MUST provide information as to why the
   format validation check was not performed.
 
-  Due to this attribute being server managed, and influenced by the state of
-  other Versions, as its value changes the Version itself MUST NOT be marked as
-  changed - meaning, attributes such as `modifiedat` and `epoch` remain
-  unchanged.
-
 - Constraints:
   - OPTIONAL
   - When specified, MUST be a non-empty string.
-  - When specified, MUST be either `true` or `false`, case-sensitive.
-  - MUST be a read-only attribute.
+  - MUST be a [read-only](#read-only-changed) attribute.
   - MUST be present when
    [`compatibilityvalidated`](#compatibilityvalidated-attribute) is
     present with a value of `false`.
   - MUST NOT be present when
    [`compatibilityvalidated`](#compatibilityvalidated-attribute) is
-    absent.
+    absent or has a value of `true`.
 
 #### `<RESOURCE>url` Attribute
 - Type: URI

--- a/core/spec.md
+++ b/core/spec.md
@@ -2,6 +2,7 @@
 
 <!-- words: validatecompatibility validateformat strictvalidation matchcase -->
 <!-- words: compat formatvalidated compatibilityvalidated -->
+<!-- words: compat formatvalidatedreason compatibilityvalidatedreason -->
 <!-- words: consistentformat -->
 
 ## Abstract
@@ -574,6 +575,11 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
           "modifiedat": "<TIMESTAMP>",
           "ancestor": "<STRING>",                  # Ancestor's versionid
           "contenttype": "<STRING>, ?              # Add default Ver extensions
+          "format": "<STRING>", ?
+          "formatvalidated": <BOOLEAN>, ?
+          "formatvalidatedreason": "<STRING>", ?
+          "compatibilityvalidated": <BOOLEAN>, ?
+          "compatibilityvalidatedreason": "<STRING>", ?
 
           "<RESOURCE>url": "<URL>", ?              # If not local
           "<RESOURCE>": ... Resource document ..., ? # If local & inlined & JSON
@@ -626,7 +632,9 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
               "contenttype": "<STRING>", ?
               "format": "<STRING>", ?
               "formatvalidated": <BOOLEAN>, ?
+              "formatvalidatedreason": "<STRING>", ?
               "compatibilityvalidated": <BOOLEAN>, ?
+              "compatibilityvalidatedreason": "<STRING>", ?
 
               "<RESOURCE>url": "<URL>", ?                # If not local
               "<RESOURCE>": ... Resource document ..., ? # If inlined & JSON
@@ -1823,7 +1831,12 @@ The following defines the specification-defined capabilities:
 - Description: The set of compatibility rules that are available for each
   supported `format`. Each map key MUST be a case-insensitive Capabilities
   `formats` value, and the map value MUST be the list of case-insensitive
-  compatibility rules supported by that `format`. An error
+  compatibility rules supported by that `format`. The key MAY include a
+  `*` (wildcard) character that matches zero or more instances of any
+  character at that location in the string. Similar to a `.*` in regular
+  expressions.
+
+  An error
   ([capability_error](#capability_error)) MUST be generated if a specified
   key/format isn't in Capabilities `formats` list or the compatibility rule
   specified is not supported for that `format` (i.e. that combination of
@@ -1842,6 +1855,7 @@ The following defines the specification-defined capabilities:
   for Version compatibility is supported.
 - Examples:
   - `"compatibilities": { "avro": [ "backward", "forward" ] }`
+  - `"compatibilities": { "jsonschema*": [ "backward", "forward", "full" ] }`
 
 #### `flags` Capability
 - Name: `flags`
@@ -2890,8 +2904,9 @@ and the following Meta-level attributes:
 
 - Constraints:
   - OPTIONAL.
-  - If present, MUST be a case-insensitive non-empty value from the Resource
-    model's enumeration range.
+  - If present, MUST be a case-insensitive non-empty value from the Registry's
+    [`capabilities.compatibilities`](#compatibilities-capability) values
+    for the set of `format` values used by the Versions of the Resource.
   - When changing the value of this attribute, it MUST be applied to all
     Versions of the Resource, and an error
     ([compatibility_violation](#compatibility_violation)) MUST be generated
@@ -3220,22 +3235,20 @@ for additional information.
   - `Avro/1.9`
 
 #### `formatvalidated` Attribute
-- Type: String
+- Type: Boolean
 - Description: When
   [`format` validation](./model.md#groupsstringresourcesstringvalidateformat)
   is enabled, this attribute will indicate whether or not the server has
   attempted to validated that the Version conforms to the rules defined by
   its `format` attribute's value.
 
-  The value MUST be a non-empty string in one of two forms:
-  - `"true"`
-  - `"false, <REASON>"`
+  A value of `true` indicates that the server has validated the Version and
+  it adheres to the `format` attribute's rules. When `true` the Version's
+  [`formatvalidatedreason`](#formatvalidatedreason-attribute) MUST NOT be
+  present.
 
-  A value of `"true"` indicates that the server has validated the Version and
-  it adheres to the `format` attribute's rules.
-
-  A value that starts with `false` indicates that the server did not attempt
-  to validated the Version. This can happen when
+  A value of `false` indicates that the server did not attempt to validated
+  the Version. This can happen when
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
   is set to `false` and:
   - The `format` attribute value is not supported by the server.
@@ -3251,12 +3264,13 @@ for additional information.
  ([format_unknown](#format_unknown) or [format_external](#format_external)) and
  reject the update request instead.
 
-  When `"false"`, this value MUST include some additional text (the `<REASON>`)
-  indicating why the server was unable to attempt validation of the Version.
-  Additionally, when `"false"`, if `compatibility` validation is enabled,
-  the Version's
+  When `false`, the
+  [`formatvalidatedreason`](#formatvalidatedreason-attribute) MUST attribute
+  MUST be present with an explanation as to why the server was unable to
+  attempt validation of the Version. Additionally, when `false`, if
+  `compatibility` validation is enabled, the Version's
   [`compatibilityvalidated`](#compatibility-attribute) attribute MUST also be
-  `"false"`.
+  `false`.
 
   Note that `"false"` MUST NOT be used for validation failure. In those cases
   the write operation MUST generate an error
@@ -3272,37 +3286,49 @@ for additional information.
 
 - Constraints:
   - OPTIONAL
-  - If present, MUST be non-empty.
+  - When specified, MUST be either `true` or `false`, case-sensitive.
   - MUST be a read-only attribute.
   - MUST be present if the Resource model's `validateformat` attribute is
     `true` and the Version's `format` attribute is present.
   - MUST NOT be present if the Resource model's `validateformat` attribute is
     `false` or the Version's `format` attribute is absent.
 
-- Examples:
-  - `"true"`
-  - `"false, unknown format"`
+#### `formatvalidatedreason` Attribute
+- Type: String
+- Description: When [`formatvalidated`](#formatvalidated-attribute) has a
+  value of `false`, this attribute MUST provide information as to why the
+  format validation check was not performed.
+
+  Due to this attribute being server managed, and influenced by the state of
+  other Versions, as its value changes the Version itself MUST NOT be marked as
+  changed - meaning, attributes such as `modifiedat` and `epoch` remain
+  unchanged.
+
+- Constraints:
+  - OPTIONAL
+  - When specified, MUST be a non-empty string.
+  - MUST be a read-only attribute.
+  - MUST be present when [`formatvalidated`](#formatvalidated-attribute) is
+    present with a value of `false`.
+  - MUST NOT be present when [`formatvalidated`](#formatvalidated-attribute) is
+    absent.
 
 #### `compatibilityvalidated` Attribute
-- Type: String
+- Type: Boolean
 - Description: When [`compatibility`
   validation](./model.md#groupsstringresourcesstringvalidateformat)
   is enabled, this attribute will indicate whether or not the server has
-  validated that the Version conforms to the rules defined by its Resource's
-  `meta.compatibility` attribute's value.
+  attempted to validate that the Version conforms to the rules defined by its
+  Resource's `meta.compatibility` attribute's value.
 
-  The value MUST be a non-empty string in one of two forms:
-  - `"true"`
-  - `"false, <REASON>"`
-
-  A value of `"true"` indicates that the server has validated the Version and
+  A value of `true` indicates that the server has validated the Version and
   it adheres to the `meta.compatibility` attribute's rules.
 
-  A value that starts with `"false"` indicates that the server did not attempt
-  to validate the Version. This can happen when
+  A value of `false` indicates that the server did not attempt to validate the
+  Version. This can happen when
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
   is set to `false` and:
-  - The `formatvalidated` attribute is `"false"`.
+  - The `formatvalidated` attribute is `false`.
   - The `format` or `meta.compatibility` attributes not supported by the
     server.
   - The Version uses the `<RESOURCE>url` attribute to reference a
@@ -3319,10 +3345,12 @@ for additional information.
   [format_external](#format_external)) and
   reject the update request instead.
 
-  When `"false"`, this value MUST include some additional text (the `<REASON>`)
-  indicating why the server was unable to attempt validation of the Version.
+  When `false`, the
+  [`formatvalidatedreason`](#formatvalidatedreason-attribute) MUST attribute
+  MUST be present with an explanation as to why the server was unable to
+  attempt validation of the Version.
 
-  Note that `"false"` MUST NOT be used for validation failure. In those cases
+  Note that `false` MUST NOT be used for validation failure. In those cases
   the write operation MUST generate an error
   ([compatibility_violation](#compatibility_violation) and reject the request
   regardless of the value of the
@@ -3336,7 +3364,7 @@ for additional information.
 
 - Constraints:
   - OPTIONAL
-  - If present, MUST be non-empty.
+  - When specified, MUST be a non-empty string.
   - MUST be a read-only attribute.
   - MUST be present if the Resource model's `validatecompatibility` attribute
     is `true`, the Version's `format` value is present, and the Resource's
@@ -3344,6 +3372,30 @@ for additional information.
   - MUST NOT be present if the Resource model's `validatecompatibility`
     attribute is `false`, or the Version's `format` value is absent, or the
     Resource's `meta.compatibility` attribute is absent.
+
+#### `compatibilityvalidatedreason` Attribute
+- Type: String
+- Description: When
+  [`compatibilityvalidated`](#compatibilityvalidated-attribute) has a
+  value of `false`, this attribute MUST provide information as to why the
+  format validation check was not performed.
+
+  Due to this attribute being server managed, and influenced by the state of
+  other Versions, as its value changes the Version itself MUST NOT be marked as
+  changed - meaning, attributes such as `modifiedat` and `epoch` remain
+  unchanged.
+
+- Constraints:
+  - OPTIONAL
+  - When specified, MUST be a non-empty string.
+  - When specified, MUST be either `true` or `false`, case-sensitive.
+  - MUST be a read-only attribute.
+  - MUST be present when
+   [`compatibilityvalidated`](#compatibilityvalidated-attribute) is
+    present with a value of `false`.
+  - MUST NOT be present when
+   [`compatibilityvalidated`](#compatibilityvalidated-attribute) is
+    absent.
 
 #### `<RESOURCE>url` Attribute
 - Type: URI
@@ -4553,9 +4605,10 @@ field is just a substitution value and MUST NOT be empty.
 * Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#compatibility_unknown`
 * Code: `400 Bad Request`
 * Subject: `<resource_xid>`
-* Title: `The compatibility value (<compat>) on Resource "<subject>" is not supported.`
+* Title: `The compatibility value (<compat>) on Resource "<subject>" is not supported for format "<format>".`
 * Args:
   - `compat`: The Resource's `meta.compatibility` value.
+  - `format`: The Version's `format` value.
 
 ### compatibility_violation
 
@@ -4793,6 +4846,15 @@ This is a fairly generic error, so if a more focused one (e.g.
 * Title: `One or more mandatory attributes for "<subject>" are missing: <list>.`
 * Args:
   - `list`: A comma separated list of attributes that are missing.
+
+### resources_only
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#resources_only`
+* Code: `400 Bad Request`
+* Subject: `<group_xid>`
+* Title: `Attribute "<name>" is invalid. Only Resource types are allowed to be specified on this request: <subject>.`
+* Args:
+  - `name`: The name of the attribute in question.
 
 ### server_error
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -3240,7 +3240,7 @@ for additional information.
 - Description: When
   [`format` validation](./model.md#groupsstringresourcesstringvalidateformat)
   is enabled, this attribute will indicate whether or not the server has
-  attempted to validate that the Version conforms to the rules defined by
+  performed validation to ensure the Version conforms to the rules defined by
   its `format` attribute's value.
 
   A value of `true` indicates that the server has validated the Version and
@@ -3248,7 +3248,7 @@ for additional information.
   [`formatvalidatedreason`](#formatvalidatedreason-attribute) MUST NOT be
   present.
 
-  A value of `false` indicates that the server did not attempt to validate
+  A value of `false` indicates that the server did not perform validation of
   the Version. This can happen when
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
   is set to `false` and:
@@ -3268,7 +3268,7 @@ for additional information.
   When `false`, the
   [`formatvalidatedreason`](#formatvalidatedreason-attribute)
   MUST be present with an explanation as to why the server was unable to
-  attempt validation of the Version. Additionally, when `false`, if
+  perform validation of the Version. Additionally, when `false`, if
   `compatibility` validation is enabled, the Version's
   [`compatibilityvalidated`](#compatibility-attribute) attribute MUST also be
   `false`.
@@ -3309,14 +3309,14 @@ for additional information.
 - Description: When [`compatibility`
   validation](./model.md#groupsstringresourcesstringvalidateformat)
   is enabled, this attribute will indicate whether or not the server has
-  attempted to validate that the Version conforms to the rules defined by its
+  performed validation of the Version conforms to the rules defined by its
   Resource's `meta.compatibility` attribute's value.
 
   A value of `true` indicates that the server has validated the Version and
   it adheres to the `meta.compatibility` attribute's rules.
 
-  A value of `false` indicates that the server did not attempt to validate the
-  Version. This can happen when
+  A value of `false` indicates that the server did not perform validation of
+  the Version. This can happen when
   [`strictvalidation`](model.md#groupsstringresourcesstringstrictvalidation)`
   is set to `false` and:
   - The `formatvalidated` attribute is `false`.
@@ -3339,7 +3339,7 @@ for additional information.
   When `false`, the
   [`compatibilityvalidatedreason`](#compatibilityvalidatedreason-attribute)
   MUST be present with an explanation as to why the server was unable to
-  attempt validation of the Version.
+  perform validation of the Version.
 
   Note that `false` MUST NOT be used for validation failure. In those cases
   the write operation MUST generate an error

--- a/message/spec.md
+++ b/message/spec.md
@@ -1,5 +1,8 @@
 # Message Definitions Registry Service - Version 1.0-rc2
 
+<!-- words: formatvalidated compatibilityvalidated -->
+<!-- words: formatvalidatedreason compatibilityvalidatedreason -->
+
 ## Abstract
 
 This specification defines a message and event catalog extension to the
@@ -468,6 +471,12 @@ this form:
           "createdat": "<TIMESTAMP>",
           "modifiedat": "<TIMESTAMP>",
           "ancestor": "<STRING>",
+          "contenttype": "<STRING>, ?
+          "format": "<STRING>", ?
+          "formatvalidated": <BOOLEAN>, ?
+          "formatvalidatedreason": "<STRING>", ?
+          "compatibilityvalidated": <BOOLEAN>, ?
+          "compatibilityvalidatedreason": "<STRING>", ?
 
           # Start of Message extension attributes
           "basemessage": "<URL>", ?            # Message being extended

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -1,5 +1,8 @@
 # Schema Registry Service - Version 1.0-rc2
 
+<!-- words: formatvalidated compatibilityvalidated -->
+<!-- words: formatvalidatedreason compatibilityvalidatedreason -->
+
 ## Abstract
 
 This specification defines a Schema Registry extension to the xRegistry
@@ -269,6 +272,12 @@ this form:
           "createdat": "<TIMESTAMP>",
           "modifiedat": "<TIMESTAMP>",
           "ancestor": "<STRING>",
+          "contenttype": "<STRING>, ?
+          "format": "<STRING>", ?
+          "formatvalidated": <BOOLEAN>, ?
+          "formatvalidatedreason": "<STRING>", ?
+          "compatibilityvalidated": <BOOLEAN>, ?
+          "compatibilityvalidatedreason": "<STRING>", ?
 
           "schemaurl": "<URL>", ?
           "schema": <ANY> ?

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,7 +4,7 @@ all: models docker
 		  exit 1 )
 
 verify: spellcheck ticks badhrefs tabcheck errorcheck samplescheck \
-	testpython links
+	testpython links website
 
 spellcheck:
 	@echo "Checking for spelling mistakes"
@@ -28,6 +28,7 @@ badhrefs:
 	@echo
 
 errorcheck:
+	@echo "Look for unused errors in the specs"
 	tools/errorcheck core/spec.md core/model.md core/http.md
 	@echo
 
@@ -60,6 +61,16 @@ models:
 	  echo Using docker ghcr.io/xregistry/xr ; \
 	  docker run -t -v $$PWD:/xreg -w /xreg --entrypoint /bin/sh \
 		ghcr.io/xregistry/xr -c "/xr model verify */model.json -v" ; \
+	fi
+	@echo
+
+website:
+	@echo If available, verify the website generation code works too
+	@if test -f `pwd -P`/../xregistry.github.io/tools/buildsite ; then \
+	  XR_SPEC=`pwd -P` `pwd -P`/../xregistry.github.io/tools/buildsite && \
+	    rm -rf xreg ; \
+	else \
+	  echo "> Website dir (../xregistry.github.io) can't be found" ; \
 	fi
 	@echo
 


### PR DESCRIPTION
- typos, wording tweaks and tooling updates
- split `formatvalidated` and `compatvalidated` - e.g:

```
"formatvalidated": "false, reason we didn't check"
```
becomes:
```
"formatvalidated": false,
"formatvalidatedreason": "reason we didn't check"
```  

