### PR TITLE
Fix #437: unpin openapi-spec-validator and fix ximportresources OpenAPI paths

### DIFF
--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -1299,7 +1299,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages/meta": {
+    "/endpoints/{groupid}/messages/{resourceid}/meta": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"
@@ -1642,7 +1642,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages$details": {
+    "/endpoints/{groupid}/messages/{resourceid}$details": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"
@@ -3046,7 +3046,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages/versions": {
+    "/endpoints/{groupid}/messages/{resourceid}/versions": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"
@@ -3449,7 +3449,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages/versions/{versionid}": {
+    "/endpoints/{groupid}/messages/{resourceid}/versions/{versionid}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -1069,7 +1069,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages/meta": {
+    "/endpoints/{groupid}/messages/{resourceid}/meta": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"
@@ -1267,7 +1267,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages$details": {
+    "/endpoints/{groupid}/messages/{resourceid}$details": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"
@@ -2234,7 +2234,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages/versions": {
+    "/endpoints/{groupid}/messages/{resourceid}/versions": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"
@@ -2491,7 +2491,7 @@
         }
       }
     },
-    "/endpoints/{groupid}/messages/versions/{versionid}": {
+    "/endpoints/{groupid}/messages/{resourceid}/versions/{versionid}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/groupid"

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -9,4 +9,4 @@ jsonpointer
 pytest
 avro
 jsonschema
-openapi-spec-validator==0.8.0
+openapi-spec-validator>=0.7.1

--- a/tools/schema-generator.py
+++ b/tools/schema-generator.py
@@ -231,7 +231,7 @@ def generate_openapi(model_definition):
                 replace_refs(meta_template_copy, "{%-resourceTypeReference-%}", f"#/components/schemas/{xid_resource_singular}")
                 replace_refs(meta_template_copy, "{%-groupTypeReference-%}", f"#/components/schemas/{xid_group_singular}")
                 replace_ops(meta_template_copy, "{%-resourceNameSingular-%}", f"{pascal(group['singular'])}{pascal(xid_resource_plural)}")
-                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}/meta"]= meta_template_copy
+                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}/{{resourceid}}/meta"]= meta_template_copy
 
         openapi["paths"].pop(path)
         path = "/{%-groupNamePlural-%}/{groupid}/{%-resourceNamePlural-%}/{resourceid}$details"
@@ -252,7 +252,7 @@ def generate_openapi(model_definition):
                 replace_refs(details_template_copy, "{%-resourceTypeReference-%}", f"#/components/schemas/{xid_resource_singular}")
                 replace_refs(details_template_copy, "{%-groupTypeReference-%}", f"#/components/schemas/{xid_group_singular}")
                 replace_ops(details_template_copy, "{%-resourceNameSingular-%}", f"{pascal(group['singular'])}{pascal(xid_resource_plural)}")
-                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}$details"]= details_template_copy
+                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}/{{resourceid}}$details"]= details_template_copy
 
         openapi["paths"].pop(path)
         path = "/{%-groupNamePlural-%}/{groupid}/{%-resourceNamePlural-%}/{resourceid}"
@@ -294,7 +294,7 @@ def generate_openapi(model_definition):
                 replace_refs(versions_template_copy, "{%-resourceTypeReference-%}", f"#/components/schemas/{xid_resource_singular}")
                 replace_refs(versions_template_copy, "{%-groupTypeReference-%}", f"#/components/schemas/{xid_group_singular}")
                 replace_ops(versions_template_copy, "{%-resourceNameSingular-%}", f"{pascal(group['singular'])}{pascal(xid_resource_plural)}")
-                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}/versions"]= versions_template_copy
+                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}/{{resourceid}}/versions"]= versions_template_copy
 
         openapi["paths"].pop(path)
         path = "/{%-groupNamePlural-%}/{groupid}/{%-resourceNamePlural-%}/{resourceid}/versions/{versionid}"
@@ -315,7 +315,7 @@ def generate_openapi(model_definition):
                 replace_refs(versionid_template_copy, "{%-resourceTypeReference-%}", f"#/components/schemas/{xid_resource_singular}")
                 replace_refs(versionid_template_copy, "{%-groupTypeReference-%}", f"#/components/schemas/{xid_group_singular}")
                 replace_ops(versionid_template_copy, "{%-resourceNameSingular-%}", f"{pascal(group['singular'])}{pascal(xid_resource_plural)}")
-                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}/versions/{{versionid}}"]= versionid_template_copy
+                openapi["paths"][f"/{group['plural']}/{{groupid}}/{xid_resource_plural}/{{resourceid}}/versions/{{versionid}}"]= versionid_template_copy
 
         openapi["paths"].pop(path)
 


### PR DESCRIPTION
Fixes #437.

## Issue

The pin `openapi-spec-validator==0.8.0` in `tools/requirements.txt` was in place because anything higher broke the test suite. Investigation showed the newer versions weren't actually broken — they were correctly catching pre-existing bugs in `tools/schema-generator.py` that the older release silently let through.

With `openapi-spec-validator>=0.8.1` (current latest: 0.8.5), the OpenAPI path-parameter resolution check raises:

```
openapi_spec_validator.validation.exceptions.UnresolvableParameterError:
  Path parameter 'resourceid' for 'get' operation in
  '/endpoints/{groupid}/messages/meta' was not resolved
```

## Root cause

In `generate_openapi(...)`, the loops that emit paths for a group's own `resources` correctly include `{resourceid}` in the URL template. The mirrored loops for `ximportresources` (resources imported from another group) were dropping the `{resourceid}` segment for four templates, producing paths whose operations referenced an undefined path parameter:

| Template | Before (broken) | After (fixed) |
|---|---|---|
| meta | `/{group}/{groupid}/{ximpres}/meta` | `/{group}/{groupid}/{ximpres}/{resourceid}/meta` |
| $details | `/{group}/{groupid}/{ximpres}$details` | `/{group}/{groupid}/{ximpres}/{resourceid}$details` |
| versions | `/{group}/{groupid}/{ximpres}/versions` | `/{group}/{groupid}/{ximpres}/{resourceid}/versions` |
| versions/{versionid} | `/{group}/{groupid}/{ximpres}/versions/{versionid}` | `/{group}/{groupid}/{ximpres}/{resourceid}/versions/{versionid}` |

The non-imported `resources` branches already had the correct URLs; the bug only affected the `ximportresources` branches.

## Fix

- `tools/schema-generator.py`: add the missing `{resourceid}` segment to the four `ximportresources` path templates so the emitted OpenAPI documents are valid.
- `tools/requirements.txt`: replace `openapi-spec-validator==0.8.0` with `openapi-spec-validator>=0.7.1`, allowing the latest validator.

## Validation

`python -m pytest test_schema_generator.py` against `openapi-spec-validator==0.8.5`: **22 passed**.