### PR TITLE
docs: add proposal for basemessage and messagegroups that allows for …

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -248,7 +248,7 @@
                     {
                       "type": "string",
                       "doc": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition",
-                      "name": "basemessageurl"
+                      "name": "basemessageuri"
                     },
                     {
                       "name": "envelope",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -71,7 +71,7 @@
             "format": "date-time",
             "description": "Time of the object modification"
           },
-          "basemessageurl": {
+          "basemessageuri": {
             "type": "string",
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -4901,7 +4901,7 @@
             "format": "date-time",
             "description": "Time of the object modification"
           },
-          "basemessageurl": {
+          "basemessageuri": {
             "type": "string",
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -819,9 +819,9 @@
         "messagegroups": {
           "name": "messagegroups",
           "type": "array",
-          "description": "The message groups that are supported by this endpoint",
+          "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
           "item": {
-            "type": "xid",
+            "type": "uri-reference",
             "target": "/messagegroups/messages"
           }
         },

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -248,7 +248,7 @@
                     {
                       "type": "string",
                       "doc": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition",
-                      "name": "basemessageurl"
+                      "name": "basemessageuri"
                     },
                     {
                       "name": "envelope",

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -65,7 +65,7 @@
             "format": "date-time",
             "description": "Time of the object modification"
           },
-          "basemessageurl": {
+          "basemessageuri": {
             "type": "string",
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -3808,7 +3808,7 @@
             "format": "date-time",
             "description": "Time of the object modification"
           },
-          "basemessageurl": {
+          "basemessageuri": {
             "type": "string",
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -654,7 +654,8 @@ This specification defines the following envelope options for the indicated
 
 The `messagegroups` attribute is an array of URI-references to message
 definition groups. Relative references (beginning with `/`) are XIDs within
-the same registry. Absolute URIs reference MessageGroups in external
+the same registry. Absolute URIs reference message
+definition groups in external
 registries. The server stores absolute URIs as-is without resolving them.
 
 The `messagegroups` attribute is used to reference message definition groups

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -652,9 +652,13 @@ This specification defines the following envelope options for the indicated
 
 #### `messagegroups`
 
-The `messagegroups` attribute is an array of XID-references to message
-definition groups. The `messagegroups` attribute is used to reference
-message definition groups that are not inlined in the endpoint definition.
+The `messagegroups` attribute is an array of URI-references to message
+definition groups. Relative references (beginning with `/`) are XIDs within
+the same registry. Absolute URIs reference MessageGroups in external
+registries. The server stores absolute URIs as-is without resolving them.
+
+The `messagegroups` attribute is used to reference message definition groups
+that are not inlined in the endpoint definition.
 
 Example:
 
@@ -665,7 +669,8 @@ Example:
     "method": "POST"
   },
   "messagegroups": [
-    "/messagegroups/mygroup"
+    "/messagegroups/mygroup",
+    "https://other-catalog.example.com/messagegroups/external-group"
   ]
 }
 ```

--- a/message/model.json
+++ b/message/model.json
@@ -33,8 +33,9 @@
           "attributes": {
             "basemessageurl": {
               "name": "basemessageurl",
-              "type": "uri",
-              "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
+              "type": "uri-reference",
+              "target": "/messagegroups/messages[/versions]",
+              "description": "Reference to a base definition for this definition. Relative references are XIDs within the same registry. Absolute URIs reference message definitions in external registries. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
             },
             "envelope": {
               "name": "envelope",

--- a/message/model.json
+++ b/message/model.json
@@ -31,8 +31,8 @@
           "modelversion": "1.0-rc2",
           "modelcompatiblewith": "https://xregistry.io/xreg/domains/message/specs/model.json",
           "attributes": {
-            "basemessageurl": {
-              "name": "basemessageurl",
+            "basemessageuri": {
+              "name": "basemessageuri",
               "type": "uri-reference",
               "target": "/messagegroups/messages[/versions]",
               "description": "Reference to a base definition for this definition. Relative references are XIDs within the same registry. Absolute URIs reference message definitions in external registries. The base definition is overridden by this definition. If not present, this definition does not override any base definition"

--- a/message/schemas/document-schema.avsc
+++ b/message/schemas/document-schema.avsc
@@ -248,7 +248,7 @@
                     {
                       "type": "string",
                       "doc": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition",
-                      "name": "basemessageurl"
+                      "name": "basemessageuri"
                     },
                     {
                       "name": "envelope",

--- a/message/schemas/document-schema.json
+++ b/message/schemas/document-schema.json
@@ -59,7 +59,7 @@
             "format": "date-time",
             "description": "Time of the object modification"
           },
-          "basemessageurl": {
+          "basemessageuri": {
             "type": "string",
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"

--- a/message/schemas/openapi.json
+++ b/message/schemas/openapi.json
@@ -3057,7 +3057,7 @@
             "format": "date-time",
             "description": "Time of the object modification"
           },
-          "basemessageurl": {
+          "basemessageuri": {
             "type": "string",
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"

--- a/message/spec.md
+++ b/message/spec.md
@@ -597,7 +597,7 @@ the core xRegistry Resource
 
   When the value is a relative reference (begins with `/`), it MUST be a
   valid XID referencing a Resource, or Version, of type `message` within the
-  same registry. When the value is an absolute URI, it SHOULD resolve to a
+  same registry. When the value is an absolute URI, it MUST resolve to a
   message definition in an external registry, but the server is not required
   to validate or resolve external references.
 
@@ -627,7 +627,7 @@ the core xRegistry Resource
   - OPTIONAL.
   - If the value is a relative reference, it MUST be a valid `xid` of a
     Resource, or Version, of type `message` as defined by this specification.
-  - If the value is an absolute URI, it SHOULD point to a message definition
+  - If the value is an absolute URI, it MUST point to a message definition
     but the server MUST NOT validate the target.
 
 - Examples:

--- a/message/spec.md
+++ b/message/spec.md
@@ -586,20 +586,26 @@ the core xRegistry Resource
 
 #### `basemessage`
 
-- Type: XID
-- Description: if present, the XID points to a message definition that is the
-  base for this message definition. By following the XID, the base message
-  can be retrieved and extended with the properties of this message. This is
-  useful for defining variants of messages that only differ in minor additive
-  aspects to avoid repetition. For example, messages that only have a
-  `envelope` with associated `envelopemetadata` to be bound to various
-  protocols.
+- Type: URI-reference
+- Description: if present, the URI-reference points to a message definition
+  that is the base for this message definition. By following the reference,
+  the base message can be retrieved and extended with the properties of this
+  message. This is useful for defining variants of messages that only differ
+  in minor additive aspects to avoid repetition. For example, messages that
+  only have a `envelope` with associated `envelopemetadata` to be bound to
+  various protocols.
+
+  When the value is a relative reference (begins with `/`), it MUST be a
+  valid XID referencing a Resource, or Version, of type `message` within the
+  same registry. When the value is an absolute URI, it SHOULD resolve to a
+  message definition in an external registry, but the server is not required
+  to validate or resolve external references.
 
   Referenced messages MAY themselves have a `basemessage` value, however,
   the chain of messages MUST NOT be recursive.
 
   The processing that a client SHOULD take to materialize the message is
-  to follow the `basemessage` attributes to the end of the chain of messages,
+  to follow the `basemessage` references to the end of the chain of messages,
   get that message's attributes, and then walk back up the chain performing a
   "merge" operation of the next message's attributes. Note in the case of an
   inherited attribute being a complex type (e.g. map, object), and the
@@ -609,17 +615,25 @@ the core xRegistry Resource
   appropriately rather than it being a complete replacement of the entire
   complex type.
 
-  If the referenced message can not be found then an error MUST NOT be
-  generated, dangling references are permitted.
+  If the referenced message can not be found, whether due to a dangling
+  reference, an unreachable external registry, or insufficient permissions,
+  an error MUST NOT be generated. Dangling references are permitted.
+
+  Resolution of absolute URIs is a client responsibility. The server stores
+  the URI value but is not required to fetch, validate, or cache external
+  message definitions.
 
 - Constraints:
   - OPTIONAL.
-  - If present, MUST be the `xid` of a Resource, or Version, of type `message`
-    as defined by this specification.
+  - If the value is a relative reference, it MUST be a valid `xid` of a
+    Resource, or Version, of type `message` as defined by this specification.
+  - If the value is an absolute URI, it SHOULD point to a message definition
+    but the server MUST NOT validate the target.
 
 - Examples:
   - `/messagegroups/group1/messages/msg1`
   - `/messagegroups/group1/messages/msg1/versions/v1.0`
+  - `https://catalog.example.com/messagegroups/shared/messages/base-event`
 
 #### `envelope`
 

--- a/message/spec.md
+++ b/message/spec.md
@@ -597,7 +597,7 @@ the core xRegistry Resource
 
   When the value is a relative reference (begins with `/`), it MUST be a
   valid XID referencing a Resource, or Version, of type `message` within the
-  same registry. When the value is an absolute URI, it MUST resolve to a
+  same registry. When the value is an absolute URI, it MUST point to a
   message definition in an external registry, but the server is not required
   to validate or resolve external references.
 

--- a/tools/test-openapi.json
+++ b/tools/test-openapi.json
@@ -3057,7 +3057,7 @@
             "format": "date-time",
             "description": "Time of the object modification"
           },
-          "basemessageurl": {
+          "basemessageuri": {
             "type": "string",
             "format": "uri",
             "description": "Reference to a base definition for this definition, either via a (relative) URL or a fragment identifier. The base definition is overridden by this definition. If not present, this definition does not override any base definition"


### PR DESCRIPTION
# Proposal: Change `basemessage` and `messagegroups` from XID to URI-Reference

## Summary

Change two attributes from `Type: XID` (same-registry only) to
`Type: URI-reference` (relative XIDs and absolute URIs):

1. **`basemessage`** on Message definitions, enabling cross-registry message
   inheritance.
2. **`messagegroups`** on Endpoint definitions, enabling endpoints to reference
   MessageGroups in external registries.

Both changes remain fully backward compatible.

## Motivation

`basemessage` enables message inheritance with deep-merge semantics: a derived
message references a base and shadows specific properties. `messagegroups` on
endpoints references the MessageGroups whose messages the endpoint handles.

Both attributes are currently typed as XID, restricting references to the same
registry. In multi-registry environments, message contracts defined in one
registry are consumed by endpoints in another. The XID restriction forces
either duplicating definitions across registries or using ad-hoc workarounds.

## Why These Changes Are Safe

### Backward Compatible

Every existing `basemessage` value is a relative XID (e.g.,
`/messagegroups/group1/messages/msg1`). Every existing `messagegroups` entry
is a relative XID (e.g., `/messagegroups/mygroup`). Under the new type:
- Relative references beginning with `/` are validated as XIDs with the
  `target` constraint, which is identical behavior to today.
- Only absolute URIs are new, and they are additive.

No existing data or behavior changes.

### Consistent with Existing Patterns

The message spec already uses this exact pattern for schema references:

| Attribute | Type | Same-Registry | Cross-Registry |
|---|---|---|---|
| `dataschemaxid` | `xid` | ✓ | ✗ |
| `dataschemauri` | `uri` | ✓ (as relative) | ✓ (as absolute) |
| `basemessage` (current) | `xid` | ✓ | ✗ |
| `basemessage` (proposed) | `uri-reference` | ✓ (as relative) | ✓ (as absolute) |
| `messagegroups` items (current) | `xid` | ✓ | ✗ |
| `messagegroups` items (proposed) | `uri-reference` | ✓ (as relative) | ✓ (as absolute) |

The `dataschemauri` / `dataschemaxid` pair is the existing precedent: URI type
for cross-registry references, XID for same-registry validation.

### Dangling References Already Permitted

The spec states: *"If the referenced message can not be found then an error
MUST NOT be generated, dangling references are permitted."*

An absolute URI to an unreachable external registry is equivalent to
a dangling XID reference. The existing error handling covers this.

### Resolution Is Client-Side

The spec says: *"The processing that a **client SHOULD** take to materialize
the message..."* Materialization is a client responsibility. The server stores
the reference; the client resolves it. Whether the target is a local XID or an
external URI is a client concern.

### The Model Already Uses URI

The model.json already defines `basemessageurl` as `type: "uri"`. This
proposal aligns the spec prose with the model.

### Core Spec Infrastructure Exists

The core model spec (core/model.md:243-247) defines the behavior:

> "A URI/URL-reference entity attribute MAY include `target` as part of its
> definition. If so, then any runtime value that is a relative URI/URL
> (begins with `/`) MUST be an `xid` and MUST adhere to the `target` entity
> type specified, if specified. **Absolute URIs/URLs are not constrained by
> the presence of a `target` value.**"

Relative references are validated as XIDs; absolute URIs pass through
unconstrained. This mechanism is already in place.

## Server Behavior

### `basemessage`

| Scenario | Server Action |
|---|---|
| Relative XID: `/messagegroups/g1/messages/m1` | Validate as XID with target `/messagegroups/messages[/versions]`. Store. May resolve locally for inline expansion. |
| Absolute URI: `https://other.registry/messagegroups/g1/messages/m1` | Store as-is. No validation, no resolution, no fetching. |
| Malformed relative: `/notavalidpath` | Error: `malformed_xid` (same as today) |
| Dangling XID: `/messagegroups/deleted/messages/gone` | Store. No error. (same as today) |
| Unreachable absolute URI | Store. No error. (dangling reference) |

### `messagegroups`

| Scenario | Server Action |
|---|---|
| Relative XID: `/messagegroups/mygroup` | Validate as XID with target `/messagegroups/messages`. Store. Resolve locally for inline expansion. |
| Absolute URI: `https://other.registry/messagegroups/external` | Store as-is. No validation, no resolution, no fetching. |
| Malformed relative: `/notavalidpath` | Error: `malformed_xid` (same as today) |
| Dangling XID: `/messagegroups/deleted` | Store. No error. |
| Unreachable absolute URI | Store. No error. |

## Client Behavior

```
Client receives message with basemessage:
  ├── Value starts with "/"?
  │   └── YES: Resolve as XID within same registry
  │            GET {registry-base}{basemessage}/$details
  │            Perform deep-merge
  │
  └── NO (absolute URI):
      └── Resolve as absolute URI (client has credentials)
          GET {basemessage}/$details
          Perform deep-merge
          (If unreachable, treat as dangling; use message as-is)
```

## Example: Cross-Registry Message Inheritance

Registry A (`https://catalog-a.example.com`) defines base CloudEvents messages.
Registry B (`https://catalog-b.example.com`) defines endpoint-specific variants.

### Base message in Registry A

```json
{
  "messageid": "com.xyz.orders.created",
  "envelope": "CloudEvents/1.0",
  "envelopemetadata": {
    "type": {
      "value": "com.xyz.orders.created",
      "required": true
    }
  },
  "dataschemaformat": "Avro/1.12.0",
  "dataschemauri": "/schemagroups/com.xyz.orders/schemas/com.xyz.orders.created"
}
```

### Derived message in Registry B (endpoint-specific override)

```json
{
  "messageid": "com.xyz.orders.created.eventhubs",
  "basemessage": "https://catalog-a.example.com/messagegroups/com.xyz.orders/messages/com.xyz.orders.created",
  "envelope": "CloudEvents/1.0",
  "protocoloptions": {
    "messagemappings": {
      "headers": {
        "ce-source": { "value": "/xyz/order-service" }
      }
    }
  }
}
```

The client fetches the base from Registry A, performs the deep-merge, and
produces a materialized message with the original schema reference plus the
endpoint-specific header mapping.

Registry B's server never contacts Registry A. It stores the absolute URI.
The client resolves it using its own credentials.