### PR TITLE
Week of Jul 6

### DIFF
--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -163,7 +163,7 @@ endpoint with a single, embedded message definition using an embedded Protobuf
           "description": "device telemetry event",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
-          "ancestor": "1.0",
+          "ancestorid": "1.0",
 
           "format": "CloudEvents/1.0",
           "metadata": {
@@ -271,7 +271,7 @@ other scenarios:
           "description": "device telemetry event",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
-          "ancestor": "1.0",
+          "ancestorid": "1.0",
 
           "format": "CloudEvents/1.0",
           "metadata": {
@@ -331,7 +331,7 @@ other scenarios:
           "description": "device telemetry event data",
           "createdat": "2024-04-30T12:00:00Z",
           "modifiedat": "2024-04-31T12:00:00Z",
-          "ancestor": "1.0",
+          "ancestorid": "1.0",
 
           "format": "Protobuf/3.0",
           "schema": "syntax = \"proto3\"; message Metrics { float metric = 1;}",

--- a/core/http.md
+++ b/core/http.md
@@ -1013,7 +1013,7 @@ PATCH /capabilities
 
 A server MUST support clients retrieving its full
 [model definition](./model.md#registry-model) via an HTTP `GET` directed to
-the stand-lone `model` entity.
+the stand-alone `model` entity.
 
 The request MUST be of the form:
 
@@ -3047,7 +3047,7 @@ HTTP/1.1 204 No Content
 
 As defined by the [core specification](./spec.md#xregistry-discovery), clients
 MAY query an xRegistry server for the list of additional xRegistry servers
-that might be of interest. If supported, the Registry-specific discovery file,
+that might be of interest. If supported, the Registry-based discovery file,
 for an HTTP server, MUST be available at the root of the Registry (e.g. as a
 sibling API to `/model`) via the `/.xregistry` API:
 
@@ -3065,6 +3065,7 @@ Content-Type: application/json; charset=utf-8
     "URL", *
   }
 }
+```
 
 Note that unlike the [Host-based Discovery](./spec.md#host-based-discovery)
 mechanism, this API includes a dot (`.`) before `xregistry` to avoid any

--- a/core/http.md
+++ b/core/http.md
@@ -59,6 +59,7 @@ model and semantics that apply to all protocols.
     - [`GET /<GROUPS>/<GID>/<RESOURCES>/<RID>/versions/<VID>`](#get-groupsgidresourcesridversionsvid)
     - [`PATCH` and `PUT /<GROUPS>/<GID>/<RESOURCES>/<RID>/versions/<VID>`](#patch-and-put-groupsgidresourcesridversionsvid)
     - [`DELETE /<GROUPS>/<GID>/<RESOURCES>/<RID>/versions/<VID>`](#delete-groupsgidresourcesridversionsvid)
+  - [xRegistry Discovery](#xregistry-discovery)
 - [Request Flags / Query Parameters](#request-flags--query-parameters)
 - [HTTP Header Values](#http-header-values)
 - [Error Processing](#error-processing)
@@ -1010,7 +1011,7 @@ PATCH /capabilities
 
 #### `GET /model`
 
-A server MAY support clients retrieving its full
+A server MUST support clients retrieving its full
 [model definition](./model.md#registry-model) via an HTTP `GET` directed to
 the stand-lone `model` entity.
 
@@ -1633,7 +1634,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
-xRegistry-ancestor: <STRING>
+xRegistry-ancestorid: <STRING>
 xRegistry-<RESOURCE>url: <URL> ?           # End of default Version attributes
 xRegistry-metaurl: <URL>                   # Resource-level attributes
 xRegistry-versionsurl: <URL>
@@ -1678,7 +1679,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
-xRegistry-ancestor: <STRING>
+xRegistry-ancestorid: <STRING>
 xRegistry-<RESOURCE>url: <URL> ?           # End of default Version attributes
 Location: <URL> ?
 Content-Location: <URL> ?
@@ -1755,7 +1756,7 @@ Link: <https://example.com/endpoints/ep1/messages&page=2>;rel=next;count=100
     "isdefault": true,
     "createdat": "2024-04-30T12:00:00Z",
     "modifiedat": "2024-04-30T12:00:01Z",
-    "ancestor": "1.0",
+    "ancestorid": "1.0",
 
     "metaurl": "https://example.com/endpoints/ep1/messages/msg1/meta",
     "versionsurl": "https://example.com/endpoints/ep1/messages/msg1/versions",
@@ -1955,7 +1956,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
-xRegistry-ancestor: <STRING>
+xRegistry-ancestorid: <STRING>
 xRegistry-<RESOURCE>url: <URL> ?       # If Resource is not in body
 xRegistry-metaurl: <URL>
 xRegistry-versionsurl: <URL>
@@ -1998,7 +1999,7 @@ Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/1
   "isdefault": true,
   "createdat": "2024-04-30T12:00:00Z",
   "modifiedat": "2024-04-30T12:00:01Z",
-  "ancestor": "1",
+  "ancestorid": "1",
 
   "metaurl": "https://example.com/endpoints/ep1/messages/msg1/meta",
   "versionsurl": "https://example.com/endpoints/ep1/messages/msg1/versions",
@@ -2060,7 +2061,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP> ?
 xRegistry-modifiedat: <TIMESTAMP> ?
-xRegistry-ancestor: <STRING> ?
+xRegistry-ancestorid: <STRING> ?
 xRegistry-<RESOURCE>url: <URL> ?
 
 ... Resource document excluded for brevity ... ?
@@ -2091,7 +2092,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
-xRegistry-ancestor: <STRING>
+xRegistry-ancestorid: <STRING>
 xRegistry-<RESOURCE>url: <URL> ?       # If Resource is not in body
 xRegistry-metaurl: <URL>
 xRegistry-versionsurl: <URL>
@@ -2130,7 +2131,7 @@ xRegistry-xid: /endpoints/ep1/messages/msg1
 xRegistry-epoch: 1
 xRegistry-name: Blob Created
 xRegistry-isdefault: true
-xRegistry-ancestor: 1
+xRegistry-ancestorid: 1
 xRegistry-metaurl: https://example.com/endpoints/ep1/messages/msg1/meta
 xRegistry-versionsurl: https://example.com/endpoints/ep1/messages/msg1/versions
 xRegistry-versionscount: 1
@@ -2174,7 +2175,7 @@ Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/1
   "description": "a cool event",
   "createdat": "2024-04-30T12:00:00Z",
   "modifiedat": "2024-04-30T12:00:01Z",
-  "ancestor": "1",
+  "ancestorid": "1",
 
   "message": {
     # Updated definition of a "Blob Created" event excluded for brevity
@@ -2237,7 +2238,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP> ?
 xRegistry-modifiedat: <TIMESTAMP> ?
-xRegistry-ancestor: <STRING> ?
+xRegistry-ancestorid: <STRING> ?
 xRegistry-<RESOURCE>url: <URL> ?
 
 ... Version document excluded for brevity ... ?
@@ -2265,7 +2266,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
-xRegistry-ancestor: <STRING>
+xRegistry-ancestorid: <STRING>
 xRegistry-<RESOURCE>url: <URL> ?       # If Resource is not in body
 Location: <URL> ?                      # If 201 or 303 is returned
 Content-Location: <URL> ?
@@ -2301,7 +2302,7 @@ xRegistry-xid: /endpoints/ep1/messages/msg1/versions/2
 xRegistry-epoch: 1
 xRegistry-name: Blob Created
 xRegistry-isdefault: true
-xRegistry-ancestor: 1
+xRegistry-ancestorid: 1
 Location: https://example.com/endpoints/ep1/messages/msg1/versions/2
 Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/2
 Content-Disposition: msg1
@@ -2342,7 +2343,7 @@ Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/1
   "description": "a cool event",
   "createdat": "2024-04-30T12:00:00Z",
   "modifiedat": "2024-04-30T12:00:01Z",
-  "ancestor": "1",
+  "ancestorid": "1",
 
   "message": {
     # Updated definition of a "Blob Created" event excluded for brevity
@@ -2564,7 +2565,7 @@ Link: <https://example.com/endpoints/ep1/messages/msg1/versions&page=2>;rel=next
     "isdefault": true,
     "createdat": "2024-04-30T12:00:00Z",
     "modifiedat": "2024-04-30T12:00:01Z",
-    "ancestor": "1.0"
+    "ancestorid": "1.0"
   }
 }
 ```
@@ -2770,7 +2771,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
-xRegistry-ancestor: <STRING>
+xRegistry-ancestorid: <STRING>
 Location: <URL> ?                        # If 303 is returned
 Content-Disposition: <STRING> ?
 
@@ -2804,7 +2805,7 @@ Content-Type: application/json; charset=utf-8
   "isdefault": true,
   "createdat": "2024-04-30T12:00:00Z",
   "modifiedat": "2024-04-30T12:00:01Z",
-  "ancestor": "1.0"
+  "ancestorid": "1.0"
 }
 ```
 
@@ -2825,7 +2826,7 @@ xRegistry-epoch: 2
 xRegistry-isdefault: true
 xRegistry-createdat: 2024-04-30T12:00:00Z
 xRegistry-modifiedat: 2024-04-30T12:00:01Z
-xRegistry-ancestor: 1.0
+xRegistry-ancestorid: 1.0
 Content-Disposition: myschema
 
 { ... Contents of a schema doc excluded for brevity ...  }
@@ -2886,7 +2887,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP> ?
 xRegistry-modifiedat: <TIMESTAMP> ?
-xRegistry-ancestor: <STRING> ?
+xRegistry-ancestorid: <STRING> ?
 xRegistry-<RESOURCE>url: <URL> ?
 
 ... Version document excluded for brevity ... ?
@@ -2917,7 +2918,7 @@ xRegistry-icon: <URL> ?
 xRegistry-labels.<KEY>: <STRING> *
 xRegistry-createdat: <TIMESTAMP>
 xRegistry-modifiedat: <TIMESTAMP>
-xRegistry-ancestor: <STRING>
+xRegistry-ancestorid: <STRING>
 xRegistry-<RESOURCE>url: <URL> ?       # If Resource is not in body
 Location: <URL> ?                      # If 201 or 303 is returned
 Content-Location: <URL> ?
@@ -2948,7 +2949,7 @@ xRegistry-xid: /endpoints/ep1/messages/msg1/versions/v2.0
 xRegistry-epoch: 1
 xRegistry-name: Blob Created v2
 xRegistry-isdefault: true
-xRegistry-ancestor: v1.0
+xRegistry-ancestorid: v1.0
 Location: https://example.com/endpoints/ep1/messages/msg1/versions/v2.0
 Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/v2.0
 Content-Disposition: msg1
@@ -2987,7 +2988,7 @@ Content-Location: https://example.com/endpoints/ep1/messages/msg1/versions/v2.0
   "description": "a cool event",
   "createdat": "2024-04-30T12:00:00Z",
   "modifiedat": "2024-04-30T12:00:01Z",
-  "ancestor": "v1.0",
+  "ancestorid": "v1.0",
 
   "message": {
     # Updated definition of a "Blob Created" event excluded for brevity
@@ -3041,6 +3042,33 @@ DELETE /endpoints/ep1/messages/msg1/versions?epoch=5
 ```
 HTTP/1.1 204 No Content
 ```
+
+## xRegistry Discovery
+
+As defined by the [core specification](./spec.md#xregistry-discovery), clients
+MAY query an xRegistry server for the list of additional xRegistry servers
+that might be of interest. If supported, the Registry-specific discovery file,
+for an HTTP server, MUST be available at the root of the Registry (e.g. as a
+sibling API to `/model`) via the `/.xregistry` API:
+
+```yaml
+GET /.xregistry
+```
+
+A successful response MUST be of the form:
+```yaml
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+{
+  "registries": {
+    "URL", *
+  }
+}
+
+Note that unlike the [Host-based Discovery](./spec.md#host-based-discovery)
+mechanism, this API includes a dot (`.`) before `xregistry` to avoid any
+potential name collisions with the xRegistry's data.
 
 ## Request Flags / Query Parameters
 

--- a/core/model.md
+++ b/core/model.md
@@ -119,7 +119,7 @@ The overall format of a model definition is as follows:
       "modelcompatiblewith": "<URI>", ?  # Statement of compatibility
       "attributes": { ... }, ?           # See "attributes" above
       "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources,
-                                         # only available for "modelsource"
+                                                  # only for "modelsource"
       "constraints": {
         "<RESOURCES>.<PATH>": {          # Resource-plural + attribute path
           "default": <VALUE>, ?          # Group specific default

--- a/core/model.md
+++ b/core/model.md
@@ -118,8 +118,8 @@ The overall format of a model definition is as follows:
       "modelversion": "<STRING>", ?      # Version of the group model
       "modelcompatiblewith": "<URI>", ?  # Statement of compatibility
       "attributes": { ... }, ?           # See "attributes" above
-      "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources
-
+      "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources,
+                                         # only available for "modelsource"
       "constraints": {
         "<RESOURCES>.<PATH>": {          # Resource-plural + attribute path
           "default": <VALUE>, ?          # Group specific default
@@ -141,7 +141,7 @@ The overall format of a model definition is as follows:
           "maxversions": <UINTEGER>, ?   # Num Vers(>=0). Default=0, 0=unlimited
           "setversionid": <BOOLEAN>, ?   # vid settable? Default=true
           "hasdocument": <BOOLEAN>, ?       # Has separate document. Default=true
-          "versionmode": "<STRING>", ?      # 'ancestor' processing algorithm
+          "versionmode": "<STRING>", ?      # Ancestor processing algorithm
           "singleversionroot": <BOOLEAN>, ? # Enforce single root. Default=false
           "validateformat": <BOOLEAN>, ?    # Do Version format checks. Default=false
           "validatecompatibility": <BOOLEAN>, ? # Do Version compat checks. Default=false
@@ -156,6 +156,10 @@ The overall format of a model definition is as follows:
   } ?
 }
 ```
+
+See the [Includes in the xRegistry Model
+Data](#includes-in-the-xregistry-model-data) section for use of the
+`$include(s)` directives in `modelsource`.
 
 The following describes the attributes of the Registry model:
 
@@ -825,17 +829,17 @@ Note that this feature has similar results as setting the Resource attribute's
   are managed with respect to aspects such as:
   - Which Version is the "newest"?
   - Which Version is the "oldest"?
-  - How a Version's `ancestor` attribute will be populated when not
+  - How a Version's `ancestorid` attribute will be populated when not
     explicitly set by a client.
 - Implementations MAY defined additional algorithms and MAY defined
   additional aspects that they control, as long as those aspects do not
   conflict with specification-defined semantics.
 - Regardless of the algorithm used, implementations MUST ensure that
-  the `ancestor` attribute of all Versions of a Resource accurately
+  the `ancestorid` attribute of all Versions of a Resource accurately
   represent the relationship of the Versions prior to the completion of
   any operation. For example, when the `createdat` algorithm is used and
   the `createdat` timestamp of a Version is modified, this might cause a
-  reordering of the Versions and the `ancestor` attributes might need to
+  reordering of the Versions and the `ancestorid` attributes might need to
   be changed accordingly. Similarly, the `defaultversionid` of the
   Resource might change if its `defaultversionsticky` attribute is `false`.
 - When not specified, the default value MUST be `manual`.
@@ -849,20 +853,20 @@ Note that this feature has similar results as setting the Resource attribute's
       more than one, then the one with the highest alphabetically
       case-insensitive `versionid` value MUST be chosen.
     - Oldest Version: MUST be determined by finding all root Versions (ones
-      that have an `ancestor` value that points to itself), then finding
+      that have an `ancestorid` value that points to itself), then finding
       the one with the oldest `createdat` timestamp. If there is more than
       one, then the one with the lowest alphabetically case-insensitive
       `versionid` MUST be chosen.
     - Ancestor Processing: typically provided by clients. During a "create"
-      operation, all Versions that do not have an `ancestor` value
+      operation, all Versions that do not have an `ancestorid` value
       provided MUST be sorted/processed by `versionid` (in case-insensitive
-      ascending order) and the `ancestor` value of each MUST be set to the
+      ascending order) and the `ancestorid` value of each MUST be set to the
       current "newest version" per the above semantics. Note that as
       each new Version is created, it MUST become the "newest". If there
       is no existing Version then the new Version becomes a root and its
-      `ancestor` value MUST be its `versionid` attribute value.
+      `ancestorid` value MUST be its `versionid` attribute value.
     - Deleted Ancestor: if a Version's ancestor is deleted, then this Version
-      MUST become a root, and its `ancestor` value MUST be set to its
+      MUST become a root, and its `ancestorid` value MUST be set to its
       `versionid` value.
 
   - `createdat`
@@ -875,15 +879,15 @@ Note that this feature has similar results as setting the Resource attribute's
       one with the lowest alphabetically case-insensitive `versionid`
       value MUST be chosen. Note that this MUST also be the one and only
       "root" Version.
-    - Ancestor Processing: The `ancestor` value of each Version MUST be
+    - Ancestor Processing: The `ancestorid` value of each Version MUST be
       determined via examination of the `createdat` timestamp of each
       Version and the Versions sorted in ascending order, where the first
-      one will be the "root" (oldest) Version and its `ancestor` value
+      one will be the "root" (oldest) Version and its `ancestorid` value
       MUST be its `versionid`. If there is more than one Version with the
       same `createdat` timestamp then those MUST be ordered in ascending
       case-insensitive ordered based on their `versionid` values.
     - Deleted Ancestor: if a Version's ancestor is deleted, then this Version's
-      `ancestor` value MUST be determined by the "ancestor processing" logic
+      `ancestorid` value MUST be determined by the "ancestor processing" logic
       as stated above.
     - When this `versionmode` is used, the `singleversionroot` aspect
       MUST be set to `true`.
@@ -901,13 +905,13 @@ Note that this feature has similar results as setting the Resource attribute's
       value per the [Semantic Versioning](https://semver.org/)
       specification's "precedence" ordering rules. Note that this MUST also
       be the one and only "root" Version.
-    - Ancestor Processing: The `ancestor` value of each Version MUST either
+    - Ancestor Processing: The `ancestorid` value of each Version MUST either
       be its `versionid` value (if it it the oldest Version), or the
       `versionid` of the next oldest Version per the
       [Semantic Versioning](https://semver.org/) specification's
       "precedence" ordering rules.
     - Deleted Ancestor: if a Version's ancestor is deleted, then this Version's
-      `ancestor` value MUST be determined by the "ancestor processing" logic
+      `ancestorid` value MUST be determined by the "ancestor processing" logic
       as stated above.
     - When this `versionmode` is used, the `singleversionroot` aspect
       MUST be set to `true`.
@@ -917,7 +921,7 @@ Note that this feature has similar results as setting the Resource attribute's
 - OPTIONAL.
 - Indicates whether Resources of this type can have multiple Versions
   that represent roots of an ancestor tree, as indicated by the
-  Version's `ancestor` attribute value being the same as its `versionid`
+  Version's `ancestorid` attribute value being the same as its `versionid`
   attribute.
 - When not specified, the default value MUST be `false`.
 - A value of `true` indicates that only one Version of the Resource can
@@ -1325,6 +1329,13 @@ where:
 Locally defined Resources MAY be defined within a Group that uses the
 `ximportresources` feature, however, Resource `plural` and `singular` values
 MUST be unique across all imported and locally defined Resources.
+
+This attribute, while listed in the schema definition of `model`, and
+`modelsource` for ease of reading the specification, is only available for
+`modelsource`. Similar to the `$include` directive, servers MUST process any
+`ximportresources` found in the `modelsource` data and the results MUST be
+reflected in the `model`, but the `ximportresources` directive MUST NOT appear
+in the `model` serialization.
 
 See [Cross Referencing Resources](./spec.md#cross-referencing-resources) for
 more additional information.

--- a/core/primer.md
+++ b/core/primer.md
@@ -981,7 +981,7 @@ against the new model, not just a subset of the entity's attributes.
 
 #### 10.7.11. Multi-root ancestor hierarchies
 
-The [`ancestor` attribute](./spec.md#ancestor-attribute) is used to build a
+The [`ancestorid` attribute](./spec.md#ancestorid-attribute) is used to build a
 hierarchy of Versions to facilitate compatibility checking when the
 [`compatibility` attribute](./spec.md#compatibility-attribute) is set. There
 are cases in which it's desirable to create multiple roots. In some
@@ -992,7 +992,7 @@ pruning of the Version tree. In such cases, when deleting the oldest Version,
 this could result in a new root being created when there are multiple
 decedents of the deleted Version.
 
-To signal that a Version represents a root of a hierarchy, the `ancestor`
+To signal that a Version represents a root of a hierarchy, the `ancestorid`
 attribute has its value set to the Version's `versionid` attribute. This
 makes the ancestor explicit, and the possible ambiguity of using another
 value such as null which, based on the scenario, could mean "no ancestor" or
@@ -1000,7 +1000,7 @@ value such as null which, based on the scenario, could mean "no ancestor" or
 
 #### 10.7.12. `singleversionroot` Policy Enforcement
 
-Related to the previous discussions concerning the `ancestor` attribute,
+Related to the previous discussions concerning the `ancestorid` attribute,
 the [Resource Model](./model.md#registry-model) `singleversionroot` attribute
 controls whether a Resource is allowed to have more than one "root" Version,
 or whether all Versions of that Resource must be a descendant of the same
@@ -1044,8 +1044,8 @@ scenarios, the server may be unable to prune Versions, when the
 must be rejected.
 
 Consider a scenario in which 3 Versions exist: v1 is the root (and therefore
-has its `ancestor` attribute set to v1), and v2 and v3 both have
-their `ancestor` attribute set to v1. In addition, the
+has its `ancestorid` attribute set to v1), and v2 and v3 both have
+their `ancestorid` attribute set to v1. In addition, the
 `groups.resources.maxversions` is set to 3. When creating a new Version, the
 server will find the oldest Version (v1) and attempt to prune it. However,
 deleting v1 would mean that v2 and v3 would become roots, as both of them
@@ -1059,7 +1059,7 @@ creating a new Version.
 #### 10.7.14. What's the oldest/newest Version of a Resource?
 
 The oldest Version of a Resource isn't necessarily the one with the oldest
-`createdat` timestamp, because the `ancestor` attribute takes precedence
+`createdat` timestamp, because the `ancestorid` attribute takes precedence
 over the `createdat` attribute. This is because the ancestor tree more
 accurately describes an ordered lineage of the Versions than timestamps. In
 the case multiple Versions exist with the same `createdat` timestamp, those
@@ -1094,7 +1094,7 @@ to their users.
 
 #### 10.7.16. Detecting circular references between Versions
 
-The specification mentions that the Version's `ancestor` attribute should not
+The specification mentions that the Version's `ancestorid` attribute should not
 be set in such a way as to cause a circular dependency list between Versions.
 However, when talking about the server generating an error in such conditions
 it says it is "STRONGLY RECOMMENDED" that an error is generated, not that it

--- a/core/resource.md
+++ b/core/resource.md
@@ -101,7 +101,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "1",
+  "ancestorid": "1",
 
   "meta": {
     "epoch": 1,
@@ -126,7 +126,7 @@ PUT /dirs/d1/files/f1
 - Conceptually, this new Version is populated with the Resource's default
   Version attributes from the request. However, since there are none, all
   mandatory attributes are assigned their default values.
-- The Version's `ancestor` value is `1` (points to itself) because it is the
+- The Version's `ancestorid` value is `1` (points to itself) because it is the
   root of a hierarchy tree.
 - Being the only Version, it is the default Version, and it is not "sticky".
 - Using `PATCH` instead of `PUT` will yield the exact same results.
@@ -170,7 +170,7 @@ POST /dirs/d1/files
     "isdefault": true,
     "createdat": "now",
     "modifiedat": "now",
-    "ancestor": "1",
+    "ancestorid": "1",
 
     "meta": {
       "epoch": 1,
@@ -234,7 +234,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -248,7 +248,7 @@ PUT /dirs/d1/files/f1
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
   }
@@ -264,7 +264,7 @@ PUT /dirs/d1/files/f1
   `meta.defaultversionid` are absent, but `versions` is not empty, all
   Resource.* attributes are ignored.
 - Since all Versions have the same `createdat` timestamp they are sorted
-  alphabetically by their `versionid` values in order to set their `ancestor`
+  alphabetically by their `versionid` values in order to set their `ancestorid`
   attributes.
 - Which means `v2` becomes the newest and therefore the default Version.
 - Ancestor order: `1` <- `v1` <- `v2`.
@@ -317,7 +317,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "3030",
   "modifiedat": "now",
-  "ancestor": "v3",
+  "ancestorid": "v3",
 
   "meta": {
     "epoch": 1,
@@ -331,14 +331,14 @@ PUT /dirs/d1/files/f1
       "epoch": 1,
       "createdat": "2020",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs },
     "v3": {
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     }
   }
 }
@@ -397,7 +397,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v2",
+  "ancestorid": "v2",
 
   "meta": {
     "epoch": 1,
@@ -412,13 +412,13 @@ PUT /dirs/d1/files/f1
       "name": "foo",
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": {
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v3": { see Resource.* attrs },
   }
@@ -474,7 +474,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -539,7 +539,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v0",
+  "ancestorid": "v0",
 
   "meta": {
     "epoch": 1,
@@ -554,13 +554,13 @@ PUT /dirs/d1/files/f1
       "name": "foo"
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v1": {
       "epoch": 1,
       "createdat": "2020",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
   }
@@ -591,7 +591,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2021",
   "modifiedat": "2021",
-  "ancestor": "v0",
+  "ancestorid": "v0",
 
   "meta": {
     "epoch": 1,
@@ -639,7 +639,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2020",
   "modifiedat": "now",
-  "ancestor": "v0",
+  "ancestorid": "v0",
 
   "meta": {
     "epoch": 2,
@@ -654,14 +654,14 @@ PUT /dirs/d1/files/f1
       "name": "foo",
       "createdat": "2021",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v1": { see Resource.* attrs },
     "v2": { see Resource.* attrs }
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v0"
+      "ancestorid": "v0"
     }
   }
 }
@@ -727,7 +727,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2020",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -742,14 +742,14 @@ PUT /dirs/d1/files/f1
       "name": "foo",
       "createdat": "2021",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v1": { see Resource.* attrs }
     "v2": {
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v0"
+      "ancestorid": "v0"
     }
   }
 }
@@ -814,7 +814,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v0",
+  "ancestorid": "v0",
 
   "meta": {
     "epoch": 1,
@@ -829,13 +829,13 @@ PUT /dirs/d1/files/f1
       "name": "foo",
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v1": {
       "epoch": 1,
       "createdat": "2020",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
   }
@@ -896,7 +896,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2020",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -911,7 +911,7 @@ PUT /dirs/d1/files/f1
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     }
   }
 }
@@ -942,7 +942,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -955,7 +955,7 @@ PUT /dirs/d1/files/f1
     "v1": { see Resource.* attrs },
     "v2": {
       "createdat": "2025",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     }
   }
 }
@@ -992,7 +992,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v2",
+  "ancestorid": "v2",
 
   "meta": {
     "epoch": 2,
@@ -1007,7 +1007,7 @@ PUT /dirs/d1/files/f1
       "epoch": 2,
       "createdat": "2020",
       "modifiedat": "now",
-      "ancestor": "v2"
+      "ancestorid": "v2"
     }
   }
 }
@@ -1042,7 +1042,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1056,7 +1056,7 @@ PUT /dirs/d1/files/f1
       "epoch": 1,
       "createdat": "2025",
       "modifiedat": "2025",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
     }
@@ -1094,7 +1094,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v2",
+  "ancestorid": "v2",
 
   "meta": {
     "epoch": 2,
@@ -1109,7 +1109,7 @@ PUT /dirs/d1/files/f1
       "epoch": 2,
       "createdat": "2020",
       "modifiedat": "now",
-      "ancestor": "v2"
+      "ancestorid": "v2"
     }
   }
 }
@@ -1145,7 +1145,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1159,7 +1159,7 @@ PUT /dirs/d1/files/f1
       "epoch": 1,
       "createdat": "2025",
       "modifiedat": "2025",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
     }
@@ -1197,7 +1197,7 @@ PATCH /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2020",
   "modifiedat": "now",
-  "ancestor": "v2",
+  "ancestorid": "v2",
 
   "meta": {
     "epoch": 2,
@@ -1211,7 +1211,7 @@ PATCH /dirs/d1/files/f1
       "epoch": 2,
       "createdat": "2025",
       "modifiedat": "now",
-      "ancestor": "v2"
+      "ancestorid": "v2"
     },
     "v2": { see Resource.* attrs }
   }
@@ -1248,7 +1248,7 @@ PATCH /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1283,7 +1283,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1324,7 +1324,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1361,7 +1361,7 @@ PATCH /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1404,7 +1404,7 @@ PATCH /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1442,7 +1442,7 @@ PUT /dirs/d1/files/f1
   "description": "very cool",
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1484,7 +1484,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1523,7 +1523,7 @@ PATCH /dirs/d1/files/f1
   "description": "very cool",
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1565,7 +1565,7 @@ PATCH /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1604,7 +1604,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 2,
@@ -1646,7 +1646,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1686,7 +1686,7 @@ PATCH /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 2,
@@ -1729,7 +1729,7 @@ PATCH /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1743,7 +1743,7 @@ PATCH /dirs/d1/files/f1
       "epoch": 1,
       "createdat": "2025",
       "modifiedat": "2025",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
   }
@@ -1773,7 +1773,7 @@ PATCH /dirs/d1/files/f1/meta
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 2,
@@ -1788,7 +1788,7 @@ PATCH /dirs/d1/files/f1/meta
       "epoch": 1,
       "createdat": "2025",
       "modifiedat": "2025",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     }
   }
 }
@@ -1823,7 +1823,7 @@ PATCH /dirs/d1/files/f1/meta
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1886,7 +1886,7 @@ Error due to `foo` being an unknown Version.
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1947,7 +1947,7 @@ Error due to `foo` being an unknown Version.
   "isdefault": true,
   "createdat": "2025",
   "modifiedat": "2025",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -1992,7 +1992,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "1999",
   "modifiedat": "now",
-  "ancestor": "v2",
+  "ancestorid": "v2",
 
   "meta": {
     "epoch": 2,
@@ -2007,7 +2007,7 @@ PUT /dirs/d1/files/f1
        "epoch": 1,
        "createdat": "1998",
        "modifiedat": "now",
-       "ancestor": "v2"
+       "ancestorid": "v2"
      }
   }
 }
@@ -2066,7 +2066,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -2081,7 +2081,7 @@ PUT /dirs/d1/files/f1
       "name": "abc",
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
   }
@@ -2136,7 +2136,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -2151,7 +2151,7 @@ PUT /dirs/d1/files/f1
       "name": "abc",
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
   }
@@ -2208,7 +2208,7 @@ PUT /dirs/d1/files/f1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -2223,7 +2223,7 @@ PUT /dirs/d1/files/f1
       "name": "abc",
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
     "v2": { see Resource.* attrs }
   }
@@ -2272,7 +2272,7 @@ PUT /dirs/d1/files/f1?setdefaultversionid=v1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -2287,7 +2287,7 @@ PUT /dirs/d1/files/f1?setdefaultversionid=v1
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
   }
 }
@@ -2334,7 +2334,7 @@ POST /dirs/d1/files/f1/versions?setdefaultversionid=v1
   "isdefault": true,
   "createdat": "now",
   "modifiedat": "now",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "meta": {
     "epoch": 1,
@@ -2349,7 +2349,7 @@ POST /dirs/d1/files/f1/versions?setdefaultversionid=v1
       "epoch": 1,
       "createdat": "now",
       "modifiedat": "now",
-      "ancestor": "v1"
+      "ancestorid": "v1"
     },
   }
 }

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -314,8 +314,8 @@
               "type": "timestamp",
               "required": true
             },
-            "ancestor": {
-              "name": "ancestor",
+            "ancestorid": {
+              "name": "ancestorid",
               "type": "string",
               "matchcase": true,
               "required": true

--- a/core/spec.md
+++ b/core/spec.md
@@ -5,6 +5,7 @@
 <!-- words: compat formatvalidatedreason compatibilityvalidatedreason -->
 <!-- words: matchversions -->
 <!-- words: myarray myobject -->
+<!-- words: href schemaregistry webpage -->
 
 ## Abstract
 
@@ -55,6 +56,7 @@ or automation and tooling usage.
   - [Sort Flag](#sort-flag)
   - [SpecVersion Flag](#specversion-flag)
 - [xRegistry Dot (`.`) Notation](#xregistry-dot--notation)
+- [xRegistry Discovery](#xregistry-discovery)
 - [Error Processing](#error-processing)
 
 ## Overview
@@ -270,7 +272,9 @@ This entity is also meant to serve a few other key purposes:
   - The domain-specific ["model"](./model.md#registry-model) that defines the
     types of entities being managed by the Registry. For example, the model
     might define a Group called `schemagroups` that has `schemas` as the
-    Resources within those Groups.
+    Resources within those Groups. All xRegistry protocol specifications
+    (e.g. `http`(./http.md) MUST define at least one REQUIRED mechanism by
+    which the model can be retrieved.
 
 ### Design: Group Entity
 
@@ -287,7 +291,7 @@ A Resource entity in the Registry holds one or more Versions of metadata, and
 optionally a domain-specific document. If a Resource holds multiple Versions,
 those can be organized with
 [compatibility policies](#compatibility-attribute) and[
-lineage](#ancestor-attribute). Each Resource
+lineage](#ancestorid-attribute). Each Resource
 always has a default Version corresponding to one of the available Versions
 that is indirectly accessed when interacting with the Resource. All held
 Versions can be accessed directly through the Versions collection.
@@ -503,8 +507,8 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
         "modelversion": "<STRING>", ?     # Version of the group model
         "modelcompatiblewith": "<URI>", ? # Statement of compatibility
         "attributes": { ... }, ?          # Group-level attributes/extensions
-        "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources
-
+        "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources,
+                                          # only available for "modelsource"
         "resources": {
           "<STRING>": {                   # Key=plural name, e.g. "messages"
             "plural": "<STRING>",         # e.g. "messages"
@@ -518,7 +522,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
             "maxversions": <UINTEGER>, ?  # Num Vers(>=0). Default=0(unlimited)
             "setversionid": <BOOLEAN>, ?  # vid settable? Default=true
             "hasdocument": <BOOLEAN>, ?   # Has separate document. Default=true
-            "versionmode": "<STRING>", ?  # 'ancestor' processing algorithm
+            "versionmode": "<STRING>", ?  # Ancestor processing algorithm
             "singleversionroot": <BOOLEAN>, ? # Default=false"
             "validateformat": <BOOLEAN>, ?    # Check version format compliance. Default=false
             "validatecompatibility": <BOOLEAN>, ? # Check version compatibility. Default=false
@@ -584,7 +588,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
           "labels": { "<STRING>": "<STRING>" * }, ?
           "createdat": "<TIMESTAMP>",
           "modifiedat": "<TIMESTAMP>",
-          "ancestor": "<STRING>",                  # Ancestor's versionid
+          "ancestorid": "<STRING>",                # Ancestor's versionid
           "contenttype": "<STRING>", ?             # Add default Ver extensions
           "format": "<STRING>", ?
           "formatvalidated": <BOOLEAN>, ?
@@ -639,7 +643,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
               "labels": { "<STRING>": "<STRING>" * }, ? # Version's labels
               "createdat": "<TIMESTAMP>",
               "modifiedat": "<TIMESTAMP>",
-              "ancestor": "<STRING>",              # Ancestor's versionid
+              "ancestorid": "<STRING>",            # Ancestor's versionid
               "contenttype": "<STRING>", ?
               "format": "<STRING>", ?
               "formatvalidated": <BOOLEAN>, ?
@@ -658,6 +662,10 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
   } ?
 }
 ```
+
+See the [Includes in the xRegistry Model
+Data](./model.md#includes-in-the-xregistry-model-data)
+section for use of the `$include(s)` directives in `modelsource`.
 
 If there is an issue with reading or parsing the data provided to the
 server, then an error ([parsing_data](#parsing_data)) MUST be generated.
@@ -2415,7 +2423,7 @@ it MUST adhere to the following:
   "labels": { "<STRING>": "<STRING>" * }, ?
   "createdat": "<TIMESTAMP>",
   "modifiedat": "<TIMESTAMP>",
-  "ancestor": "<STRING>",
+  "ancestorid": "<STRING>",
   "contenttype": "<STRING>", ?
 
   "<RESOURCE>url": "<URL>", ?                # If not local
@@ -2599,7 +2607,7 @@ The overall processing of the request message is as follows:
 1.  Process the Versions in the `versions` collection, if present.
 2.  Process the Resource's default Version attributes only if the default
     Version is not present in the `versions` collection.
-3.  Update all Version's [`ancestor` values](#ancestor-attribute) as needed,
+3.  Update all Version's [`ancestorid` values](#ancestorid-attribute) as needed,
     based on the Resource's
     [`versionmode`](./model.md#groupsstringresourcesstringversionmode) value.
 4.  Process the `meta` sub-object, if present.
@@ -2611,7 +2619,7 @@ The overall processing of the request message is as follows:
 9.  Enforce the [Version compatibility checks](#compatibility-attribute).
 10. Enforce the [Resource `maxversions`
     constraints](./model.md#groupsstringresourcesstringmaxversions). Note that
-    this might require updating the [`ancestor` values](#ancestor-attribute)
+    this might require updating the [`ancestorid` values](#ancestorid-attribute)
     again after some Versions have been deleted.
 
 The following provides additional details:
@@ -2733,7 +2741,7 @@ So, if the target Resource (`sharedSchema`) is defined as:
   "isdefault": true,
   "createdat": "2024-01-01-T12:00:00Z",
   "modifiedat": "2024-01-01-T12:01:00Z",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "metaurl": "http://example.com/schemagroups/group2/schemas/sharedSchema/meta",
   "versionscount": 1,
@@ -2753,7 +2761,7 @@ then the resulting serialization of the source Resource would be:
   "isdefault": true,
   "createdat": "2024-01-01-T12:00:00Z",
   "modifiedat": "2024-01-01-T12:01:00Z",
-  "ancestor": "v1",
+  "ancestorid": "v1",
 
   "metaurl": "http://example.com/schemagroups/group1/schemas/mySchema/meta",
   "meta": {
@@ -2980,7 +2988,7 @@ and the following Meta-level attributes:
 - Description: States that Versions of this Resource adhere to a certain
   compatibility rule. For example, a `backward` compatibility value would
   indicate that all Versions of a Resource are backwards compatible with the
-  next oldest Version, as determined by their `ancestor` attributes.
+  next oldest Version, as determined by their `ancestorid` attributes.
 
   This specification makes no statement as to which parts of the Version data
   are examined for compatibility (e.g. xRegistry metadata, domain-specific
@@ -2995,7 +3003,7 @@ and the following Meta-level attributes:
   list of available values and to define the exact meaning of each.
 
   For `compatibility` strategies that require understanding the lineage
-  relationship between the Versions, the [`ancestor`](#ancestor-attribute)
+  relationship between the Versions, the [`ancestorid`](#ancestorid-attribute)
   attribute on each Version MUST be used to determine that information.
 
   This specification defines the following enumeration values. Implementations
@@ -3193,7 +3201,7 @@ following:
   "labels": { "<STRING>": "<STRING>" * }, ?
   "createdat": "<TIMESTAMP>",
   "modifiedat": "<TIMESTAMP>",
-  "ancestor": "<STRING>",
+  "ancestorid": "<STRING>",
   "contenttype": "<STRING>", ?
 
   "<RESOURCE>url": "<URL>", ?                  # If not local
@@ -3274,11 +3282,11 @@ and the following Version-level attributes:
   - `true`
   - `false`
 
-#### `ancestor` Attribute
+#### `ancestorid` Attribute
 - Type: String
 - Description: The `versionid` of this Version's ancestor.
 
-  The `ancestor` attribute MUST be set to the `versionid` of this Version's
+  The `ancestorid` attribute MUST be set to the `versionid` of this Version's
   ancestor. If this Version is a root of an ancestor hierarchy tree then it
   MUST be set to its own `versionid` value.
 
@@ -3288,12 +3296,12 @@ and the following Version-level attributes:
 
   If a create operation asks the server to choose the `versionid` when
   creating a root Version, the `versionid` is not yet known and therefore
-  cannot be specified in the `ancestor` attribute as part of the request. In
+  cannot be specified in the `ancestorid` attribute as part of the request. In
   those cases a value of `request` MUST be used as a way to reference itself.
 
 - Constraints:
   - REQUIRED.
-  - The `ancestor` attribute MUST NOT be set to a value that
+  - The `ancestorid` attribute MUST NOT be set to a value that
     creates circular references between Versions and it is STRONGLY RECOMMENDED
     that the server generate an error
     ([ancestor_circular_reference](#ancestor_circular_reference)) if a request
@@ -3301,11 +3309,11 @@ and the following Version-level attributes:
     ancestor B, and Version B's ancestor A, would generate an error.
   - When absent in an update operation request, it MUST be interpreted as the
     same as if it were present with its existing value.
-  - Any attempt to set an `ancestor` attribute to a non-existing `versionid`
+  - Any attempt to set an `ancestorid` attribute to a non-existing `versionid`
     MUST generate an error ([unknown_id](#unknown_id)).
-  - For clarity, any modification to the `ancestor` attribute MUST result in
+  - For clarity, any modification to the `ancestorid` attribute MUST result in
     the owning Version's `epoch` and `modifiedat` attributes be updated
-    appropriately, regardless of whether the change to `ancestor` was
+    appropriately, regardless of whether the change to `ancestorid` was
     explicitly part of a request or indirectly changed due to changes to other
     Versions.
 
@@ -3789,8 +3797,8 @@ of Resource and Version entities that have a domain-specific document.
 
 ### Collections Flag
 
-The `collections` flag MAY be used on requests directed to the Registry itself
-or to Group instances to indicate that the response message MUST NOT include
+The `collections` flag MAY be used on requests directed to the Registry itself,
+or to Group instances, to indicate that the response message MUST NOT include
 any attributes from the top-level entity (Registry or Group), but instead MUST
 include only all of the nested xRegistry Collection maps that are defined at
 that level. Specifying it on a request directed to some other part of the
@@ -3980,9 +3988,6 @@ Where:
 - `<ATTRIBUTE>` uses dot notation as well. Technically, the filter expression
   is a single dot notation reference, but the `<PATH>` and `<ATTRIBUTE>` are
   called out separately here for descriptive purposes.
-- `<PATH>` MUST only consist of valid `<GROUPS>` type names, `<RESOURCES>`
-  type names or `versions`, otherwise an error ([bad_filter](#bad_filter))
-  MUST be generated.
 - `<ATTRIBUTE>` MUST be the attribute in the entity to be examined.
 - A non-`null` `<VALUE>` MUST only be used when referencing scalar attributes.
 - A reference to a nonexistent attribute SHOULD NOT generate an error and
@@ -4055,6 +4060,8 @@ If the request references an entity (not a collection), and the expression
 references an attribute in that entity (i.e. there is no `<PATH>`), then if the
 expression does not match the entity, that entity MUST NOT be returned. In
 other words, a `404 Not Found` would be generated in the HTTP protocol case.
+
+Invalid filter expressions MUST generate an error ([bad_filter](#bad_filter)).
 
 **Examples:**
 
@@ -4265,17 +4272,13 @@ Some examples using the [HTTP protocol binding](./http.md#inline-flag):
 
 The value of the `inline` flag is a list of `<PATH>` values where each is a
 string indicating which inlineable attribute to show in the response.
-References to nested attributes are represented using a dot (`.`) notation
-where the xRegistry collection names along the hierarchy are concatenated. For
-example: `endpoints.messages.versions` will inline all Versions of Messages.
-Non-leaf parts of the `<PATH>` MUST only reference xRegistry collection names
-and not any specific entity IDs since `<PATH>` is meant to be an abstract
-traversal of the model.
-
-To reference an attribute with a dot as part of its name, the JSONPath
-escaping mechanism MUST be used: `['my.name']`. For example,
-`prop1.my.name.prop2` would be specified as `prop1['my.name'].prop2` if
-`my.name` is the name of an attribute.
+References to nested attributes are represented using a
+[dot (`.`) notation](#xregistry-dot--notation) where the xRegistry collection
+names along the hierarchy are concatenated. For example:
+`endpoints.messages.versions` will inline all Versions of Messages.  Non-leaf
+parts of the `<PATH>` MUST only reference xRegistry collection names and not
+any specific entity IDs since `<PATH>` is meant to be an abstract traversal of
+the model.
 
 There MAY be multiple `<PATH>`s specified in a single request and each
 protocol binding specification will indicate how the list is specified.
@@ -4388,8 +4391,9 @@ This flag MUST include a single parameter, a string containing the attribute
  whether the results are to be sorted in ascending or descending order.
 
 The following rules apply:
-- `<ATTRIBUTE>` MUST be the JSONPath to one of the attributes defined in
-  collection's entities that will be the primary sort key for the results.
+- `<ATTRIBUTE>` MUST be a [dot (`.`) notation](#xregistry-dot--notation) path
+  to one of the attributes defined in collection's entities that will be the
+  primary sort key for the results.
   The attribute MUST only reference a scalar attribute within the top-level
   collection, it MUST NOT attempt to traverse into a nested xRegistry
   collection even if that nested collection is inlined.
@@ -4501,14 +4505,10 @@ When using [filters](#filter-flag) the following special values MAY be used:
 | ------ | --- |
 | `.*`   | Match any item in an object/map |
 | `[*]`  | Match any item in an array |
-| `[-1]` | Match the final item in an array |
 
 Note that `['*']` is not the same as `.*`. Rather, `['*']` is a reference
 to an attribute/key called `*` - assuming that it is a valid attribute/key
 name in that particular situation.
-
-Use of `-1` as a special index in an array does not extend to other negative
-integers. Those MUST generate an error ([bad_request](#bad_request)).
 
 **Examples**
 
@@ -4597,8 +4597,11 @@ The `,` in a single filter expression represents an `AND` operation.
 
 ### Additional Special Dot-Notation Considerations
 
-While not used in this server specification, the following syntax guidelines
-are RECOMMENDED to be used for consistency across xRegistry tooling:
+The dot-notation defined in this specification is purposely limited to keep
+implementation requirements to a minimum. However, third-party xRegistry
+tooling might leverage more expressive dot-notation features. In order to
+encourage interoperability and consistency across tooling, the following
+syntax guidelines are RECOMMENDED for other common situations:
 
 - Insert an item into the middle of an array: `[INTEGER:]`.
   - E.g. `set myarray[3:]=mary` would be used to insert "mary" at the 4th
@@ -4612,6 +4615,10 @@ are RECOMMENDED to be used for consistency across xRegistry tooling:
 - Append to the end of an array: `[$]`.
   - E.g. `set myarray[$]=mary` would append "mary" to the end of the array,
     and create the array first if it is not yet defined.
+- Referencing the last item in an array: `[-1]`.
+  - E.g. `set myarray[-1]=mary` would replace the last item in the array.
+  - If the array is empty, then an error would be generated.
+  - This notation does not extend to other negative integers.
 - Specifying an empty object/map: `{}`.
   - E.g. `set myobject={}` would replace any value for `myobject` with an
     empty object/map.
@@ -4622,6 +4629,100 @@ are RECOMMENDED to be used for consistency across xRegistry tooling:
   since this specification does not support sparse arrays. Note, that if the
   intent is to replace that item, rather than doing a delete followed by an
   insert, a direct replacement of that index is RECOMMENDED.
+
+## xRegistry Discovery
+
+This specification defines the following mechanisms by which xRegistry servers
+can be discovered:
+
+### Host-based Discovery
+
+Leveraging the `/.well-known` mechanism, this specification defines an
+xRegistry file that MAY exist at the root of a host's web server:
+
+```yaml
+GET /.well-known/xregistry
+```
+
+The format of the document returned MUST be:
+
+```yaml
+{
+  "registries": {
+    "URL", *
+  }
+}
+```
+
+Where:
+- Each `URL` is the full absolute URL location an xRegistry server.
+
+While normally this list would only include servers hosted on this specific
+host, it is not a requirement that this be the case.
+
+This mechanism is RECOMMENDED if access to the root of the hosting
+environment is available.
+
+- Examples:
+  - ```
+    {
+      "registries": [
+        "https://example.com/schemaregistry"
+      ]
+    }
+
+### Registry-specific Discovery
+
+Similar to the [Host-based Discovery](#host-based-discovery) mechanism,
+an xRegistry server instance MAY advertise a list of additional xRegistry
+servers by supporting a protocol-specific retrieval mechanism.
+
+Regardless of the exact protocol mechanism, the data returned MUST adhere
+to the same format as the Host-based discovery mechanism:
+
+```yaml
+{
+  "registries": {
+    "URL", *
+  }
+}
+```
+
+Where:
+- Each `URL` is the full absolute URL location an xRegistry server.
+- While not expected, the list MAY include the current server's URL.
+- This list MAY, but is not mandated to, include URLs from the
+  host-based discovery mechanism. It is expected that clients will
+  detect duplicate URLs if needed.
+
+See the [xRegistry HTTP specification](./http.md#xregistry-discovery) for the
+HTTP-specific discovery mechanism.
+
+- Examples:
+  - ```
+    {
+      "registries": [
+        "https://example.com/schemaregistry"
+      ]
+    }
+    ```
+
+### Webpage-based Discovery
+
+Web pages MAY choose to advertise the location of a related xRegistry
+server by including a `<link>` element in the page's `<head>` section.
+The format of the element MUST adhere to:
+
+```yaml
+<link rel="alternative" type="application/xregistry+json"
+      title="STRING" href="URL"/>
+```
+
+- Example:
+  - ```yaml
+    <link rel="alternative" type="application/xregistry+json"
+          title="Our xRegistry server" href="https://example.com/xregistry"/>
+    ```
 
 ## Error Processing
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -508,7 +508,7 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
         "modelcompatiblewith": "<URI>", ? # Statement of compatibility
         "attributes": { ... }, ?          # Group-level attributes/extensions
         "ximportresources": [ "<XIDTYPE>", * ], ?   # Include these Resources,
-                                          # only available for "modelsource"
+                                                    # only for "modelsource"
         "resources": {
           "<STRING>": {                   # Key=plural name, e.g. "messages"
             "plural": "<STRING>",         # e.g. "messages"
@@ -4637,14 +4637,19 @@ can be discovered:
 
 ### Host-based Discovery
 
-Leveraging the `/.well-known` mechanism, this specification defines an
-xRegistry file that MAY exist at the root of a host's web server:
+If access to the root of a hosting environment is available, then it is
+RECOMMENDED that implementations leverage the
+[`/.well-known` discovery
+mechanism](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml)
+by making xRegistry "discovery" metadata available at the
+following URL:
 
 ```yaml
-GET /.well-known/xregistry
+/.well-known/xregistry
 ```
 
-The format of the document returned MUST be:
+If supported, a request (`GET`) to this location MUST return a document of
+the form:
 
 ```yaml
 {
@@ -4657,21 +4662,19 @@ The format of the document returned MUST be:
 Where:
 - Each `URL` is the full absolute URL location an xRegistry server.
 
-While normally this list would only include servers hosted on this specific
-host, it is not a requirement that this be the case.
-
-This mechanism is RECOMMENDED if access to the root of the hosting
-environment is available.
+While normally this list would only include xRegistry servers hosted on this
+specific host, it is not a requirement that this be the case.
 
 - Examples:
-  - ```
+  - ```yaml
     {
       "registries": [
         "https://example.com/schemaregistry"
       ]
     }
+    ```
 
-### Registry-specific Discovery
+### Registry-base Discovery
 
 Similar to the [Host-based Discovery](#host-based-discovery) mechanism,
 an xRegistry server instance MAY advertise a list of additional xRegistry
@@ -4695,17 +4698,40 @@ Where:
   host-based discovery mechanism. It is expected that clients will
   detect duplicate URLs if needed.
 
-See the [xRegistry HTTP specification](./http.md#xregistry-discovery) for the
-HTTP-specific discovery mechanism.
+See the [xRegistry HTTP specification](./http.md#xregistry-discovery) for more
+information on the HTTP-specific discovery mechanism.
 
 - Examples:
-  - ```
+  - Using HTTP, a "dev" registry, points to a "prod" registry:
+    ```yaml
+    GET http://example.com/registries/dev/.xregistry
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json; charset=utf-8
     {
       "registries": [
-        "https://example.com/schemaregistry"
+        "https://example.com/registries/prod"
       ]
     }
     ```
+  - Additionally, if access to the root of the host is available, the
+    following would work:
+    ```yaml
+    GET http://example.com/.well-known/xregistry
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json; charset=utf-8
+    {
+      "registries": [
+        "https://example.com/registries/dev",
+        "https://example.com/registries/prod"
+      ]
+    }
+    ```
+
+Since clients might not be aware of the hosting limitations of the servers,
+to maximize the set of xRegistries servers found, both Host-based and
+Registry-based mechanisms SHOULD be attempted.
 
 ### Webpage-based Discovery
 
@@ -4721,7 +4747,7 @@ The format of the element MUST adhere to:
 - Example:
   - ```yaml
     <link rel="alternative" type="application/xregistry+json"
-          title="Our xRegistry server" href="https://example.com/xregistry"/>
+          title="Our xRegistry server" href="https://xreg.example.com/"/>
     ```
 
 ## Error Processing

--- a/message/spec.md
+++ b/message/spec.md
@@ -469,7 +469,7 @@ this form:
           "labels": { "<STRING>": "<STRING>" * }, ?
           "createdat": "<TIMESTAMP>",
           "modifiedat": "<TIMESTAMP>",
-          "ancestor": "<STRING>",
+          "ancestorid": "<STRING>",
           "contenttype": "<STRING>", ?
           "format": "<STRING>", ?
           "formatvalidated": <BOOLEAN>, ?

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -271,7 +271,7 @@ this form:
           "labels": { "<STRING>": "<STRING>" * }, ?
           "createdat": "<TIMESTAMP>",
           "modifiedat": "<TIMESTAMP>",
-          "ancestor": "<STRING>",
+          "ancestorid": "<STRING>",
           "contenttype": "<STRING>", ?
           "format": "<STRING>", ?
           "formatvalidated": <BOOLEAN>, ?
@@ -393,10 +393,10 @@ major version identifier in the `schemaid`, like `"com.example.event.v1"` or
 schemas can be more easily identified by users and developers. The schema
 `versionid` then functions as the semantic minor version identifier.
 
-The [`ancestor`][xRegistry ancestor] attribute permits multiple version branches
-to exist, and allows for implementations to determine the Version lineage. See
-the [`ancestor`][xRegistry ancestor] attribute in the core xRegistry
-specification for more information.
+The [`ancestorid`][xRegistry ancestorid] attribute permits multiple version
+branches to exist, and allows for implementations to determine the Version
+lineage. See the [`ancestorid`][xRegistry ancestorid] attribute in the core
+xRegistry specification for more information.
 
 ### 4.3. Schema Formats
 
@@ -435,7 +435,7 @@ Versions for a schema named `com.example.telemetrydata`:
           "versionid": "3",
           "isdefault": true,
           "description": "device telemetry event data",
-          "ancestor": "2",
+          "ancestorid": "2",
           "format": "Protobuf/3",
           # other xRegistry default Version attributes excluded for brevity
 
@@ -450,7 +450,7 @@ Versions for a schema named `com.example.telemetrydata`:
               "versionid": "1",
               "isdefault": false,
               "description": "device telemetry event data",
-              "ancestor": "1",
+              "ancestorid": "1",
               "format": "Protobuf/3",
               # other xRegistry Version-level attributes excluded for brevity
 
@@ -461,7 +461,7 @@ Versions for a schema named `com.example.telemetrydata`:
               "versionid": "2",
               "isdefault": false,
               "description": "device telemetry event data",
-              "ancestor": "1",
+              "ancestorid": "1",
               "format": "Protobuf/3",
               # other xRegistry Version-level attributes excluded for brevity
 
@@ -472,7 +472,7 @@ Versions for a schema named `com.example.telemetrydata`:
               "versionid": "3",
               "isdefault": true,
               "description": "device telemetry event data",
-              "ancestor": "2",
+              "ancestorid": "2",
               "format": "Protobuf/3",
               # other xRegistry Version-level attributes excluded for brevity
 
@@ -636,7 +636,7 @@ a schema, allowing for fine-grained access control.
 [xRegistry compatibility]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#compatibility-attribute
 [xRegistry version-ids]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#version-ids
 [xRegistry attributes-and-extensions]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#attributes-and-extensions
-[xRegistry ancestor]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#ancestor-attribute
+[xRegistry ancestorid]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#ancestorid-attribute
 [xRegistry pagination]: https://xregistry.io/xreg/xregistryspecs/pagination-v1/docs/spec.html
 [xRegistry deprecated]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#deprecated
 [xRegistry default-version]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#registry-design

--- a/tools/dict
+++ b/tools/dict
@@ -1,6 +1,7 @@
 acks
 amqp
 amqps
+ancestorid
 api
 apicur
 apicurio


### PR DESCRIPTION
- Remove filter text about flagging bad groups/resources. Treat them like
  "unknown attributes".
- Move [-1] syntax into "other dot notation uses", not part of core spec.
- Mandate that GET /model is always supported - for interop
- s/ancestor/ancestorid/g - for consistency
- add support for xregistry well-known files
- make ximportresources be a modelsource only thing


Fixes: #496 #495 #490 #494 #493 #488 