### PR TITLE
Add JSON Structure format identifier to Schema Registry

### DIFF
--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -974,7 +974,7 @@ Example:
 [MQTT 3.1.1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
 [CloudEvents]: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
 [CloudEvents Subscriptions API]: https://github.com/cloudevents/spec/blob/main/subscriptions/spec.md
-[NATS]: https://docs.nats.io/reference/reference-protocols/nats-protocol
+[NATS]: https://docs.nats.io/reference/protocols/client/
 [Apache Kafka]: https://kafka.apache.org/protocol
 [Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html
 [Apache Kafka consumer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html

--- a/message/spec.md
+++ b/message/spec.md
@@ -1404,7 +1404,7 @@ Example:
 [MQTT 5.0]: https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html
 [MQTT 3.1.1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
 [CloudEvents]: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
-[NATS]: https://docs.nats.io/reference/reference-protocols/nats-protocol
+[NATS]: https://docs.nats.io/reference/protocols/client/
 [Apache Kafka]: https://kafka.apache.org/protocol
 [Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html
 [Apache Kafka consumer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -497,10 +497,11 @@ When the `format` attribute is set to `JsonSchema`, the `schema` attribute of
 the schema Resource is a JSON object representing a JSON Schema document
 conformant with the declared version.
 
-When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri),
-points to a JSON Schema document it MAY use a [JSON pointer][JSON pointer]
-expression to deep link into the schema document to reference a particular type
-definition. Otherwise the top-level object definition of the schema is used.
+When a URI, like the Message Registry's
+[`dataschemauri`](../message/spec.md#dataschemauri), points to a JSON Schema
+document it MAY use a [JSON pointer][JSON pointer] expression to deep link into
+the schema document to reference a particular type definition. Otherwise the
+top-level object definition of the schema is used.
 
 The version of the JSON Schema format is the version of the JSON Schema
 specification that is used to define the schema. The version of the JSON Schema
@@ -532,10 +533,11 @@ When the `format` attribute is set to `XSD`, the `schema` attribute of schema
 Resource is a string containing an XML Schema document conformant with the
 declared version.
 
-When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri),
-points to a JSON Schema document it MAY use an XPath expression to deep link
-into the schema document to reference a particular type definition. Otherwise
-the top-level object definition of the schema is used.
+When a URI, like the Message Registry's
+[`dataschemauri`](../message/spec.md#dataschemauri), points to a JSON Schema
+document it MAY use an XPath expression to deep link into the schema document to
+reference a particular type definition. Otherwise the top-level object
+definition of the schema is used.
 
 The identifiers for the following XML Schema versions:
 
@@ -562,12 +564,12 @@ Examples:
 - `Avro/1.8.2` is the identifier for the Apache Avro release 1.8.2.
 - `Avro/1.11.0` is the identifier for the Apache Avro release 1.11.0
 
-When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri),
-points to a JSON Schema document it MAY use a URI fragment suffix
-`[:]{record-name}` to deep link into the schema document to reference a
-particular type definition. Otherwise the top-level object definition of the
-schema is used. The ':' character is used as a separator when the URI already
-contains a fragment.
+When a URI, like the Message Registry's
+[`dataschemauri`](../message/spec.md#dataschemauri), points to a JSON Schema
+document it MAY use a URI fragment suffix `[:]{record-name}` to deep link into
+the schema document to reference a particular type definition. Otherwise the
+top-level object definition of the schema is used. The ':' character is used as
+a separator when the URI already contains a fragment.
 
 Examples:
 
@@ -594,11 +596,11 @@ with the declared version.
 - `Protobuf/3` is the identifier for the Protobuf syntax version 3.
 - `Protobuf/2` is the identifier for the Protobuf syntax version 2.
 
-A URI, like [`dataschemauri`](../message/spec.md#dataschemauri) that
-points to a Protobuf Schema document MUST reference a Protobuf `message`
-declaration contained in the schema document using a URI fragment suffix
-`[:]{message-name}`. The ':' character is used as a separator when the URI
-already contains a fragment.
+A URI, like the Message Registry's
+[`dataschemauri`](../message/spec.md#dataschemauri), that points to a Protobuf
+Schema document MUST reference a Protobuf `message` declaration contained in the
+schema document using a URI fragment suffix `[:]{message-name}`. The ':'
+character is used as a separator when the URI already contains a fragment.
 
 Examples:
 
@@ -628,11 +630,11 @@ the JSON Structure Core specification. If a future RFC is published, the
 version identifier will be updated to reflect the RFC number, for example
 `JsonStructure/rfc-0000`.
 
-When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri), points to a
-JSON Structure schema document, it MAY use a [JSON pointer][JSON pointer]
-expression to deep link into the schema document to reference a particular type
-definition. This is typically used to reference type definitions within the
-`definitions` namespace.
+When a URI, like the Message Registry's
+[`dataschemauri`](../message/spec.md#dataschemauri), points to a JSON Structure
+schema document, it MAY use a [JSON pointer][JSON pointer] expression to deep
+link into the schema document to reference a particular type definition. This is
+typically used to reference type definitions within the `definitions` namespace.
 
 Examples:
 

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -534,7 +534,7 @@ Resource is a string containing an XML Schema document conformant with the
 declared version.
 
 When a URI, like the Message Registry's
-[`dataschemauri`](../message/spec.md#dataschemauri), points to a JSON Schema
+[`dataschemauri`](../message/spec.md#dataschemauri), points to an XML Schema
 document it MAY use an XPath expression to deep link into the schema document to
 reference a particular type definition. Otherwise the top-level object
 definition of the schema is used.
@@ -565,7 +565,7 @@ Examples:
 - `Avro/1.11.0` is the identifier for the Apache Avro release 1.11.0
 
 When a URI, like the Message Registry's
-[`dataschemauri`](../message/spec.md#dataschemauri), points to a JSON Schema
+[`dataschemauri`](../message/spec.md#dataschemauri), points to an Avro Schema
 document it MAY use a URI fragment suffix `[:]{record-name}` to deep link into
 the schema document to reference a particular type definition. Otherwise the
 top-level object definition of the schema is used. The ':' character is used as

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -2,6 +2,7 @@
 
 <!-- words: formatvalidated compatibilityvalidated -->
 <!-- words: formatvalidatedreason compatibilityvalidatedreason -->
+<!-- words: jsonstructure jstruct namespace -->
 
 ## Abstract
 

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -32,6 +32,7 @@ allows for the storage, management and discovery of schema documents.
     - [4.3.2. XML Schema](#432-xml-schema)
     - [4.3.3. Apache Avro Schema](#433-apache-avro-schema)
     - [4.3.4. Protobuf Schema](#434-protobuf-schema)
+    - [4.3.5. JSON Structure Schema](#435-json-structure-schema)
 
 ## 1. Overview
 
@@ -495,7 +496,7 @@ When the `format` attribute is set to `JsonSchema`, the `schema` attribute of
 the schema Resource is a JSON object representing a JSON Schema document
 conformant with the declared version.
 
-When a URI, like [`schemauri`](../message/spec.md#dataschemauri),
+When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri),
 points to a JSON Schema document it MAY use a [JSON pointer][JSON pointer]
 expression to deep link into the schema document to reference a particular type
 definition. Otherwise the top-level object definition of the schema is used.
@@ -530,7 +531,7 @@ When the `format` attribute is set to `XSD`, the `schema` attribute of schema
 Resource is a string containing an XML Schema document conformant with the
 declared version.
 
-When a URI, like [`schemauri`](../message/spec.md#dataschemauri),
+When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri),
 points to a JSON Schema document it MAY use an XPath expression to deep link
 into the schema document to reference a particular type definition. Otherwise
 the top-level object definition of the schema is used.
@@ -560,7 +561,7 @@ Examples:
 - `Avro/1.8.2` is the identifier for the Apache Avro release 1.8.2.
 - `Avro/1.11.0` is the identifier for the Apache Avro release 1.11.0
 
-When a URI, like [`schemauri`](../message/spec.md#dataschemauri),
+When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri),
 points to a JSON Schema document it MAY use a URI fragment suffix
 `[:]{record-name}` to deep link into the schema document to reference a
 particular type definition. Otherwise the top-level object definition of the
@@ -592,7 +593,7 @@ with the declared version.
 - `Protobuf/3` is the identifier for the Protobuf syntax version 3.
 - `Protobuf/2` is the identifier for the Protobuf syntax version 2.
 
-A URI, like [`schemauri`](../message/spec.md#dataschemauri) that
+A URI, like [`dataschemauri`](../message/spec.md#dataschemauri) that
 points to a Protobuf Schema document MUST reference a Protobuf `message`
 declaration contained in the schema document using a URI fragment suffix
 `[:]{message-name}`. The ':' character is used as a separator when the URI
@@ -609,6 +610,38 @@ Examples:
   the which the reference is already in the form of a URI fragment, the suffix
   is appended separated with a colon, for instance
   `.../com.example.telemetrydata:TelemetryEvent`.
+
+#### 4.3.5. JSON Structure Schema
+
+The [`format`](../core/spec.md#format-attribute) identifier for JSON Structure
+Schema is `JsonStructure`. When the `format` attribute is set to `JsonStructure`,
+the `schema` attribute of the schema Resource is a JSON object representing a JSON
+Structure schema document [JSTRUCT-CORE].
+
+The version identifier follows the pattern `JsonStructure/{version}`, where
+`{version}` is the version of the JSON Structure Core specification that is
+used to define the schema.
+
+`JsonStructure/draft-04` is the identifier for the Internet-Draft version 04 of
+the JSON Structure Core specification. If a future RFC is published, the
+version identifier will be updated to reflect the RFC number, for example
+`JsonStructure/rfc-0000`.
+
+When a URI, like [`dataschemauri`](../message/spec.md#dataschemauri), points to a
+JSON Structure schema document, it MAY use a [JSON pointer][JSON pointer]
+expression to deep link into the schema document to reference a particular type
+definition. This is typically used to reference type definitions within the
+`definitions` namespace.
+
+Examples:
+
+- `https://example.com/schemas/person.json#/definitions/Employee` uses the
+  `#/definitions/Employee` fragment to reference the `Employee` type definition.
+- For local Schema Registry references like
+  `#/schemagroups/com.example.schemas/schemas/com.example.person/versions/1/definitions/Employee`,
+  append the JSON Pointer fragment to reference a specific type within that schema.
+
+
 
 Like the [xRegistry Core][xRegistry Core] specification, this specification does
 not explicitly address authentication or authorization levels of users, nor how
@@ -629,6 +662,7 @@ a schema, allowing for fine-grained access control.
 ---
 
 [JSON Pointer]: https://www.rfc-editor.org/rfc/rfc6901
+[JSTRUCT-CORE]: https://json-structure.github.io/core/draft-vasters-json-structure-core.html
 [CloudEvents dataschema]: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema
 [xRegistry Core]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html
 [xRegistry self]: https://xregistry.io/xreg/xregistryspecs/core-v1/docs/spec.html#self-attribute


### PR DESCRIPTION
## Summary

This PR implements support for JSON Structure schema format in the xRegistry Schema Registry specification.

## Changes

- Add new section 4.3.5 documenting JSON Structure schema format
- Define format identifier as \JsonStructure\ 
- Support version identifier \JsonStructure/draft-04\
- Document deep-linking via JSON Pointer to type definitions within the \definitions\ namespace
- Include practical examples for both external and Schema Registry local references

## Format Details

- **Identifier:** \JsonStructure\
- **Current Version:** \JsonStructure/draft-04\ (Internet-Draft version 04)
- **Deep-linking:** Via JSON Pointer fragments to reference type definitions in the \definitions\ namespace
- **Storage:** Schema documents stored as JSON objects

## Related Issue

Closes #506

## References

- JSON Structure Specification: https://json-structure.github.io/core/draft-vasters-json-structure-core.html
- xRegistry Schema Registry: schema/spec.md