### PR TITLE
Week of June 15

### DIFF
--- a/core/model.md
+++ b/core/model.md
@@ -2,7 +2,7 @@
 
 <!-- words: compat validatecompatibility validateformat strictvalidation -->
 <!-- words: matchcase compatibilityvalidated formatvalidated -->
-<!-- words: validators -->
+<!-- words: validators matchversions -->
 
 ## Abstract
 
@@ -84,6 +84,7 @@ The overall format of a model definition is as follows:
       "enum": [ <VALUE> * ], ?         # Array of scalars of type "<TYPE>"
       "strict": <BOOLEAN>, ?           # Just "enum" values or not. Default=true
       "matchcase": <BOOLEAN>, ?        # Strings case-sensitive? Default=false
+      "matchversions": <BOOLEAN>, ?    # Same for all Versions? Default=false
       "readonly": <BOOLEAN>, ?         # From client's POV. Default=false
       "immutable": <BOOLEAN>, ?        # Once set, can't change. Default=false
       "required": <BOOLEAN>, ?         # Default=false
@@ -122,7 +123,7 @@ The overall format of a model definition is as follows:
       "constraints": {
         "<RESOURCES>.<PATH>": {          # Resource-plural + attribute path
           "default": <VALUE>, ?          # Group specific default
-          "enum": [ <VALUE> * ], ?       # Allowed subset of values
+          "enum": [ <VALUE> + ], ?       # Allowed subset of values
           "equals": "<PATH>" ?           # Matching Group attribute path
         } *
       }, ?
@@ -324,8 +325,28 @@ The following describes the attributes of the Registry model:
 - OPTIONAL.
 - Indicates whether the `string` attribute's value MUST be compared with
   a matching value in a case-sensitive way, or not.
-- This attribute MUST NOT be `true` if the owning attribute's `type` (or
+- This aspect MUST NOT be `true` if the owning attribute's `type` (or
   `item.type` for non-scalars) is not `"string"`.
