### PR TITLE
Add references to codegen/viewer/xrproxy and mention document schemas (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,19 @@ with a lowercase `x`, even when the first word in a sentence.
 | Pagination Specification      | n/a | [WIP](pagination/spec.md)                          |
 |                               |
 | **Even More:** |
-| Server & CLI Reference Implementation | [server repo](https://github.com/xregistry/server) |
+| Server & CLI Reference Implementation | [xregistry/server](https://github.com/xregistry/server) |
+| Code & File Generation CLI (`xrcg`)   | [xregistry/codegen](https://github.com/xregistry/codegen) |
+| Web Viewer for xRegistry APIs         | [xregistry/viewer](https://github.com/xregistry/viewer) |
+| xRegistry Proxies for package registries (NPM, PyPI, Maven, NuGet, OCI, MCP) | [xregistry/xrproxy](https://github.com/xregistry/xrproxy) |
 | [Samples](core/samples/README.md) | |
+
+Machine-readable schemas for each specification's document format are
+published alongside the specs as JSON Schema (`document-schema.json`),
+Avro (`document-schema.avsc`), and OpenAPI (`openapi.json`) in the
+`schemas/` subdirectory of each domain spec
+([endpoint](endpoint/schemas/), [message](message/schemas/),
+[schema](schema/schemas/)). The core model has its own JSON Schema at
+[core/model.schema.json](core/model.schema.json).
 
 Additional release related information:
   [Historical releases and changelogs](docs/RELEASES.md)

--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -6,7 +6,7 @@ one of the xRegistry specifications, please include in the list below.
 - xRegistry code & file generation CLI (`xrcg`) — generates type-safe
   messaging SDKs (Java, C#, Python, TypeScript) for Kafka, MQTT, AMQP,
   Event Hubs, Service Bus, Event Grid, and HTTP/CloudEvents from xRegistry
-  message catalog definitions, plus AsyncAPI and OpenAPI documents:
+  endpoint, message, and schema catalog definitions, plus AsyncAPI and OpenAPI documents:
   https://github.com/xregistry/codegen
 - xRegistry Viewer — Angular-based web UI for browsing xRegistry-compliant
   APIs: https://github.com/xregistry/viewer

--- a/docs/open-source.md
+++ b/docs/open-source.md
@@ -1,5 +1,15 @@
 If you have created (or know of) an open source library or product that uses
 one of the xRegistry specifications, please include in the list below.
 
-- Official xRegistry reference implementation:
+- Official xRegistry reference implementation (server & CLI):
   https://github.com/xregistry/server
+- xRegistry code & file generation CLI (`xrcg`) — generates type-safe
+  messaging SDKs (Java, C#, Python, TypeScript) for Kafka, MQTT, AMQP,
+  Event Hubs, Service Bus, Event Grid, and HTTP/CloudEvents from xRegistry
+  message catalog definitions, plus AsyncAPI and OpenAPI documents:
+  https://github.com/xregistry/codegen
+- xRegistry Viewer — Angular-based web UI for browsing xRegistry-compliant
+  APIs: https://github.com/xregistry/viewer
+- xRegistry Proxies (`xrproxy`) — read-only xRegistry server implementations
+  that front popular package registries (NPM, PyPI, Maven, NuGet, OCI, MCP)
+  behind a unified xRegistry API: https://github.com/xregistry/xrproxy


### PR DESCRIPTION
Fixes #121.

Adds pointers from the main `README.md` to the sister repositories in the xRegistry org, and notes that machine-readable document schemas exist for each spec.

## Changes

- **`README.md`** — In the "Even More" section of the artifacts table, added rows for:
  - `xregistry/codegen` — the `xrcg` code & file generation CLI
  - `xregistry/viewer` — the Angular-based web viewer
  - `xregistry/xrproxy` — package registry proxies (NPM, PyPI, Maven, NuGet, OCI, MCP)

  Also added a paragraph below the table noting that JSON Schema (`document-schema.json`), Avro (`document-schema.avsc`), and OpenAPI (`openapi.json`) representations of each domain spec's document format are available in the per-spec `schemas/` directories, with a pointer to `core/model.schema.json` for the core model.

- **`docs/open-source.md`** — Expanded the open-source listing with the three sister repos and short descriptions.