### PR TITLE
Week of June 1

### DIFF
--- a/core/http.md
+++ b/core/http.md
@@ -301,6 +301,12 @@ following:
     if there are entities that need to be removed.
   - The processing of each individual entity in the map MUST follow the same
     rules as defined for `PUT` above.
+  - In the case of an empty map of Versions and the Resource being referenced
+    does not exist yet, an error ([missing_versions](#missing_versions)) MUST
+    be generated because a Resource can not exist without any Versions. If
+    the intent was to create a Resource with a Version that has just default
+    values, then there are other APIs that can be used that make that intent
+    clear (e.g. `PUT` to the Resource itself).
 
 The processing of each individual entity follows the same set of rules:
 - If an entity with the specified `<SINGULAR>id` already exists then it MUST be
@@ -596,8 +602,9 @@ Where:
   changes to those values.
 - For both the `PATCH` and `PUT` cases, if present, the `modelsource` attribute
   MUST be a complete replacement representation of the model definition. A
-  value of `null` MUST reset the model to the server's default value.
-  See [Creating or Updating the Registry
+  value of `null` or `{}` MUST reset the model to the server's default value
+  (no Groups, Resources, extension attributes or custom specification-defined
+  attributes).  See [Creating or Updating the Registry
   Model](./model.md#creating-or-updating-the-registry-model) for more
   information.
 - When the `capabilities` attribute is present and `PATCH` is used then only
@@ -1041,6 +1048,9 @@ A server MAY support clients retrieving the client-provided
 [model definition](./model.md#registry-model) used to define the current
 model via an HTTP `GET` directed to the stand-alone `modelsource` entity.
 
+In cases where the Registry's model has never been specified via `modelsource`,
+this operation MUST return `{}` not an empty HTTP body.
+
 The request MUST be of the form:
 
 ```yaml
@@ -1079,6 +1089,10 @@ Content-Type: application/json; charset=utf-8
 To update the `modelsource` as part of a request to update the
 [Registry entity](./spec.md#registry-entity), you can include the attribute
 as part of the [`PUT /`](#patch-and-put-) request.
+
+Note: the HTTP body MUST be a JSON object and an empty request MUST generate
+an error ([missing_body](#missing_body)). To denote an empty model `{}` SHOULD
+be used instead.
 
 ### Group Entity
 
@@ -3276,6 +3290,13 @@ starting with `/`. E.g. `/export` if the "export" feature is not supported.
 * Type: `https://github.com/xregistry/spec/blob/main/core/http.md#missing_body`
 * Code: `400 Bad Request`
 * Title: `The request is missing an HTTP body - try '{}'.`
+* Subject: `<request_path>`
+
+#### missing_versions
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/http.md#missing_versions`
+* Code: `400 Bad Request`
+* Title: `At least one Version needs to be included in the request to process "<subject>".`
 * Subject: `<request_path>`
 
 <!-- end-err-def -->

--- a/core/model.md
+++ b/core/model.md
@@ -2,7 +2,7 @@
 
 <!-- words: compat validatecompatibility validateformat strictvalidation -->
 <!-- words: matchcase compatibilityvalidated formatvalidated -->
-<!-- words: consistentformat validators -->
+<!-- words: consistentformat validators stickyversion -->
 
 ## Abstract
 
@@ -118,6 +118,14 @@ The overall format of a model definition is as follows:
       "modelcompatiblewith": "<URI>", ?  # Statement of compatibility
       "attributes": { ... }, ?           # See "attributes" above
       "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources
+
+      "constraints": {
+        "<RESOURCES>.<PATH>": {          # Resource-plural + attribute path
+          "default": <VALUE>, ?          # Group specific default
+          "enum": [ <VALUE> * ], ?       # Allowed subset of values
+          "equals": "<PATH>" ?           # Matching Group attribute path
+        } *
+      }, ?
 
       "resources": {
         "<STRING>": {                    # Key=plural name, e.g. "messages"
@@ -539,6 +547,97 @@ The following describes the attributes of the Registry model:
 - See [Reuse of Resource Definitions](#reuse-of-resource-definitions) for
   more information.
 
+### `groups.<STRING>.constraints`
+
+The `constraints` map defines a set of rules that can be used to govern
+the attribute values in Resources that are added to instances of the Group
+type being defined.
+
+These constraints MUST be applied to all instances of this Group type. Group
+instances MAY choose to add additional entries, or further restrict the ones
+defined here, via use of the Group instance's
+[`constraints` attribute](./spec.md#constraints-attribute).
+
+The constraints MUST be applied to all Versions of all Resources in the Group
+instances, and generate an error
+([constraint_failure](./spec.md#constraint_failure)) if a violation is
+detected.
+
+When possible these constraints are best described when defining the Resource
+attributes in question, rather than here. However, there are cases where this
+might not be possible, such as when Resources are added to a Group type via the
+`ximportresources` feature or defining a relationship between Group and
+Resource attributes - such is the case for the `equals` constraint defined
+below.
+
+Inclusion of a Resource in a Group instance via the
+[`meta.xref`](./spec.md#cross-referencing-resources) mechanism introduces
+some special considerations. The following describes the how the aspects of
+a constraint are applied to such xref'd Resources:
+- The `enum` and `equals` constraints, if specified, MUST be adhered to by the
+  Resource. Note that this includes changes to the Resource in its original
+  location that would then violate any of the Groups' constraints that xref
+  that Resource.
+- The `default` values specified MUST NOT be applied to the Resource since
+  its presence in the Group is just a "reference" (or "read-only"). Write
+  operations on the Resource need to be done in its original location.
+
+### `groups.<STRING>.constraints.<RESOURCES>.<PATH>`
+
+This map key MUST reference the Resource attribute that is to be constrained.
+It MUST reference a scalar attribute (top-level, or nested within object or
+map, but MUST NOT reference items in arrays). It MUST only reference
+statically-defined attributes, not ones that are dynamically added via an
+`ifvalues` clause or via a `*` extension definition.
+
+The `<RESOURCES>` portion of the map key MUST be the plural name of the
+Resource type being referenced.
+
+The `<PATH>` portion of the map key MUST be a dot (`.`) notional traversal to
+the Resource attribute being constrained.
+
+### `groups.<STRING>.constraints.<RESOURCES>.<PATH>.default`
+
+This attribute defines the default value that MUST be used for the referenced
+Resource attribute. This MUST override any default value specified in the
+model for that attribute. See the
+[attribute `default` aspect](#attributesstringdefault) for additional
+information concerning default value processing, as they apply here as well
+with one exception: adding a default value here does not mandate that the
+referenced Resource attribute's `required` attribute be set to `true`.
+However, it would have the same net effect at runtime because a value would
+always be defined for that attribute.
+
+### `groups.<STRING>.constraints.<RESOURCES>.<PATH>.enum`
+
+This attribute defines the set of values that the referenced Resource attribute
+MUST be restricted to. The list's values MUST be valid per the Resource
+attribute's model definition (e.g. a proper subset of any `enum` defined, and
+of the same type). The list MUST NOT be empty.
+
+### `groups.<STRING>.constraints.<RESOURCES>.<PATH>.equals`
+
+Use of this attribute within a constraint MAY be used to ensure that all
+Resource instances within a Group instance have the same value for the
+specified attribute in all of their Versions.
+
+When present, this attribute MUST contain the dot (`.`) notation path in the
+Group instance that the referenced Resource attribute MUST match. If the two
+attributes exist and do not match then an error
+([constraint_failure](./spec.md#constraint_failure)) MUST be generated.
+
+If the referenced Group attribute does not exist, then the `equals` constraint
+enforcement for the Resource attribute MUST be silently ignored.
+
+If, after any potential `default` processing logic is performed, the Resource
+attribute (in any of its Versions) does not exist but the Group attribute does
+exist, then an error ([constraint_failure](./spec.md#constraint_failure)) MUST
+be generated.
+
+This attribute MUST reference a statically defined Group attribute. In other
+words, it can not reference an attribute defined by an `ifvalues` clause or a
+`*` extension definition.
+
 ### `groups.<STRING>.resources`
 - Type: Map where the key MUST be the plural name (`groups.resources.plural`)
   of the Resource type (`<RESOURCES>`).
@@ -634,18 +733,17 @@ The following describes the attributes of the Registry model:
   Version is supported for Resources of this type. Once set, the default
   Version MUST NOT change unless there is some explicit action by a client
   to change it - hence the term "sticky".
-- When not specified, the default value MUST be `true`.
+- When the server's `stickyversion` capability is `true`, then when this
+  aspect is not specified its default value MUST be `true`. Otherwise,
+  this aspect MUST always have a value of `false`.
 - A value of `true` indicates a client MAY select the default Version of
   a Resource via one of the methods described in this specification rather
   than the server always choosing the default Version.
 - A value of `false` indicates the server MUST choose which Version is the
   default Version.
-- An attempt to set the `defaultversionid` attribute when this aspect is
-  `false` MUST generate an error
-  ([setdefaultversionid_not_allowed](spec.md#setdefaultversionid_not_allowed)).
 - This attribute MUST NOT be `true` if `maxversions` is one (`1`). An attempt
-  to set it to `false` MUST generate an error
-  ([setdefaultversionsticky_false](./spec.md#setdefaultversionsticky_false).
+  to set it to `true` MUST generate an error
+  ([setdefaultversionsticky_false](./spec.md#setdefaultversionsticky_false)).
 
 ### `groups.<STRING>.resources.<STRING>.hasdocument`
 - Type: Boolean (`true` or `false`, case-sensitive).
@@ -658,6 +756,10 @@ The following describes the attributes of the Registry model:
   A value of `true` does not mean that these Resources are guaranteed to
   have a non-empty document, and a query to the Resource MAY return an
   empty document.
+
+  Attempts to change this value from `true` to `false` when there are existing
+  Versions with domain-specific documents MUST generate an error
+  ([hasdocument_violation](./spec.md#hasdocument_violation)).
 
   See
   [Document Resources vs Metadata-Only Resources](./spec.md#document-resources-vs-metadata-only-resources)
@@ -1086,6 +1188,8 @@ with respect to how models are defined or updated:
   aspect changed to `false`.
 - Specification-defined attributes that are `readonly` MUST NOT have this
   aspect changed to `false`.
+- Specification-defined attributes that define a `default` value MUST always
+  include a `default` value in its definition.
 
 Any specification attributes not included in a request to define, or update,
 a model MUST be included in the resulting full model. In other words, the full

--- a/core/spec.md
+++ b/core/spec.md
@@ -557,6 +557,13 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
         "alternative": "<URL>", ?
         "documentation": "<URL>"?
       }, ?
+      "constraints": {
+        "<RESOURCES>.<PATH>": {                # Resource-plural + attr path
+          "default": <VALUE>, ?                # Group specific default
+          "enum": [ <VALUE> * ], ?             # Allowed subset of values
+          "equals": "<PATH>" ?                 # Matching Group attribute path
+        } *
+      }, ?
 
       # Repeat for each Resource type in the Group
       "<RESOURCES>url": "<URL>",                   # e.g. "messagesurl"
@@ -1409,6 +1416,65 @@ of the existing entity. Then the existing entity would be deleted.
     }
     ```
 
+##### `constraints` Attribute
+
+- Type: Map of Resource attributes to be constrained just for this Group.
+
+  This attribute is used to create a set of Group instance specific constraints
+  on the Resources that exist within it. For example, with this mechanism a
+  Group can restrict all Resources within it to only have a subset of the
+  allowed values for a particular attribute. This allows for Group instance
+  specific restrictions without requiring the creating of new Resource types.
+
+  These restrictions are designed to only allow subsetting of the constraints
+  specified by the Resource type model and any Group model
+  [`constraints`](model.md#groupsstringconstraints) defined. They can not be
+  used to extend the allowable values of the attributes being constrained.
+
+  The definition of this map is the same as the Group type
+  [`constraints`](model.md#groupsstringconstraints) attribute.
+
+  Any map key value specified here that is the same as a key value included
+  in the Group type model's [`constraints`](model.md#groupsstringconstraints),
+  is interpreted as a request to further constrain the Resource attribute
+  being referenced. Therefore, the two definitions of the constraints are
+  layered (or merged), per the following rules:
+  - `default` attribute:
+    - If present here, it MUST be a valid value within the effective `enum`
+      values per the above `enum` bullet.
+    - If not present here, but specified at the Group type level, then the
+      value specified at the Group type level, MUST be valid per the effective
+      `enum` values per the above `enum` bullet.
+  - `enum` attribute:
+    - If present here and at the Group type level, then the values here MUST
+      be a subset of the values specified at the Group type level.
+    - If not present here, then any `enum` values specified at the Group type
+      level MUST apply.
+  - `equals` attribute:
+    - If present here and at the Group type level, then the values MUST be
+      the exact same.
+    - If not present here, then any `equals` value specified at the Group type
+      level MUST apply.
+
+- Constraints:
+  - OPTIONAL
+- Examples:
+  ```yaml
+  "constraints": {
+    "schemas.format" : {
+      "default": [ "jsonschema/draft-07" ],
+      "enum": [ "avro/1.9", "jsonschema/draft-07" ],
+      "equals": "format"
+    }
+  }
+  ```
+  The above example mandates that:
+  - All schema Resources within this group have a `format` values that
+    is either `avro/1.9` or `jsonschema/draft-07`. And when not specified,
+    it will default to `jsonschema/draft-07`.
+  - It also ensures that each Resource's `format` attribute is the same as
+    the owning Group's `format` values (if present).
+
 ### Registry Collections
 
 Registry collections (`<GROUPS>`, `<RESOURCES>` and `versions`) that are
@@ -2048,7 +2114,7 @@ The JSON serialization of the capabilities offering map MUST be of the form:
 {
   "<STRING>": {                   # Name of Capability attribute
     "type": "<TYPE>",
-    "enum": [ <VALUE>, * ], ?     # Allowed values for scalars
+    "enum": [ <VALUE> * ], ?      # Allowed values for scalars
     "min": <VALUE>, ?
     "max": <VALUE>, ?
     "documentation": "<URL>", ?
@@ -2554,9 +2620,9 @@ The overall processing of the request message is as follows:
     [`versionmode`](./model.md#groupsstringresourcesstringversionmode) value.
 4.  Process the `meta` sub-object, if present.
 5.  Update [`meta.defaultversionid`](#defaultversionid-attribute) as needed.
-6.  Enforce the [Version format checks](#format-attribute). Including the
-    enforcement of the Resource model's `consistentformat` aspect if set to
-    `true`.
+6.  Enforce the [Version format checks](#format-attribute) and the [Group-level
+    constraints](model.md#groupsstringconstraints). Including the enforcement
+    of the Resource model's `consistentformat` aspect if set to `true`.
 7.  Enforce the [Version compatibility checks](#compatibility-attribute).
 8.  Enforce the [Resource `maxversions`
     constraints](./model.md#groupsstringresourcesstringmaxversions). Note that
@@ -3069,6 +3135,11 @@ information about the management of default Versions.
   - When specified, it MUST be a case-sensitive `true` or `false`.
   - When specified in a request, a value of `null` MUST be interpreted as a
     request to delete the attribute, implicitly setting it to `false`.
+
+Attempts to set this attribute to `true` when the Resource's
+[`setdefaultversionsticky`](./model.md#groupsstringresourcesstringsetdefaultversionsticky)
+model aspect is `false` MUST generate an error
+[`defaultversionsticky_not_allowed`](#defaultversionsticky_not_allowed).
 
 See [`defaultversionid` Attribute](#defaultversionid-attribute) for more
 information on the relationship between these two attributes.
@@ -4281,8 +4352,12 @@ The following rules apply:
 - A value of `request` MUST only be used on APIs that allow the creation of
   only a single new Version. In the case of HTTP, that is the `POST` API
   directed to a Resource. This is because no other operation allows for the
-  creation of a single Version without specifying its `versionid`. Use of this
-  value on an inappropriate API MUST generate an error ([bad_flag](#bad_flag)).
+  creation of a single Version without specifying its `versionid`. Using it
+  when more than one Version is created MUST generate an error
+  ([too_many_versions](#too_many_versions)).  Other uses of this value on an
+  inappropriate API MUST generate an error ([bad_flag](#bad_flag)).
+- If a value of `request` was used but no Version was created for the request,
+  then an error ([defaultversionid_request](#defaultversionid_request)) MUST
   be generated.
 - If a non-`null` and non-`request` value does not reference an existing
   Version of the Resource, after all Version processing is completed, then an
@@ -4307,7 +4382,7 @@ When a request is directed at a collection of Groups, Resources or Versions,
 the `Sort` flag MAY be used to indicate the order in which the entities of
 that collection are to be returned (i.e. sorted). Use of the `sort` flag
 on a non-collection result MUST generate an error
-([sort_noncollection](#sort_noncollection).
+([sort_noncollection](#sort_noncollection)).
 
 This flag MUST include a single parameter, a string containing the attribute
 (`<ATTRIBUTE>`) name to use as the "sort key" plus an OPTIONAL indication of
@@ -4658,6 +4733,15 @@ field is just a substitution value and MUST NOT be empty.
 * Args:
   - `compat`: The Resource's `meta.compatibility` value.
 
+### constraint_failure
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#constraint_failure`
+* Code: `400 Bad Request`
+* Subject: `<resource_xid>`
+* Title: `The request would result in one or more Versions of "<subject>" not being compliant with its owning Group's "equals" constraint for attribute "<path>".`
+* Args:
+  - `path`: The dot (`.`) notion traversal path to the Resource's attribute being constrained.
+
 ### data_retrieval_error
 
 * Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#data_retrieval_error`
@@ -4665,6 +4749,20 @@ field is just a substitution value and MUST NOT be empty.
 * Subject: `<path>`
 * Title: `The server was unable to retrieve all of the requested data.`
 * Detail: Suggestion: which entity's data was problematic, and why.
+
+### defaultversionid_request
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#defaultversionid_request`
+* Code: `400 Bad Request`
+* Subject: `<resource_xid>`
+* Title: `Processing "<subject>", the "defaultversionid" attribute is not allowed to be "request" since a Version wasn't processed.`
+
+### defaultversionsticky_not_allowed
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#defaultversionsticky_not_allowed`
+* Code: `400 Bad Request`
+* Subject: `<resource_xid>`
+* Title: `Setting "defaultversionsticky" to "true" is not allowed for "<subject>".`
 
 ### extra_xref_attribute
 
@@ -4715,6 +4813,13 @@ field is just a substitution value and MUST NOT be empty.
 * Title: `Attribute "<name>" is invalid. Only Group types are allowed to be specified on this request: <subject>.`
 * Args:
   - `name`: The name of the attribute in question.
+
+### hasdocument_violation
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#hasdocument_violation`
+* Code: `400 Bad Request`
+* Subject: `<version_xid>`
+* Title: `The request would cause Version "<subject>" to be non-compliant. The Resource model has "hasdocument" set to "false" but this Version has document content.`
 
 ### inline_noninlineable
 
@@ -4916,9 +5021,7 @@ something unexpected happened in the server that caused an error condition.
 * Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#setdefaultversionid_not_allowed`
 * Code: `400 Bad Request`
 * Subject: `<resource_xid>`
-* Title: `Processing "<subject>", the "setdefaultversionid" flag is not allowed to be specified for entities of type "<singular>".`
-* Args:
-  - `singular`: The "singular" type name of the offending Resource.
+* Title: `Setting "defaultversionid" is not allowed for "<subject>".`
 
 ### setdefaultversionsticky_false
 
@@ -4941,6 +5044,13 @@ something unexpected happened in the server that caused an error condition.
 * Subject: `<request_path>`
 * Title: `The size of the response is too large to return in a single response.`
 * Detail: Suggestion: list of attributes that are too large.
+
+### too_many_versions
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#too_many_versions`
+* Code: `400 Bad Request`
+* Subject: `<request_path>`
+* Title: `When the "setdefaultversionid" flag is set to "request", only one Version is allowed to be specified in the request message.`
 
 ### unknown_attribute
 

--- a/schema/model.json
+++ b/schema/model.json
@@ -13,6 +13,12 @@
         }
       },
 
+      "constraints": {
+        "schemas.format": {
+          "equals": "format"
+        }
+      },
+
       "resources": {
         "schemas": {
           "singular": "schema",

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -346,6 +346,23 @@ containing 5 schemas.
 }
 ```
 
+There might be cases where all schemas within a schemagroup need to have the
+same `format` value. To enable this, set the schemagroup's `format` value to
+the string that all schemas/Versions within that schemagroup need to use.
+
+Additionally, if desired, a schemagroup-instance level constraint MAY be added:
+
+```yaml
+"constraints": {
+  "schemas.format": {
+    "default": "JsonSchema/draft-07"
+  }
+}
+```
+ 
+This will define a schemagroup-specific default value for the schemas' `format`
+value so clients would not need to specify it manually for each schema.
+
 ### 4.2. Schema Resources
 
 The Resource (`<RESOURCE>`) inside of Schema Groups is named `schema`. The

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -7,51 +7,51 @@ verify: spellcheck ticks badhrefs tabcheck errorcheck samplescheck \
 	testpython links website
 
 spellcheck:
-	@echo "Checking for spelling mistakes"
+	@echo "Checking for spelling mistakes:"
 	tools/spellcheck */README.md */spec.md core/*.md \
 		docs/share/README.md */samples/README.md */samples/*/README.md
 	@echo
 
 tabcheck:
-	@echo "Checking for tabs and extra spaces"
+	@echo "Checking for tabs and extra spaces:"
 	tools/tabcheck `find . -name "*.md" -o -name "*.json"`
 	@echo
 
 ticks:
-	@echo "Checking for uneven back-ticks"
+	@echo "Checking for uneven back-ticks:"
 	@(! grep '^[^`]*`[^`]*$$' core/*.md)
 	@echo
 
 badhrefs:
-	@echo "Checking for hrefs that have /#"
+	@echo "Checking for hrefs that have /#:"
 	@(! grep -e '/#' -r --include="*.md")
 	@echo
 
 errorcheck:
-	@echo "Look for unused errors in the specs"
+	@echo "Validating the errors in the specs:"
 	tools/errorcheck core/spec.md core/model.md core/http.md
 	@echo
 
 samplescheck:
-	@echo "Check for too verbose samples"
+	@echo "Check for too verbose samples:"
 	tools/samplescheck */model.json */samples/*json */samples/*/*json
 	@echo
 
 loadpython:
-	@echo Loading python deps
+	@echo "Loading python deps:"
 	@python -m pip install -qq -r tools/requirements.txt
 
 testpython: loadpython
-	@echo Testing our python tools
+	@echo "Testing our python tools:"
 	@pytest tools/
 
 links: loadpython
-	@echo Verifying links in our docs
+	@echo "Verifying links in our docs:"
 	@python tools/verify.py .
 	@echo
 
 models:
-	@echo "Verifying the models are valid"
+	@echo "Verifying the models are valid:"
 	@# Note this will use a local 'xr' if available so that local build/test
 	@# of 'xr' can be done
 	if which xr ; then \
@@ -65,7 +65,7 @@ models:
 	@echo
 
 website:
-	@echo If available, verify the website generation code works too
+	@echo "If available, verify the website generation code works too:"
 	@if test -f `pwd -P`/../xregistry.github.io/tools/buildsite ; then \
 	  XR_SPEC=`pwd -P` `pwd -P`/../xregistry.github.io/tools/buildsite && \
 	    rm -rf xreg ; \
@@ -75,7 +75,7 @@ website:
 	@echo
 
 makeschema: loadpython
-	@echo Rebuilding the schemas...
+	@echo "Rebuilding the schemas..."
 	@python tools/schema-generator.py --type json-schema --schema-id https://xregistry.io/xreg/xregistryspecs/schema-v1/schemas/document-schema.json --output schema/schemas/document-schema.json schema/model.json
 	@python tools/schema-generator.py --type avro-schema --output schema/schemas/document-schema.avsc schema/model.json
 	@python tools/schema-generator.py --type openapi --output schema/schemas/openapi.json schema/model.json

--- a/tools/errorcheck
+++ b/tools/errorcheck
@@ -55,7 +55,7 @@ for file in $* ; do
   IFS="!" lines=$(sed -r -n "/$START_PATTERN/,/$END_PATTERN/p" $file | \
     sed -n 's/##* //p')
 
-  [[ "$lines" == "" ]] && echo "No error defined" && continue
+  [[ "$lines" == "" ]] && echo "  - No errors defined" && continue
 
   diff=$(IFS="!" diff <(echo "$lines") <(echo "$lines" | sort) || true)
   if [[ "$diff" != "" ]] ; then


### PR DESCRIPTION
- reword an error message to be more generic
- change the default for ResourceModel.setdefaultversionsticky based on `stickyversions` capability
- fix some errors
- add support for "constraints" (at Group model level, and Group Instance level):

```
      "constraints": {
        "<RESOURCES>.<PATH>": {          # Resource-plural + attribute path
          "default": <VALUE>, ?          # Group specific default
          "enum": [ <VALUE> * ], ?       # Allowed subset of values
          "equals": "<PATH>" ?           # Matching Group attribute path
        } *
      }, ?
```