+- When not specified, the default value MUST be `false`.
+
+### `attributes.<STRING>.matchversions`
+- Type: Boolean.
+- OPTIONAL.
+- Indicates whether all Versions of a Resource instance MUST have the same
+  value for this attribute (or MUST be missing from all Versions). If an
+  inconsistency is found then an error
+  ([mismatched_version_attribute](spec.md#mismatched_version_attribute)) MUST
+  be generated.
+- This aspect MUST only be `true` for attribute definitions that:
+  - Are within a [Resource type's versioned
+    attributes](#groupsstringresourcesstringattributes) section.
+  - Are for scalar typed attributes.
+  - Are statically defined. Meaning, not defined as part of a `ifvalues` clause
+    or via a `*` extension definition
+  - Are not defined within an array or map. Within an object is allowed.
+- In the case of the attribute type being a `string`, the comparison MUST take
+  into account the [matchcase](#attributesstringmatchcase) aspect of the
+  attribute.
 - When not specified, the default value MUST be `false`.
 
 ### `attributes.<STRING>.readonly`
@@ -402,6 +423,9 @@ The following describes the attributes of the Registry model:
   default value MUST only apply to new, or subsequent updates (when set to
   `null`, which would reset it to the current default value) of existing,
   instances of the attribute.
+- If the attribute is defined to have an `enum` list, and its `strict` aspect
+  is `true`, then if a `default` value is specified it MUST be one of those
+  `enum` values.
 
 ### `attributes.<STRING>.attributes`
 - Type: Object, see `attributes` above.
@@ -583,8 +607,8 @@ a constraint are applied to such xref'd Resources:
 ### `groups.<STRING>.constraints.<RESOURCES>.<PATH>`
 
 This map key MUST reference the Resource attribute that is to be constrained.
-It MUST reference a scalar attribute (top-level, or nested within object or
-map, but MUST NOT reference items in arrays). It MUST only reference
+It MUST reference a scalar attribute (top-level, or nested within objects) but
+but MUST NOT reference items in arrays or maps). It MUST only reference
 statically-defined attributes, not ones that are dynamically added via an
 `ifvalues` clause or via a `*` extension definition.
 
@@ -596,33 +620,48 @@ the Resource attribute being constrained.
 
 ### `groups.<STRING>.constraints.<RESOURCES>.<PATH>.default`
 
-This attribute defines the default value that MUST be used for the referenced
+This aspect defines the default value that MUST be used for the referenced
 Resource attribute. This MUST override any default value specified in the
 model for that attribute. See the
 [attribute `default` aspect](#attributesstringdefault) for additional
 information concerning default value processing, as they apply here as well
 with one exception: adding a default value here does not mandate that the
-referenced Resource attribute's `required` attribute be set to `true`.
+referenced Resource attribute's `required` aspect be set to `true`.
 However, it would have the same net effect at runtime because a value would
 always be defined for that attribute.
 
+Note, if the constraint does not define a new `enum` set, but a `default` value
+is defined, then if the referenced attribute has an `enum` set and has its
+`strict` aspect set to `true` then this `default` value MUST be one of those
+`enum` values.
+
 ### `groups.<STRING>.constraints.<RESOURCES>.<PATH>.enum`
 
-This attribute defines the set of values that the referenced Resource attribute
-MUST be restricted to. The list's values MUST be valid per the Resource
-attribute's model definition (e.g. a proper subset of any `enum` defined, and
-of the same type). The list MUST NOT be empty.
+This aspect defines the set of values that the referenced Resource attribute
+MUST be restricted to regardless of whether the Resource's
+[`strict`](#attributesstringstrict) attribute is set to `true` or not. The
+list's values MUST be valid per the Resource attribute's model definition
+(e.g. a proper subset of any `enum` defined if the Resource's `enum` is
+[`strict`](#attributesstringstrict), and of the same type).
+
+As with the [`enum` attribute](#attributesstringenum) defined for attributes,
+an empty `enum` list in a constraints MUST be treated the same as no `enum`
+aspect at all and no further constraints on the allowable attribute values are
+applied beyond what the attribute itself defines.
+
+If an `enum` set is defined, but a `default` values is not, then any `default`
+value specified in the attribute itself MUST be part of the `enum` set.
 
 ### `groups.<STRING>.constraints.<RESOURCES>.<PATH>.equals`
 
-Use of this attribute within a constraint MAY be used to ensure that all
+Use of this aspect within a constraint MAY be used to ensure that all
 Resource instances within a Group instance have the same value for the
 specified attribute in all of their Versions.
 
-When present, this attribute MUST contain the dot (`.`) notation path in the
-Group instance that the referenced Resource attribute MUST match. If the two
-attributes exist and do not match then an error
-([constraint_failure](./spec.md#constraint_failure)) MUST be generated.
+When present, this aspect MUST contain the dot (`.`) notation path in the
+Group instance that the referenced Resource attribute MUST match. In the
+case of the attribute type being a `string`, the comparison MUST take into
+account the [matchcase](#attributesstringmatchcase) aspect of the attribute.
 
 If the referenced Group attribute does not exist, then the `equals` constraint
 enforcement for the Resource attribute MUST be silently ignored.
@@ -634,7 +673,11 @@ be generated.
 
 This attribute MUST reference a statically defined Group attribute. In other
 words, it can not reference an attribute defined by an `ifvalues` clause or a
-`*` extension definition.
+`*` extension definition. Nor can it reference an attribute within an array.
+
+Note that if a Resource type's versioned attribute has a `matchversions` aspect
+set to `false`, then this feature will have the same net affect as
+`matchversions` for that attribute being `true`.
 
 ### `groups.<STRING>.resources`
 - Type: Map where the key MUST be the plural name (`groups.resources.plural`)
@@ -709,6 +752,13 @@ words, it can not reference an attribute defined by an `ifvalues` clause or a
   A special case for the pruning rules is that if `maxversions` is set to
   one (1), then the "default" Version is not skipped, which means it will be
   deleted and the new Version will become "default".
+- An attempt to change `maxversions` to `1` when there are existing Resource
+  instances that have their `defaultversionsticky` attribute set to `true` MUST
+  generate an error
+  ([setdefaultversionsticky_false](spec.md#setdefaultversionsticky_false)).
+  See
+  [`defaultversionsticky` Attribute](spec.md#defaultversionsticky-attribute)
+  for additional information.
 
 ### `groups.<STRING>.resources.<STRING>.setversionid`
 - Type: Boolean (`true` or `false`, case-sensitive).

--- a/core/model.schema.json
+++ b/core/model.schema.json
@@ -83,6 +83,25 @@
               },
               "description": "Include these Resources"
             },
+            "constraints": {
+              "type": "object",
+              "properties": {
+                "default": {
+                  "type": [ "string", "number", "integer", "boolean" ]
+                },
+                "enum": {
+                  "type": "array",
+                  "items": {
+                    "type": [ "string", "number", "integer", "boolean" ]
+                  },
+                  "minItems": 1
+                },
+                "equals": {
+                  "type": "string"
+                }
+              }
+              "description": "Group level constraints over resources"
+            }
             "resources": {
               "type": "object",
               "description": "Resource types within this group",
@@ -309,6 +328,11 @@
           "type": "boolean",
           "default": false,
           "description": "Whether string value comparisons are case-sensitive"
+        },
+        "matchversions": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether attribute must be the same across all versions"
         },
         "readonly": {
           "type": "boolean",

--- a/core/primer.md
+++ b/core/primer.md
@@ -1,7 +1,7 @@
 # xRegistry Primer
 
 <!-- words: validatecompatibility validateformat strickvalidation -->
-<!-- words: strictvalidation -->
+<!-- words: strictvalidation matchversions -->
 
 <!-- no verify-specs -->
 
@@ -1016,3 +1016,12 @@ This is being called out because for light-weight server implementations that
 do not support validation checks, a user might define a Resource type with
 those aspects enabled without realizing they're defining a potentially
 unusable Resource type - if clients use the `format` attribute.
+
+## Constraints and MatchVersions Features
+
+These features limit the validation of attributes down to simple attributes
+(scalars in objects). Supporting attributes that are more complex, for example
+within maps, arrays, `ifvalues` clauses or `*` extensions, might be possible
+but the decision to limit it was made to ensure broad support across as many
+possible implementation choices as possible, while also keeping the code
+complexity burden to a minimum.

--- a/core/spec.md
+++ b/core/spec.md
@@ -3,6 +3,7 @@
 <!-- words: validatecompatibility validateformat strictvalidation matchcase -->
 <!-- words: compat formatvalidated compatibilityvalidated -->
 <!-- words: compat formatvalidatedreason compatibilityvalidatedreason -->
+<!-- words: matchversions -->
 
 ## Abstract
 
@@ -466,6 +467,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
         "enum": [ <VALUE> * ], ?        # Array of scalars of type `"type"`
         "strict": <BOOLEAN>, ?          # Just "enum" values? Default=true
         "matchcase": <BOOLEAN>, ?       # Strings case-sensitive? Def=false
+        "matchversions": <BOOLEAN>, ?   # Same for all Versions? Def=false
         "readonly": <BOOLEAN>, ?        # From client's POV. Default=false
         "immutable": <BOOLEAN>, ?       # Once set, can't change. Default=false
         "required": <BOOLEAN>, ?        # Default=false
@@ -556,7 +558,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
       "constraints": {
         "<RESOURCES>.<PATH>": {                # Resource-plural + attr path
           "default": <VALUE>, ?                # Group specific default
-          "enum": [ <VALUE> * ], ?             # Allowed subset of values
+          "enum": [ <VALUE> + ], ?             # Allowed subset of values
           "equals": "<PATH>" ?                 # Matching Group attribute path
         } *
       }, ?
@@ -1437,10 +1439,10 @@ of the existing entity. Then the existing entity would be deleted.
   layered (or merged), per the following rules:
   - `default` attribute:
     - If present here, it MUST be a valid value within the effective `enum`
-      values per the above `enum` bullet.
+      values per the `enum` bullet below.
     - If not present here, but specified at the Group type level, then the
       value specified at the Group type level, MUST be valid per the effective
-      `enum` values per the above `enum` bullet.
+      `enum` values per the `enum` bullet below.
   - `enum` attribute:
     - If present here and at the Group type level, then the values here MUST
       be a subset of the values specified at the Group type level.
@@ -2602,10 +2604,12 @@ The overall processing of the request message is as follows:
     [`versionmode`](./model.md#groupsstringresourcesstringversionmode) value.
 4.  Process the `meta` sub-object, if present.
 5.  Update [`meta.defaultversionid`](#defaultversionid-attribute) as needed.
-6.  Enforce the [Version format checks](#format-attribute) and the [Group-level
-    constraints](model.md#groupsstringconstraints).
-7.  Enforce the [Version compatibility checks](#compatibility-attribute).
-8.  Enforce the [Resource `maxversions`
+6.  Enforce the [Version format checks](#format-attribute).
+7.  Enforce the [Group-level constraints](model.md#groupsstringconstraints).
+8.  Enforce the [Resource `matchversions`
+    checks](model.md#attributesstringmatchversions).
+9.  Enforce the [Version compatibility checks](#compatibility-attribute).
+10. Enforce the [Resource `maxversions`
     constraints](./model.md#groupsstringresourcesstringmaxversions). Note that
     this might require updating the [`ancestor` values](#ancestor-attribute)
     again after some Versions have been deleted.
@@ -3116,7 +3120,7 @@ information about the management of default Versions.
   - When specified, it MUST be a case-sensitive `true` or `false`.
   - When specified in a request, a value of `null` MUST be interpreted as a
     request to delete the attribute, implicitly setting it to `false`.
-  - When a Resource's `maxversions` is set to `1`, than an attempt to set this
+  - When a Resource type's `maxversions` is set to `1`, any attempt to set this
     this attribute to `true` MUST generate an error
     ([setdefaultversionsticky_false](#setdefaultversionsticky_false)) since
     setting a default/sticky Version is unnecessary when there can only be
@@ -3136,6 +3140,10 @@ use the following definition:
   "default": false
 }
 ```
+
+Likewise, forcing all Resource instances to have "sticky" Versions MAY be
+achieved via the same mechanism but using `true` instead of `false` in the
+`enum` and `default` aspects.
 
 See [`defaultversionid` Attribute](#defaultversionid-attribute) for more
 information on the relationship between these two attributes.
@@ -4864,6 +4872,15 @@ field is just a substitution value and MUST NOT be empty.
   - `singular`: The "singular" name of the model entity being processed.
   - `invalid_id`: The ID values specified in the request.
   - `expected_id`: The ID that was supposed to be used instead.
+
+### mismatched_version_attribute
+
+* Type: `https://github.com/xregistry/spec/blob/main/core/spec.md#mismatched_version_attribute`
+* Code: `400 Bad Request`
+* Subject: `<resource_xid>`
+* Title: `The request would cause the "<name>" attribute across the Versions of "<subject>" to be different.`
+* Args:
+  - `name`: The dot (`.`) notation path to the attribute causing the violation.
 
 ### misplaced_epoch
 

--- a/schema/model.json
+++ b/schema/model.json
@@ -32,7 +32,8 @@
           "attributes": {
             "format": {
               "type": "string",
-              "required": true
+              "required": true,
+              "matchversions": true
             },
             "*": {
               "name": "*",


### PR DESCRIPTION
- add support for "matchversions" (and add to schema spec's model)
- make "constraints.equals" use "matchcase" when doing string compares
- clarity that setting maxversions=1 when there are sticky versions -> error
- tell people who to require sticky versions (set defaultversionsticky'e enum/default to "true")


Fixes #478 
Fixes #477 