### PR TITLE
fix(endpoint): align authorization and protocol options guidance

### DIFF
--- a/cloudevents/samples/scenarios/mqtt-sparkplugB.xreg.json
+++ b/cloudevents/samples/scenarios/mqtt-sparkplugB.xreg.json
@@ -1,7 +1,7 @@
 {
   "endpoints": {
     "Eclipse.SparkplugBv10EdgeNodeProducer": {
-      "description": "This declaration is for the endpoint to which an Sparkplug B v1.0 edge node produces messages",
+      "description": "Endpoint to which a Sparkplug B v1.0 Edge Node publishes its NBIRTH, NDATA and NDEATH messages. Each message definition carries its own topic, so no endpoint-level publish topic is declared",
       "usage": [
         "producer"
       ],
@@ -9,32 +9,52 @@
       "deployed": false,
       "endpoints": [],
       "protocoloptions": {
-        "topic": "spBv1.0/{group_id}/{message_type}/{edge_node_id}",
-        "willmessage": "/messagegroups/Eclipse.SparkplugB.EdgeNode/messages/NDEATH",
-        "willtopic": "spBv1.0/{group_id}/NDEATH/{edge_node_id}"
+        "cleansession": true,
+        "willtopic": "spBv1.0/{group_id}/NDEATH/{edge_node_id}",
+        "willmessage": "/messagegroups/Eclipse.SparkplugB.EdgeNode/messages/NDEATH"
       },
       "messagegroups": [
         "/messagegroups/Eclipse.SparkplugB.EdgeNode"
       ]
     },
-    "Eclipse.SparkplugBv10EdgeNodeConsumer": {
-      "description": "This declaration is for the endpoint from which an Sparkplug B v1.0 edge node consumes messages",
+    "Eclipse.SparkplugBv10EdgeNodeCommandConsumer": {
+      "description": "Endpoint on which a Sparkplug B v1.0 Edge Node subscribes for NCMD messages. Sparkplug requires this subscription at QoS 1 so that rebirth requests are always honored",
       "usage": [
+        "subscriber",
         "consumer"
       ],
       "protocol": "MQTT/3.1.1",
       "deployed": false,
       "endpoints": [],
       "protocoloptions": {
-        "topic": "spBv1.0/STATE/#,spBv1.0/{group_id}/NCMD/{edge_node_id},spBv1.0/{group_id}/DCMD/{edge_node_id}/#"
+        "cleansession": true,
+        "topicfilter": "spBv1.0/{group_id}/NCMD/{edge_node_id}",
+        "qos": 1
       },
       "messagegroups": [
-        "/messagegroups/Eclipse.SparkplugB.EdgeNodeCommands",
+        "/messagegroups/Eclipse.SparkplugB.EdgeNodeCommands"
+      ]
+    },
+    "Eclipse.SparkplugBv10EdgeNodePrimaryHostStateConsumer": {
+      "description": "Endpoint on which a Sparkplug B v1.0 Edge Node that is configured with a Primary Host Application subscribes for that host's STATE messages",
+      "usage": [
+        "subscriber",
+        "consumer"
+      ],
+      "protocol": "MQTT/3.1.1",
+      "deployed": false,
+      "endpoints": [],
+      "protocoloptions": {
+        "cleansession": true,
+        "topicfilter": "spBv1.0/STATE/{sparkplug_host_id}",
+        "qos": 1
+      },
+      "messagegroups": [
         "/messagegroups/Eclipse.SparkplugB.HostApplicationState"
       ]
     },
     "Eclipse.SparkplugBv10DeviceProducer": {
-      "description": "This declaration is for the endpoint to which an Sparkplug B v1.0 device produces messages",
+      "description": "Endpoint to which an Edge Node publishes the DBIRTH, DDATA and DDEATH messages of an attached Sparkplug B v1.0 Device",
       "usage": [
         "producer"
       ],
@@ -47,22 +67,25 @@
       ]
     },
     "Eclipse.SparkplugBv10DeviceConsumer": {
-      "description": "This declaration is for the endpoint from which an Sparkplug B v1.0 device consumes messages",
+      "description": "Endpoint on which an Edge Node subscribes for DCMD messages targeting an attached Sparkplug B v1.0 Device that supports writing to outputs. Sparkplug requires this subscription at QoS 1",
       "usage": [
+        "subscriber",
         "consumer"
       ],
       "protocol": "MQTT/3.1.1",
       "deployed": false,
       "endpoints": [],
       "protocoloptions": {
-        "topic": "spBv1.0/{group_id}/DCMD/{edge_node_id}/{device_id}"
+        "cleansession": true,
+        "topicfilter": "spBv1.0/{group_id}/DCMD/{edge_node_id}/{device_id}",
+        "qos": 1
       },
       "messagegroups": [
         "/messagegroups/Eclipse.SparkplugB.DeviceCommands"
       ]
     },
     "Eclipse.SparkplugBv10HostApplicationProducer": {
-      "description": "Sparkplug B v1.0 Producer Endpoint for Host Applications",
+      "description": "Endpoint to which a Sparkplug B v1.0 Host Application publishes its STATE messages and the NCMD and DCMD commands it issues",
       "usage": [
         "producer"
       ],
@@ -70,14 +93,51 @@
       "deployed": false,
       "endpoints": [],
       "protocoloptions": {
-        "topic": "spBv1.0/STATE/{sparkplug_host_id}",
-        "willmessage": "/messagegroups/Eclipse.SparkplugB.HostApplication/messages/STATE.Death",
-        "willtopic": "spBv1.0/STATE/{sparkplug_host_id}"
+        "cleansession": true,
+        "willtopic": "spBv1.0/STATE/{sparkplug_host_id}",
+        "willmessage": "/messagegroups/Eclipse.SparkplugB.HostApplicationState/messages/STATE.Death"
       },
       "messagegroups": [
         "/messagegroups/Eclipse.SparkplugB.HostApplicationState",
         "/messagegroups/Eclipse.SparkplugB.DeviceCommands",
         "/messagegroups/Eclipse.SparkplugB.EdgeNodeCommands"
+      ]
+    },
+    "Eclipse.SparkplugBv10HostApplicationConsumer": {
+      "description": "Endpoint on which a Sparkplug B v1.0 Host Application subscribes to the Sparkplug topic namespace to receive Edge Node and Device messages",
+      "usage": [
+        "subscriber",
+        "consumer"
+      ],
+      "protocol": "MQTT/3.1.1",
+      "deployed": false,
+      "endpoints": [],
+      "protocoloptions": {
+        "cleansession": true,
+        "topicfilter": "spBv1.0/#",
+        "qos": 1
+      },
+      "messagegroups": [
+        "/messagegroups/Eclipse.SparkplugB.EdgeNode",
+        "/messagegroups/Eclipse.SparkplugB.Device"
+      ]
+    },
+    "Eclipse.SparkplugBv10HostApplicationStateConsumer": {
+      "description": "Endpoint on which a Sparkplug B v1.0 Host Application subscribes to its own STATE topic, so that it detects an 'offline' STATE published on its behalf while it is in fact online",
+      "usage": [
+        "subscriber",
+        "consumer"
+      ],
+      "protocol": "MQTT/3.1.1",
+      "deployed": false,
+      "endpoints": [],
+      "protocoloptions": {
+        "cleansession": true,
+        "topicfilter": "spBv1.0/STATE/{sparkplug_host_id}",
+        "qos": 1
+      },
+      "messagegroups": [
+        "/messagegroups/Eclipse.SparkplugB.HostApplicationState"
       ]
     }
   },
@@ -95,7 +155,7 @@
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         },
         "NDATA": {
           "description": "Data payload for Sparkplug Edge Nodes",
@@ -106,18 +166,18 @@
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         },
         "NDEATH": {
-          "description": "Death certificate for Sparkplug Edge Nodes",
+          "description": "Death certificate for Sparkplug Edge Nodes, registered as the MQTT Will Message. Sparkplug requires Will QoS 1 and Will Retain false",
           "protocol": "MQTT/3.1.1",
           "protocoloptions": {
             "topic_name": "spBv1.0/{group_id}/NDEATH/{edge_node_id}",
-            "qos": 0,
+            "qos": 1,
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         }
       }
     },
@@ -134,7 +194,7 @@
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         },
         "DDEATH": {
           "description": "Death certificate for Sparkplug Devices",
@@ -145,7 +205,7 @@
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         },
         "DDATA": {
           "description": "Device data telemetry message",
@@ -156,7 +216,7 @@
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         }
       }
     },
@@ -165,6 +225,7 @@
       "description": "Eclipse Sparkplug B is a lightweight messaging protocol for industrial IoT. This definition is for Sparkplug B v1.0 packets originating from a Host Application.",
       "messages": {
         "STATE.Death": {
+          "description": "Host Application Death Certificate, registered as the MQTT Will Message with 'online' set to false",
           "protocol": "MQTT/3.1.1",
           "protocoloptions": {
             "topic_name": "spBv1.0/STATE/{sparkplug_host_id}",
@@ -172,9 +233,10 @@
             "retain": true
           },
           "dataschemaformat": "JsonSchema/draft-07",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.JSON/versions/v1.0:messages/STATEDeath"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_JSON/versions/v1.0:messages/STATEDeath"
         },
         "STATE.Birth": {
+          "description": "Host Application Birth Certificate, published with 'online' set to true immediately after the MQTT session is established",
           "protocol": "MQTT/3.1.1",
           "protocoloptions": {
             "topic_name": "spBv1.0/STATE/{sparkplug_host_id}",
@@ -182,7 +244,7 @@
             "retain": true
           },
           "dataschemaformat": "JsonSchema/draft-07",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.JSON/versions/v1.0:messages/STATEBirth"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_JSON/versions/v1.0:messages/STATEBirth"
         }
       }
     },
@@ -191,6 +253,7 @@
       "description": "Eclipse Sparkplug B is a lightweight messaging protocol for industrial IoT. This definition is for Sparkplug B v1.0 packets originating from a Host Application.",
       "messages": {
         "NCMD": {
+          "description": "Command issued by a Host Application to an Edge Node, for example a 'Node Control/Rebirth' request",
           "protocol": "MQTT/3.1.1",
           "protocoloptions": {
             "topic_name": "spBv1.0/{group_id}/NCMD/{edge_node_id}",
@@ -198,7 +261,7 @@
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         }
       }
     },
@@ -207,6 +270,7 @@
       "description": "Eclipse Sparkplug B is a lightweight messaging protocol for industrial IoT. This definition is for Sparkplug B v1.0 packets originating from a Host Application.",
       "messages": {
         "DCMD": {
+          "description": "Command issued by a Host Application to write to the outputs of an attached Device",
           "protocol": "MQTT/3.1.1",
           "protocoloptions": {
             "topic_name": "spBv1.0/{group_id}/DCMD/{edge_node_id}/{device_id}",
@@ -214,7 +278,7 @@
             "retain": false
           },
           "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Sparkplug/schemas/SparkplugB.Protobuf/versions/v1.0:Payload"
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
         }
       }
     }
@@ -232,28 +296,27 @@
               "format": "JsonSchema/draft-07",
               "schema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
-                "$id": "https://raw.githubusercontent.com/Cirrus-Link/Sparkplug/master/sparkplug_b/sparkplug_b.json",
                 "title": "Sparkplug B JSON Messages",
-                "description": "Sparkplug B JSON Messages",
+                "description": "Sparkplug B STATE messages. Unlike all other Sparkplug messages, STATE messages are JSON UTF-8 documents rather than Sparkplug B Protobuf payloads",
                 "messages": {
                   "STATE": {
                     "type": "object",
+                    "description": "Sparkplug Host Application STATE payload, which carries exactly the two keys 'online' and 'timestamp'",
                     "properties": {
-                      "state": {
-                        "type": "string",
-                        "enum": [
-                          "online",
-                          "offline"
-                        ]
+                      "online": {
+                        "type": "boolean",
+                        "description": "Whether the Sparkplug Host Application is online"
                       },
                       "timestamp": {
-                        "type": "integer"
+                        "type": "integer",
+                        "description": "UTC time in milliseconds since the Epoch"
                       }
                     },
                     "required": [
-                      "state",
+                      "online",
                       "timestamp"
-                    ]
+                    ],
+                    "additionalProperties": false
                   },
                   "STATEDeath": {
                     "allOf": [
@@ -262,10 +325,8 @@
                       },
                       {
                         "properties": {
-                          "state": {
-                            "enum": [
-                              "offline"
-                            ]
+                          "online": {
+                            "const": false
                           }
                         }
                       }
@@ -278,10 +339,8 @@
                       },
                       {
                         "properties": {
-                          "state": {
-                            "enum": [
-                              "online"
-                            ]
+                          "online": {
+                            "const": true
                           }
                         }
                       }

--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -487,7 +487,7 @@
                 }
               },
               "name": "usage",
-              "doc": "Client's expected usage of this endpoint"
+              "doc": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous."
             },
             {
               "type": "string",
@@ -604,7 +604,7 @@
                 }
               },
               "name": "messagegroups",
-              "doc": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries."
+              "doc": "The message groups that are supported by this endpoint"
             },
             {
               "name": "Extensions",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -1405,7 +1405,7 @@
                       },
                       "durable": {
                         "type": "boolean",
-                        "description": "The AMQP durable flag. Whether the node is durable or transient"
+                        "description": "Whether the AMQP node identified by 'node' is durable rather than transient. This is a property of the node, not of the link terminus and not of the message header field of the same name. Terminus durability is expressed by 'terminus-durability'"
                       },
                       "link-properties": {
                         "type": "object",
@@ -1423,7 +1423,7 @@
                       },
                       "distribution-mode": {
                         "type": "string",
-                        "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message"
+                        "description": "The AMQP source distribution mode. 'move' means a transferred message is removed from the node and is therefore seen by only one receiver. 'copy' means the message remains at the node after transfer and may also be transferred to other receivers. This does not describe message locking"
                       },
                       "connection-capabilities": {
                         "type": "array",
@@ -1463,11 +1463,11 @@
                       },
                       "sender-settle-mode": {
                         "type": "string",
-                        "description": "AMQP sender settle mode"
+                        "description": "AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the client for a producer endpoint, the remote node for a consumer endpoint"
                       },
                       "receiver-settle-mode": {
                         "type": "string",
-                        "description": "AMQP receiver settle mode"
+                        "description": "AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a producer endpoint, the client for a consumer endpoint"
                       }
                     }
                   }
@@ -1536,7 +1536,7 @@
                       },
                       "topic": {
                         "type": "string",
-                        "description": "The MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                        "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
                       },
                       "qos": {
                         "type": "integer",
@@ -1547,13 +1547,9 @@
                         "type": "boolean",
                         "description": "The MQTT retain flag to use for publishers on ths endpoint"
                       },
-                      "cleansession": {
-                        "type": "boolean",
-                        "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
-                      },
                       "topicfilter": {
                         "type": "string",
-                        "description": "MQTT subscribe topic filter"
+                        "description": "MQTT subscribe topic filter. MAY contain the '+' and '#' wildcard characters"
                       },
                       "cleanstart": {
                         "type": "boolean",
@@ -1566,7 +1562,7 @@
                       },
                       "sharedsubscriptiongroup": {
                         "type": "string",
-                        "description": "MQTT 5 shared subscription group"
+                        "description": "MQTT 5 shared subscription group. It MUST only be used together with 'topicfilter' and MUST NOT include the '$share/' prefix"
                       },
                       "nolocal": {
                         "type": "boolean",
@@ -1657,7 +1653,7 @@
                       },
                       "topic": {
                         "type": "string",
-                        "description": "MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                        "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
                       },
                       "qos": {
                         "type": "integer",
@@ -1894,7 +1890,7 @@
                       },
                       "consumergroup": {
                         "type": "string",
-                        "description": "The Apache Kafka consumer group name to use for consumers"
+                        "description": "The Apache Kafka consumer group name. It MUST be present and non-empty on a 'consumer' endpoint and MUST be absent on a 'subscriber' endpoint"
                       },
                       "headers": {
                         "type": "object",
@@ -1986,15 +1982,15 @@
                       },
                       "subject": {
                         "type": "string",
-                        "description": "The NATS subject"
+                        "description": "The concrete NATS publish subject. It MUST NOT contain the '*' or '>' wildcard tokens"
                       },
                       "subjectfilter": {
                         "type": "string",
-                        "description": "The NATS subscription subject filter"
+                        "description": "The NATS subscription subject filter. It MAY contain the '*' and '>' wildcard tokens"
                       },
                       "queuegroup": {
                         "type": "string",
-                        "description": "The NATS queue group for queue subscriptions"
+                        "description": "The NATS queue group for queue subscriptions. It MUST only be used together with 'subjectfilter'"
                       }
                     }
                   }

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -1228,7 +1228,7 @@
           },
           "usage": {
             "type": "array",
-            "description": "Client's expected usage of this endpoint",
+            "description": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous.",
             "items": {
               "type": "string",
               "enum": [
@@ -1249,28 +1249,28 @@
               "effective": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint deprecation went into effect"
+                "description": "tbd"
               },
               "removal": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint will be removed"
+                "description": "tbd"
               },
               "alternative": {
                 "type": "string",
                 "format": "uri",
-                "description": "alternative endpoint to consider"
+                "description": "tbd"
               },
               "docs": {
                 "type": "string",
                 "format": "uri",
-                "description": "additional information about deprecation"
+                "description": "tbd"
               }
             }
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
+            "description": "The message groups that are supported by this endpoint",
             "items": {
               "type": "string",
               "format": "uri"
@@ -1356,14 +1356,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "AMQP Addressing URL"
+                              "description": "AMQP Addressing URI"
                             }
                           }
                         }
@@ -1376,7 +1376,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1387,20 +1391,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "node": {
                         "type": "string",
@@ -1441,6 +1438,36 @@
                         "items": {
                           "type": "string"
                         }
+                      },
+                      "source-filters": {
+                        "type": "object",
+                        "description": "AMQP source filters used for subscription/receive setup",
+                        "additionalProperties": {}
+                      },
+                      "dynamic": {
+                        "type": "boolean",
+                        "description": "Whether a dynamic source or target is requested"
+                      },
+                      "terminus-durability": {
+                        "type": "string",
+                        "description": "Durability mode for the applicable source/target terminus"
+                      },
+                      "expiry-policy": {
+                        "type": "string",
+                        "description": "Expiry policy for the applicable source/target terminus"
+                      },
+                      "timeout": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Timeout in seconds for the applicable expiry policy"
+                      },
+                      "sender-settle-mode": {
+                        "type": "string",
+                        "description": "AMQP sender settle mode"
+                      },
+                      "receiver-settle-mode": {
+                        "type": "string",
+                        "description": "AMQP receiver settle mode"
                       }
                     }
                   }
@@ -1464,14 +1491,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                              "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                             }
                           }
                         }
@@ -1484,7 +1511,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1495,20 +1526,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "topic": {
                         "type": "string",
@@ -1525,7 +1549,37 @@
                       },
                       "cleansession": {
                         "type": "boolean",
-                        "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                        "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
+                      },
+                      "topicfilter": {
+                        "type": "string",
+                        "description": "MQTT subscribe topic filter"
+                      },
+                      "cleanstart": {
+                        "type": "boolean",
+                        "description": "MQTT 5 clean start flag"
+                      },
+                      "sessionexpiryinterval": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "MQTT 5 session expiry interval in seconds"
+                      },
+                      "sharedsubscriptiongroup": {
+                        "type": "string",
+                        "description": "MQTT 5 shared subscription group"
+                      },
+                      "nolocal": {
+                        "type": "boolean",
+                        "description": "MQTT 5 no-local subscription flag"
+                      },
+                      "retainaspublished": {
+                        "type": "boolean",
+                        "description": "MQTT 5 retain-as-published subscription flag"
+                      },
+                      "retainhandling": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "MQTT 5 retain-handling subscription mode"
                       },
                       "willtopic": {
                         "type": "string",
@@ -1558,14 +1612,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                              "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                             }
                           }
                         }
@@ -1578,7 +1632,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1589,20 +1647,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "topic": {
                         "type": "string",
@@ -1620,6 +1671,10 @@
                       "cleansession": {
                         "type": "boolean",
                         "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                      },
+                      "topicfilter": {
+                        "type": "string",
+                        "description": "MQTT subscribe topic filter"
                       },
                       "willtopic": {
                         "type": "string",
@@ -1652,14 +1707,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "HTTP URL"
+                              "description": "HTTP URI"
                             }
                           }
                         }
@@ -1672,7 +1727,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1683,20 +1742,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "method": {
                         "type": "string",
@@ -1728,6 +1780,26 @@
                         "additionalProperties": {
                           "type": "string"
                         }
+                      },
+                      "apikeyname": {
+                        "type": "string",
+                        "description": "Name of the API key header/query carrier when authorization.type is APIKey"
+                      },
+                      "apikeyin": {
+                        "type": "string",
+                        "description": "Placement of API key metadata for HTTP when authorization.type is APIKey. Expected values: header or query"
+                      },
+                      "plainscheme": {
+                        "type": "string",
+                        "description": "HTTP transport pattern when authorization.type is Plain. Expected values: basic, form, or query"
+                      },
+                      "plainusernamefield": {
+                        "type": "string",
+                        "description": "Parameter or header field name carrying the username when plainscheme is form or query"
+                      },
+                      "plainpasswordfield": {
+                        "type": "string",
+                        "description": "Parameter or header field name carrying the password when plainscheme is form or query"
                       }
                     }
                   }
@@ -1751,7 +1823,7 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -1781,7 +1853,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1792,20 +1868,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "topic": {
                         "type": "string",
@@ -1813,7 +1882,7 @@
                       },
                       "acks": {
                         "type": "integer",
-                        "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                        "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is 1"
                       },
                       "key": {
                         "type": "string",
@@ -1841,6 +1910,14 @@
                       "valueserializer": {
                         "type": "string",
                         "description": "The Kafka value serializer"
+                      },
+                      "autooffsetreset": {
+                        "type": "string",
+                        "description": "Consumer offset reset behavior when no valid committed offset exists"
+                      },
+                      "enableautocommit": {
+                        "type": "boolean",
+                        "description": "Whether the consumer commits offsets automatically"
                       }
                     }
                   }
@@ -1864,14 +1941,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "NATS URL"
+                              "description": "NATS URI"
                             }
                           }
                         }
@@ -1884,7 +1961,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1895,24 +1976,25 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "subject": {
                         "type": "string",
                         "description": "The NATS subject"
+                      },
+                      "subjectfilter": {
+                        "type": "string",
+                        "description": "The NATS subscription subject filter"
+                      },
+                      "queuegroup": {
+                        "type": "string",
+                        "description": "The NATS queue group for queue subscriptions"
                       }
                     }
                   }

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -4288,14 +4288,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "AMQP Addressing URL"
+                      "description": "AMQP Addressing URI"
                     }
                   }
                 }
@@ -4308,7 +4308,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -4319,20 +4323,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "node": {
                 "type": "string",
@@ -4373,6 +4370,36 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "source-filters": {
+                "type": "object",
+                "description": "AMQP source filters used for subscription/receive setup",
+                "additionalProperties": {}
+              },
+              "dynamic": {
+                "type": "boolean",
+                "description": "Whether a dynamic source or target is requested"
+              },
+              "terminus-durability": {
+                "type": "string",
+                "description": "Durability mode for the applicable source/target terminus"
+              },
+              "expiry-policy": {
+                "type": "string",
+                "description": "Expiry policy for the applicable source/target terminus"
+              },
+              "timeout": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Timeout in seconds for the applicable expiry policy"
+              },
+              "sender-settle-mode": {
+                "type": "string",
+                "description": "AMQP sender settle mode"
+              },
+              "receiver-settle-mode": {
+                "type": "string",
+                "description": "AMQP receiver settle mode"
               }
             }
           }
@@ -4396,14 +4423,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                      "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                     }
                   }
                 }
@@ -4416,7 +4443,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -4427,20 +4458,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "topic": {
                 "type": "string",
@@ -4458,6 +4482,10 @@
               "cleansession": {
                 "type": "boolean",
                 "description": "The MQTT clean session flag to use for publishers on this endpoint"
+              },
+              "topicfilter": {
+                "type": "string",
+                "description": "MQTT subscribe topic filter"
               },
               "willtopic": {
                 "type": "string",
@@ -4490,14 +4518,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                      "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                     }
                   }
                 }
@@ -4510,7 +4538,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -4521,20 +4553,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "topic": {
                 "type": "string",
@@ -4551,7 +4576,37 @@
               },
               "cleansession": {
                 "type": "boolean",
-                "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
+              },
+              "topicfilter": {
+                "type": "string",
+                "description": "MQTT subscribe topic filter"
+              },
+              "cleanstart": {
+                "type": "boolean",
+                "description": "MQTT 5 clean start flag"
+              },
+              "sessionexpiryinterval": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "MQTT 5 session expiry interval in seconds"
+              },
+              "sharedsubscriptiongroup": {
+                "type": "string",
+                "description": "MQTT 5 shared subscription group"
+              },
+              "nolocal": {
+                "type": "boolean",
+                "description": "MQTT 5 no-local subscription flag"
+              },
+              "retainaspublished": {
+                "type": "boolean",
+                "description": "MQTT 5 retain-as-published subscription flag"
+              },
+              "retainhandling": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "MQTT 5 retain-handling subscription mode"
               },
               "willtopic": {
                 "type": "string",
@@ -4584,7 +4639,7 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -4614,7 +4669,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -4625,20 +4684,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "topic": {
                 "type": "string",
@@ -4646,7 +4698,7 @@
               },
               "acks": {
                 "type": "integer",
-                "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is 1"
               },
               "key": {
                 "type": "string",
@@ -4674,6 +4726,14 @@
               "valueserializer": {
                 "type": "string",
                 "description": "The Kafka value serializer"
+              },
+              "autooffsetreset": {
+                "type": "string",
+                "description": "Consumer offset reset behavior when no valid committed offset exists"
+              },
+              "enableautocommit": {
+                "type": "boolean",
+                "description": "Whether the consumer commits offsets automatically"
               }
             }
           }
@@ -4697,14 +4757,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "HTTP URL"
+                      "description": "HTTP URI"
                     }
                   }
                 }
@@ -4717,7 +4777,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -4728,20 +4792,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "method": {
                 "type": "string",
@@ -4773,6 +4830,26 @@
                 "additionalProperties": {
                   "type": "string"
                 }
+              },
+              "apikeyname": {
+                "type": "string",
+                "description": "Name of the API key header/query carrier when authorization.type is APIKey"
+              },
+              "apikeyin": {
+                "type": "string",
+                "description": "Placement of API key metadata for HTTP when authorization.type is APIKey. Expected values: header or query"
+              },
+              "plainscheme": {
+                "type": "string",
+                "description": "HTTP transport pattern when authorization.type is Plain. Expected values: basic, form, or query"
+              },
+              "plainusernamefield": {
+                "type": "string",
+                "description": "Parameter or header field name carrying the username when plainscheme is form or query"
+              },
+              "plainpasswordfield": {
+                "type": "string",
+                "description": "Parameter or header field name carrying the password when plainscheme is form or query"
               }
             }
           }
@@ -4796,14 +4873,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "NATS URL"
+                      "description": "NATS URI"
                     }
                   }
                 }
@@ -4816,7 +4893,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -4827,24 +4908,25 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "subject": {
                 "type": "string",
                 "description": "The NATS subject"
+              },
+              "subjectfilter": {
+                "type": "string",
+                "description": "The NATS subscription subject filter"
+              },
+              "queuegroup": {
+                "type": "string",
+                "description": "The NATS queue group for queue subscriptions"
               }
             }
           }
@@ -5054,7 +5136,7 @@
           },
           "usage": {
             "type": "array",
-            "description": "Client's expected usage of this endpoint",
+            "description": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous.",
             "items": {
               "type": "string",
               "enum": [
@@ -5075,28 +5157,28 @@
               "effective": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint deprecation went into effect"
+                "description": "tbd"
               },
               "removal": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint will be removed"
+                "description": "tbd"
               },
               "alternative": {
                 "type": "string",
                 "format": "uri",
-                "description": "alternative endpoint to consider"
+                "description": "tbd"
               },
               "docs": {
                 "type": "string",
                 "format": "uri",
-                "description": "additional information about deprecation"
+                "description": "tbd"
               }
             }
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
+            "description": "The message groups that are supported by this endpoint",
             "items": {
               "type": "string",
               "format": "uri"

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -4337,7 +4337,7 @@
               },
               "durable": {
                 "type": "boolean",
-                "description": "The AMQP durable flag. Whether the node is durable or transient"
+                "description": "Whether the AMQP node identified by 'node' is durable rather than transient. This is a property of the node, not of the link terminus and not of the message header field of the same name. Terminus durability is expressed by 'terminus-durability'"
               },
               "link-properties": {
                 "type": "object",
@@ -4355,7 +4355,7 @@
               },
               "distribution-mode": {
                 "type": "string",
-                "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message"
+                "description": "The AMQP source distribution mode. 'move' means a transferred message is removed from the node and is therefore seen by only one receiver. 'copy' means the message remains at the node after transfer and may also be transferred to other receivers. This does not describe message locking"
               },
               "connection-capabilities": {
                 "type": "array",
@@ -4395,11 +4395,11 @@
               },
               "sender-settle-mode": {
                 "type": "string",
-                "description": "AMQP sender settle mode"
+                "description": "AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the client for a producer endpoint, the remote node for a consumer endpoint"
               },
               "receiver-settle-mode": {
                 "type": "string",
-                "description": "AMQP receiver settle mode"
+                "description": "AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a producer endpoint, the client for a consumer endpoint"
               }
             }
           }
@@ -4468,7 +4468,7 @@
               },
               "topic": {
                 "type": "string",
-                "description": "MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
               },
               "qos": {
                 "type": "integer",
@@ -4563,7 +4563,7 @@
               },
               "topic": {
                 "type": "string",
-                "description": "The MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
               },
               "qos": {
                 "type": "integer",
@@ -4574,13 +4574,9 @@
                 "type": "boolean",
                 "description": "The MQTT retain flag to use for publishers on ths endpoint"
               },
-              "cleansession": {
-                "type": "boolean",
-                "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
-              },
               "topicfilter": {
                 "type": "string",
-                "description": "MQTT subscribe topic filter"
+                "description": "MQTT subscribe topic filter. MAY contain the '+' and '#' wildcard characters"
               },
               "cleanstart": {
                 "type": "boolean",
@@ -4593,7 +4589,7 @@
               },
               "sharedsubscriptiongroup": {
                 "type": "string",
-                "description": "MQTT 5 shared subscription group"
+                "description": "MQTT 5 shared subscription group. It MUST only be used together with 'topicfilter' and MUST NOT include the '$share/' prefix"
               },
               "nolocal": {
                 "type": "boolean",
@@ -4710,7 +4706,7 @@
               },
               "consumergroup": {
                 "type": "string",
-                "description": "The Apache Kafka consumer group name to use for consumers"
+                "description": "The Apache Kafka consumer group name. It MUST be present and non-empty on a 'consumer' endpoint and MUST be absent on a 'subscriber' endpoint"
               },
               "headers": {
                 "type": "object",
@@ -4918,15 +4914,15 @@
               },
               "subject": {
                 "type": "string",
-                "description": "The NATS subject"
+                "description": "The concrete NATS publish subject. It MUST NOT contain the '*' or '>' wildcard tokens"
               },
               "subjectfilter": {
                 "type": "string",
-                "description": "The NATS subscription subject filter"
+                "description": "The NATS subscription subject filter. It MAY contain the '*' and '>' wildcard tokens"
               },
               "queuegroup": {
                 "type": "string",
-                "description": "The NATS queue group for queue subscriptions"
+                "description": "The NATS queue group for queue subscriptions. It MUST only be used together with 'subjectfilter'"
               }
             }
           }

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -6,19 +6,18 @@
     },
     "endpoints": {
       "singular": "endpoint",
-      "modelversion": "1.0-rc3",
+      "modelversion": "1.0-rc2",
       "modelcompatiblewith": "https://xregistry.io/xreg/domains/endpoint/specs/model.json",
       "attributes": {
         "usage": {
           "name": "usage",
           "type": "array",
-          "description": "Client's expected usage of this endpoint",
+          "description": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous.",
           "enum": [
             "subscriber",
             "consumer",
             "producer"
           ],
-          "strict": true,
           "item": {
             "type": "string"
           }
@@ -36,22 +35,22 @@
             "effective": {
               "name": "effective",
               "type": "timestamp",
-              "description": "date endpoint deprecation went into effect"
+              "description": "tbd"
             },
             "removal": {
               "name": "removal",
               "type": "timestamp",
-              "description": "date endpoint will be removed"
+              "description": "tbd"
             },
             "alternative": {
               "name": "alternative",
               "type": "url",
-              "description": "alternative endpoint to consider"
+              "description": "tbd"
             },
             "docs": {
               "name": "docs",
               "type": "url",
-              "description": "additional information about deprecation"
+              "description": "tbd"
             },
             "*": {
               "name": "*",
@@ -109,14 +108,14 @@
                     "endpoints": {
                       "name": "endpoints",
                       "type": "array",
-                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                       "item": {
                         "type": "object",
                         "attributes": {
-                          "url": {
-                            "name": "url",
-                            "type": "url",
-                            "description": "AMQP Addressing URL"
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "AMQP Addressing URI"
                           },
                           "*": {
                             "name": "*",
@@ -135,7 +134,12 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                          },
+                          "mechanism": {
+                            "name": "mechanism",
+                            "type": "string",
+                            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                           },
                           "resourceuri": {
                             "name": "resourceuri",
@@ -147,14 +151,6 @@
                             "type": "uri",
                             "description": "The authority uri where authorization shall be requested (if applicable)"
                           },
-                          "granttypes": {
-                            "name": "granttypes",
-                            "type": "array",
-                            "description": "The grant types that can be requested (if applicable)",
-                            "item": {
-                              "type": "string"
-                            }
-                          },
                           "*": {
                             "name": "*",
                             "type": "any"
@@ -165,9 +161,8 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "required": true,
-                      "default": false
+                      "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "default": true
                     },
                     "node": {
                       "name": "node",
@@ -224,6 +219,64 @@
                         "type": "string"
                       }
                     },
+                    "source-filters": {
+                      "name": "source-filters",
+                      "type": "map",
+                      "description": "AMQP source filters used for subscription/receive setup",
+                      "item": {
+                        "type": "any"
+                      }
+                    },
+                    "dynamic": {
+                      "name": "dynamic",
+                      "type": "boolean",
+                      "description": "Whether a dynamic source or target is requested"
+                    },
+                    "terminus-durability": {
+                      "name": "terminus-durability",
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "configuration",
+                        "unsettled-state"
+                      ],
+                      "description": "Durability mode for the applicable source/target terminus"
+                    },
+                    "expiry-policy": {
+                      "name": "expiry-policy",
+                      "type": "string",
+                      "enum": [
+                        "link-detach",
+                        "session-end",
+                        "connection-close",
+                        "never"
+                      ],
+                      "description": "Expiry policy for the applicable source/target terminus"
+                    },
+                    "timeout": {
+                      "name": "timeout",
+                      "type": "uinteger",
+                      "description": "Timeout in seconds for the applicable expiry policy"
+                    },
+                    "sender-settle-mode": {
+                      "name": "sender-settle-mode",
+                      "type": "string",
+                      "enum": [
+                        "unsettled",
+                        "settled",
+                        "mixed"
+                      ],
+                      "description": "AMQP sender settle mode"
+                    },
+                    "receiver-settle-mode": {
+                      "name": "receiver-settle-mode",
+                      "type": "string",
+                      "enum": [
+                        "first",
+                        "second"
+                      ],
+                      "description": "AMQP receiver settle mode"
+                    },
                     "*": {
                       "name": "*",
                       "type": "any"
@@ -242,14 +295,14 @@
                     "endpoints": {
                       "name": "endpoints",
                       "type": "array",
-                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                       "item": {
                         "type": "object",
                         "attributes": {
-                          "url": {
-                            "name": "url",
-                            "type": "url",
-                            "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                           },
                           "*": {
                             "name": "*",
@@ -268,25 +321,22 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                          },
+                          "mechanism": {
+                            "name": "mechanism",
+                            "type": "string",
+                            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                           },
                           "resourceuri": {
                             "name": "resourceuri",
-                            "type": "url",
+                            "type": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"
                           },
                           "authorityuri": {
                             "name": "authorityuri",
                             "type": "uri",
                             "description": "The authority uri where authorization shall be requested (if applicable)"
-                          },
-                          "granttypes": {
-                            "name": "granttypes",
-                            "type": "array",
-                            "description": "The grant types that can be requested (if applicable)",
-                            "item": {
-                              "type": "string"
-                            }
                           },
                           "*": {
                             "name": "*",
@@ -298,9 +348,8 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "required": true,
-                      "default": false
+                      "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "default": true
                     },
                     "topic": {
                       "name": "topic",
@@ -329,9 +378,49 @@
                     "cleansession": {
                       "name": "cleansession",
                       "type": "boolean",
-                      "description": "The MQTT clean session flag to use for publishers on this endpoint",
+                      "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval",
                       "required": true,
                       "default": true
+                    },
+                    "topicfilter": {
+                      "name": "topicfilter",
+                      "type": "string",
+                      "description": "MQTT subscribe topic filter"
+                    },
+                    "cleanstart": {
+                      "name": "cleanstart",
+                      "type": "boolean",
+                      "description": "MQTT 5 clean start flag"
+                    },
+                    "sessionexpiryinterval": {
+                      "name": "sessionexpiryinterval",
+                      "type": "uinteger",
+                      "description": "MQTT 5 session expiry interval in seconds"
+                    },
+                    "sharedsubscriptiongroup": {
+                      "name": "sharedsubscriptiongroup",
+                      "type": "string",
+                      "description": "MQTT 5 shared subscription group"
+                    },
+                    "nolocal": {
+                      "name": "nolocal",
+                      "type": "boolean",
+                      "description": "MQTT 5 no-local subscription flag"
+                    },
+                    "retainaspublished": {
+                      "name": "retainaspublished",
+                      "type": "boolean",
+                      "description": "MQTT 5 retain-as-published subscription flag"
+                    },
+                    "retainhandling": {
+                      "name": "retainhandling",
+                      "type": "uinteger",
+                      "enum": [
+                        0,
+                        1,
+                        2
+                      ],
+                      "description": "MQTT 5 retain-handling subscription mode"
                     },
                     "willtopic": {
                       "name": "willtopic",
@@ -362,14 +451,14 @@
                     "endpoints": {
                       "name": "endpoints",
                       "type": "array",
-                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                       "item": {
                         "type": "object",
                         "attributes": {
-                          "url": {
-                            "name": "url",
-                            "type": "url",
-                            "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                           },
                           "*": {
                             "name": "*",
@@ -388,25 +477,22 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                          },
+                          "mechanism": {
+                            "name": "mechanism",
+                            "type": "string",
+                            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                           },
                           "resourceuri": {
                             "name": "resourceuri",
-                            "type": "url",
+                            "type": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"
                           },
                           "authorityuri": {
                             "name": "authorityuri",
                             "type": "uri",
                             "description": "The authority uri where authorization shall be requested (if applicable)"
-                          },
-                          "granttypes": {
-                            "name": "granttypes",
-                            "type": "array",
-                            "description": "The grant types that can be requested (if applicable)",
-                            "item": {
-                              "type": "string"
-                            }
                           },
                           "*": {
                             "name": "*",
@@ -418,9 +504,8 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "required": true,
-                      "default": false
+                      "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "default": true
                     },
                     "topic": {
                       "name": "topic",
@@ -453,6 +538,11 @@
                       "required": true,
                       "default": true
                     },
+                    "topicfilter": {
+                      "name": "topicfilter",
+                      "type": "string",
+                      "description": "MQTT subscribe topic filter"
+                    },
                     "willtopic": {
                       "name": "willtopic",
                       "type": "string",
@@ -482,14 +572,14 @@
                     "endpoints": {
                       "name": "endpoints",
                       "type": "array",
-                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                       "item": {
                         "type": "object",
                         "attributes": {
-                          "url": {
-                            "name": "url",
-                            "type": "url",
-                            "description": "HTTP URL"
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "HTTP URI"
                           },
                           "*": {
                             "name": "*",
@@ -508,25 +598,22 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                          },
+                          "mechanism": {
+                            "name": "mechanism",
+                            "type": "string",
+                            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                           },
                           "resourceuri": {
                             "name": "resourceuri",
-                            "type": "url",
+                            "type": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"
                           },
                           "authorityuri": {
                             "name": "authorityuri",
                             "type": "uri",
                             "description": "The authority uri where authorization shall be requested (if applicable)"
-                          },
-                          "granttypes": {
-                            "name": "granttypes",
-                            "type": "array",
-                            "description": "The grant types that can be requested (if applicable)",
-                            "item": {
-                              "type": "string"
-                            }
                           },
                           "*": {
                             "name": "*",
@@ -538,9 +625,8 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "required": true,
-                      "default": false
+                      "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "default": true
                     },
                     "method": {
                       "name": "method",
@@ -578,6 +664,33 @@
                         "type": "string"
                       }
                     },
+                    "apikeyname": {
+                      "name": "apikeyname",
+                      "type": "string",
+                      "description": "Name of the API key header/query carrier when authorization.type is APIKey"
+                    },
+                    "apikeyin": {
+                      "name": "apikeyin",
+                      "type": "string",
+                      "description": "Placement of API key metadata for HTTP when authorization.type is APIKey. Expected values: header or query",
+                      "default": "header"
+                    },
+                    "plainscheme": {
+                      "name": "plainscheme",
+                      "type": "string",
+                      "description": "HTTP transport pattern when authorization.type is Plain. Expected values: basic, form, or query",
+                      "default": "basic"
+                    },
+                    "plainusernamefield": {
+                      "name": "plainusernamefield",
+                      "type": "string",
+                      "description": "Parameter or header field name carrying the username when plainscheme is form or query"
+                    },
+                    "plainpasswordfield": {
+                      "name": "plainpasswordfield",
+                      "type": "string",
+                      "description": "Parameter or header field name carrying the password when plainscheme is form or query"
+                    },
                     "*": {
                       "name": "*",
                       "type": "any"
@@ -596,7 +709,7 @@
                     "endpoints": {
                       "name": "endpoints",
                       "type": "array",
-                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                       "item": {
                         "type": "object",
                         "namecharset": "extended",
@@ -640,25 +753,22 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                          },
+                          "mechanism": {
+                            "name": "mechanism",
+                            "type": "string",
+                            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                           },
                           "resourceuri": {
                             "name": "resourceuri",
-                            "type": "url",
+                            "type": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"
                           },
                           "authorityuri": {
                             "name": "authorityuri",
                             "type": "uri",
                             "description": "The authority uri where authorization shall be requested (if applicable)"
-                          },
-                          "granttypes": {
-                            "name": "granttypes",
-                            "type": "array",
-                            "description": "The grant types that can be requested (if applicable)",
-                            "item": {
-                              "type": "string"
-                            }
                           },
                           "*": {
                             "name": "*",
@@ -670,9 +780,8 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "required": true,
-                      "default": false
+                      "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "default": true
                     },
                     "topic": {
                       "name": "topic",
@@ -682,7 +791,7 @@
                     "acks": {
                       "name": "acks",
                       "type": "integer",
-                      "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1",
+                      "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is 1",
                       "required": true,
                       "default": 1
                     },
@@ -723,6 +832,21 @@
                       "required": true,
                       "default": "org.apache.kafka.common.serialization.StringSerializer"
                     },
+                    "autooffsetreset": {
+                      "name": "autooffsetreset",
+                      "type": "string",
+                      "enum": [
+                        "earliest",
+                        "latest",
+                        "none"
+                      ],
+                      "description": "Consumer offset reset behavior when no valid committed offset exists"
+                    },
+                    "enableautocommit": {
+                      "name": "enableautocommit",
+                      "type": "boolean",
+                      "description": "Whether the consumer commits offsets automatically"
+                    },
                     "*": {
                       "name": "*",
                       "type": "any"
@@ -741,14 +865,14 @@
                     "endpoints": {
                       "name": "endpoints",
                       "type": "array",
-                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                      "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                       "item": {
                         "type": "object",
                         "attributes": {
-                          "url": {
-                            "name": "url",
-                            "type": "url",
-                            "description": "NATS URL"
+                          "uri": {
+                            "name": "uri",
+                            "type": "uri",
+                            "description": "NATS URI"
                           },
                           "*": {
                             "name": "*",
@@ -767,25 +891,22 @@
                           "type": {
                             "name": "type",
                             "type": "string",
-                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                          },
+                          "mechanism": {
+                            "name": "mechanism",
+                            "type": "string",
+                            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                           },
                           "resourceuri": {
                             "name": "resourceuri",
-                            "type": "url",
+                            "type": "uri",
                             "description": "The resource uri for which authorization shall be granted (if applicable)"
                           },
                           "authorityuri": {
                             "name": "authorityuri",
                             "type": "uri",
                             "description": "The authority uri where authorization shall be requested (if applicable)"
-                          },
-                          "granttypes": {
-                            "name": "granttypes",
-                            "type": "array",
-                            "description": "The grant types that can be requested (if applicable)",
-                            "item": {
-                              "type": "string"
-                            }
                           },
                           "*": {
                             "name": "*",
@@ -797,14 +918,23 @@
                     "deployed": {
                       "name": "deployed",
                       "type": "boolean",
-                      "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint",
-                      "required": true,
-                      "default": false
+                      "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "default": true
                     },
                     "subject": {
                       "name": "subject",
                       "type": "string",
                       "description": "The NATS subject"
+                    },
+                    "subjectfilter": {
+                      "name": "subjectfilter",
+                      "type": "string",
+                      "description": "The NATS subscription subject filter"
+                    },
+                    "queuegroup": {
+                      "name": "queuegroup",
+                      "type": "string",
+                      "description": "The NATS queue group for queue subscriptions"
                     },
                     "*": {
                       "name": "*",
@@ -819,9 +949,9 @@
         "messagegroups": {
           "name": "messagegroups",
           "type": "array",
-          "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
+          "description": "The message groups that are supported by this endpoint",
           "item": {
-            "type": "uri",
+            "type": "xid",
             "target": "/messagegroups/messages"
           }
         },

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -173,7 +173,7 @@
                     "durable": {
                       "name": "durable",
                       "type": "boolean",
-                      "description": "The AMQP durable flag. Whether the node is durable or transient",
+                      "description": "Whether the AMQP node identified by 'node' is durable rather than transient. This is a property of the node, not of the link terminus and not of the message header field of the same name. Terminus durability is expressed by 'terminus-durability'",
                       "required": true,
                       "default": false
                     },
@@ -200,7 +200,7 @@
                         "move",
                         "copy"
                       ],
-                      "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message",
+                      "description": "The AMQP source distribution mode. 'move' means a transferred message is removed from the node and is therefore seen by only one receiver. 'copy' means the message remains at the node after transfer and may also be transferred to other receivers. This does not describe message locking",
                       "required": true,
                       "default": "move"
                     },
@@ -267,7 +267,7 @@
                         "settled",
                         "mixed"
                       ],
-                      "description": "AMQP sender settle mode"
+                      "description": "AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the client for a producer endpoint, the remote node for a consumer endpoint"
                     },
                     "receiver-settle-mode": {
                       "name": "receiver-settle-mode",
@@ -276,7 +276,7 @@
                         "first",
                         "second"
                       ],
-                      "description": "AMQP receiver settle mode"
+                      "description": "AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a producer endpoint, the client for a consumer endpoint"
                     },
                     "*": {
                       "name": "*",
@@ -356,7 +356,7 @@
                     "topic": {
                       "name": "topic",
                       "type": "string",
-                      "description": "The MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                      "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
                     },
                     "qos": {
                       "name": "qos",
@@ -377,17 +377,10 @@
                       "required": true,
                       "default": false
                     },
-                    "cleansession": {
-                      "name": "cleansession",
-                      "type": "boolean",
-                      "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval",
-                      "required": true,
-                      "default": true
-                    },
                     "topicfilter": {
                       "name": "topicfilter",
                       "type": "string",
-                      "description": "MQTT subscribe topic filter"
+                      "description": "MQTT subscribe topic filter. MAY contain the '+' and '#' wildcard characters"
                     },
                     "cleanstart": {
                       "name": "cleanstart",
@@ -402,7 +395,7 @@
                     "sharedsubscriptiongroup": {
                       "name": "sharedsubscriptiongroup",
                       "type": "string",
-                      "description": "MQTT 5 shared subscription group"
+                      "description": "MQTT 5 shared subscription group. It MUST only be used together with 'topicfilter' and MUST NOT include the '$share/' prefix"
                     },
                     "nolocal": {
                       "name": "nolocal",
@@ -513,7 +506,7 @@
                     "topic": {
                       "name": "topic",
                       "type": "string",
-                      "description": "MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                      "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
                     },
                     "qos": {
                       "name": "qos",
@@ -815,7 +808,7 @@
                     "consumergroup": {
                       "name": "consumergroup",
                       "type": "string",
-                      "description": "The Apache Kafka consumer group name to use for consumers"
+                      "description": "The Apache Kafka consumer group name. It MUST be present and non-empty on a 'consumer' endpoint and MUST be absent on a 'subscriber' endpoint"
                     },
                     "headers": {
                       "name": "headers",
@@ -932,17 +925,17 @@
                     "subject": {
                       "name": "subject",
                       "type": "string",
-                      "description": "The NATS subject"
+                      "description": "The concrete NATS publish subject. It MUST NOT contain the '*' or '>' wildcard tokens"
                     },
                     "subjectfilter": {
                       "name": "subjectfilter",
                       "type": "string",
-                      "description": "The NATS subscription subject filter"
+                      "description": "The NATS subscription subject filter. It MAY contain the '*' and '>' wildcard tokens"
                     },
                     "queuegroup": {
                       "name": "queuegroup",
                       "type": "string",
-                      "description": "The NATS queue group for queue subscriptions"
+                      "description": "The NATS queue group for queue subscriptions. It MUST only be used together with 'subjectfilter'"
                     },
                     "*": {
                       "name": "*",

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -6,7 +6,7 @@
     },
     "endpoints": {
       "singular": "endpoint",
-      "modelversion": "1.0-rc2",
+      "modelversion": "1.0-rc3",
       "modelcompatiblewith": "https://xregistry.io/xreg/domains/endpoint/specs/model.json",
       "attributes": {
         "usage": {
@@ -162,6 +162,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "required": true,
                       "default": true
                     },
                     "node": {
@@ -349,6 +350,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "required": true,
                       "default": true
                     },
                     "topic": {
@@ -505,6 +507,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "required": true,
                       "default": true
                     },
                     "topic": {
@@ -626,6 +629,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "required": true,
                       "default": true
                     },
                     "method": {
@@ -673,12 +677,14 @@
                       "name": "apikeyin",
                       "type": "string",
                       "description": "Placement of API key metadata for HTTP when authorization.type is APIKey. Expected values: header or query",
+                      "required": true,
                       "default": "header"
                     },
                     "plainscheme": {
                       "name": "plainscheme",
                       "type": "string",
                       "description": "HTTP transport pattern when authorization.type is Plain. Expected values: basic, form, or query",
+                      "required": true,
                       "default": "basic"
                     },
                     "plainusernamefield": {
@@ -781,6 +787,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "required": true,
                       "default": true
                     },
                     "topic": {
@@ -919,6 +926,7 @@
                       "name": "deployed",
                       "type": "boolean",
                       "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication",
+                      "required": true,
                       "default": true
                     },
                     "subject": {

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -487,7 +487,7 @@
                 }
               },
               "name": "usage",
-              "doc": "Client's expected usage of this endpoint"
+              "doc": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous."
             },
             {
               "type": "string",
@@ -604,7 +604,7 @@
                 }
               },
               "name": "messagegroups",
-              "doc": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries."
+              "doc": "The message groups that are supported by this endpoint"
             },
             {
               "name": "Extensions",

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -1399,7 +1399,7 @@
                       },
                       "durable": {
                         "type": "boolean",
-                        "description": "The AMQP durable flag. Whether the node is durable or transient"
+                        "description": "Whether the AMQP node identified by 'node' is durable rather than transient. This is a property of the node, not of the link terminus and not of the message header field of the same name. Terminus durability is expressed by 'terminus-durability'"
                       },
                       "link-properties": {
                         "type": "object",
@@ -1417,7 +1417,7 @@
                       },
                       "distribution-mode": {
                         "type": "string",
-                        "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message"
+                        "description": "The AMQP source distribution mode. 'move' means a transferred message is removed from the node and is therefore seen by only one receiver. 'copy' means the message remains at the node after transfer and may also be transferred to other receivers. This does not describe message locking"
                       },
                       "connection-capabilities": {
                         "type": "array",
@@ -1457,11 +1457,11 @@
                       },
                       "sender-settle-mode": {
                         "type": "string",
-                        "description": "AMQP sender settle mode"
+                        "description": "AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the client for a producer endpoint, the remote node for a consumer endpoint"
                       },
                       "receiver-settle-mode": {
                         "type": "string",
-                        "description": "AMQP receiver settle mode"
+                        "description": "AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a producer endpoint, the client for a consumer endpoint"
                       }
                     }
                   }
@@ -1530,7 +1530,7 @@
                       },
                       "topic": {
                         "type": "string",
-                        "description": "The MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                        "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
                       },
                       "qos": {
                         "type": "integer",
@@ -1541,13 +1541,9 @@
                         "type": "boolean",
                         "description": "The MQTT retain flag to use for publishers on ths endpoint"
                       },
-                      "cleansession": {
-                        "type": "boolean",
-                        "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
-                      },
                       "topicfilter": {
                         "type": "string",
-                        "description": "MQTT subscribe topic filter"
+                        "description": "MQTT subscribe topic filter. MAY contain the '+' and '#' wildcard characters"
                       },
                       "cleanstart": {
                         "type": "boolean",
@@ -1560,7 +1556,7 @@
                       },
                       "sharedsubscriptiongroup": {
                         "type": "string",
-                        "description": "MQTT 5 shared subscription group"
+                        "description": "MQTT 5 shared subscription group. It MUST only be used together with 'topicfilter' and MUST NOT include the '$share/' prefix"
                       },
                       "nolocal": {
                         "type": "boolean",
@@ -1651,7 +1647,7 @@
                       },
                       "topic": {
                         "type": "string",
-                        "description": "MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                        "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
                       },
                       "qos": {
                         "type": "integer",
@@ -1888,7 +1884,7 @@
                       },
                       "consumergroup": {
                         "type": "string",
-                        "description": "The Apache Kafka consumer group name to use for consumers"
+                        "description": "The Apache Kafka consumer group name. It MUST be present and non-empty on a 'consumer' endpoint and MUST be absent on a 'subscriber' endpoint"
                       },
                       "headers": {
                         "type": "object",
@@ -1980,15 +1976,15 @@
                       },
                       "subject": {
                         "type": "string",
-                        "description": "The NATS subject"
+                        "description": "The concrete NATS publish subject. It MUST NOT contain the '*' or '>' wildcard tokens"
                       },
                       "subjectfilter": {
                         "type": "string",
-                        "description": "The NATS subscription subject filter"
+                        "description": "The NATS subscription subject filter. It MAY contain the '*' and '>' wildcard tokens"
                       },
                       "queuegroup": {
                         "type": "string",
-                        "description": "The NATS queue group for queue subscriptions"
+                        "description": "The NATS queue group for queue subscriptions. It MUST only be used together with 'subjectfilter'"
                       }
                     }
                   }

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -1222,7 +1222,7 @@
           },
           "usage": {
             "type": "array",
-            "description": "Client's expected usage of this endpoint",
+            "description": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous.",
             "items": {
               "type": "string",
               "enum": [
@@ -1243,28 +1243,28 @@
               "effective": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint deprecation went into effect"
+                "description": "tbd"
               },
               "removal": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint will be removed"
+                "description": "tbd"
               },
               "alternative": {
                 "type": "string",
                 "format": "uri",
-                "description": "alternative endpoint to consider"
+                "description": "tbd"
               },
               "docs": {
                 "type": "string",
                 "format": "uri",
-                "description": "additional information about deprecation"
+                "description": "tbd"
               }
             }
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
+            "description": "The message groups that are supported by this endpoint",
             "items": {
               "type": "string",
               "format": "uri"
@@ -1350,14 +1350,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "AMQP Addressing URL"
+                              "description": "AMQP Addressing URI"
                             }
                           }
                         }
@@ -1370,7 +1370,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1381,20 +1385,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "node": {
                         "type": "string",
@@ -1435,6 +1432,36 @@
                         "items": {
                           "type": "string"
                         }
+                      },
+                      "source-filters": {
+                        "type": "object",
+                        "description": "AMQP source filters used for subscription/receive setup",
+                        "additionalProperties": {}
+                      },
+                      "dynamic": {
+                        "type": "boolean",
+                        "description": "Whether a dynamic source or target is requested"
+                      },
+                      "terminus-durability": {
+                        "type": "string",
+                        "description": "Durability mode for the applicable source/target terminus"
+                      },
+                      "expiry-policy": {
+                        "type": "string",
+                        "description": "Expiry policy for the applicable source/target terminus"
+                      },
+                      "timeout": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Timeout in seconds for the applicable expiry policy"
+                      },
+                      "sender-settle-mode": {
+                        "type": "string",
+                        "description": "AMQP sender settle mode"
+                      },
+                      "receiver-settle-mode": {
+                        "type": "string",
+                        "description": "AMQP receiver settle mode"
                       }
                     }
                   }
@@ -1458,14 +1485,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                              "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                             }
                           }
                         }
@@ -1478,7 +1505,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1489,20 +1520,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "topic": {
                         "type": "string",
@@ -1519,7 +1543,37 @@
                       },
                       "cleansession": {
                         "type": "boolean",
-                        "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                        "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
+                      },
+                      "topicfilter": {
+                        "type": "string",
+                        "description": "MQTT subscribe topic filter"
+                      },
+                      "cleanstart": {
+                        "type": "boolean",
+                        "description": "MQTT 5 clean start flag"
+                      },
+                      "sessionexpiryinterval": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "MQTT 5 session expiry interval in seconds"
+                      },
+                      "sharedsubscriptiongroup": {
+                        "type": "string",
+                        "description": "MQTT 5 shared subscription group"
+                      },
+                      "nolocal": {
+                        "type": "boolean",
+                        "description": "MQTT 5 no-local subscription flag"
+                      },
+                      "retainaspublished": {
+                        "type": "boolean",
+                        "description": "MQTT 5 retain-as-published subscription flag"
+                      },
+                      "retainhandling": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "MQTT 5 retain-handling subscription mode"
                       },
                       "willtopic": {
                         "type": "string",
@@ -1552,14 +1606,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                              "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                             }
                           }
                         }
@@ -1572,7 +1626,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1583,20 +1641,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "topic": {
                         "type": "string",
@@ -1614,6 +1665,10 @@
                       "cleansession": {
                         "type": "boolean",
                         "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                      },
+                      "topicfilter": {
+                        "type": "string",
+                        "description": "MQTT subscribe topic filter"
                       },
                       "willtopic": {
                         "type": "string",
@@ -1646,14 +1701,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "HTTP URL"
+                              "description": "HTTP URI"
                             }
                           }
                         }
@@ -1666,7 +1721,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1677,20 +1736,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "method": {
                         "type": "string",
@@ -1722,6 +1774,26 @@
                         "additionalProperties": {
                           "type": "string"
                         }
+                      },
+                      "apikeyname": {
+                        "type": "string",
+                        "description": "Name of the API key header/query carrier when authorization.type is APIKey"
+                      },
+                      "apikeyin": {
+                        "type": "string",
+                        "description": "Placement of API key metadata for HTTP when authorization.type is APIKey. Expected values: header or query"
+                      },
+                      "plainscheme": {
+                        "type": "string",
+                        "description": "HTTP transport pattern when authorization.type is Plain. Expected values: basic, form, or query"
+                      },
+                      "plainusernamefield": {
+                        "type": "string",
+                        "description": "Parameter or header field name carrying the username when plainscheme is form or query"
+                      },
+                      "plainpasswordfield": {
+                        "type": "string",
+                        "description": "Parameter or header field name carrying the password when plainscheme is form or query"
                       }
                     }
                   }
@@ -1745,7 +1817,7 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -1775,7 +1847,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1786,20 +1862,13 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "topic": {
                         "type": "string",
@@ -1807,7 +1876,7 @@
                       },
                       "acks": {
                         "type": "integer",
-                        "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                        "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is 1"
                       },
                       "key": {
                         "type": "string",
@@ -1835,6 +1904,14 @@
                       "valueserializer": {
                         "type": "string",
                         "description": "The Kafka value serializer"
+                      },
+                      "autooffsetreset": {
+                        "type": "string",
+                        "description": "Consumer offset reset behavior when no valid committed offset exists"
+                      },
+                      "enableautocommit": {
+                        "type": "boolean",
+                        "description": "Whether the consumer commits offsets automatically"
                       }
                     }
                   }
@@ -1858,14 +1935,14 @@
                     "properties": {
                       "endpoints": {
                         "type": "array",
-                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                        "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "url": {
+                            "uri": {
                               "type": "string",
                               "format": "uri",
-                              "description": "NATS URL"
+                              "description": "NATS URI"
                             }
                           }
                         }
@@ -1878,7 +1955,11 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                              "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                            },
+                            "mechanism": {
+                              "type": "string",
+                              "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                             },
                             "resourceuri": {
                               "type": "string",
@@ -1889,24 +1970,25 @@
                               "type": "string",
                               "format": "uri",
                               "description": "The authority uri where authorization shall be requested (if applicable)"
-                            },
-                            "granttypes": {
-                              "type": "array",
-                              "description": "The grant types that can be requested (if applicable)",
-                              "items": {
-                                "type": "string"
-                              }
                             }
                           }
                         }
                       },
                       "deployed": {
                         "type": "boolean",
-                        "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                        "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
                       },
                       "subject": {
                         "type": "string",
                         "description": "The NATS subject"
+                      },
+                      "subjectfilter": {
+                        "type": "string",
+                        "description": "The NATS subscription subject filter"
+                      },
+                      "queuegroup": {
+                        "type": "string",
+                        "description": "The NATS queue group for queue subscriptions"
                       }
                     }
                   }

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -3244,7 +3244,7 @@
               },
               "durable": {
                 "type": "boolean",
-                "description": "The AMQP durable flag. Whether the node is durable or transient"
+                "description": "Whether the AMQP node identified by 'node' is durable rather than transient. This is a property of the node, not of the link terminus and not of the message header field of the same name. Terminus durability is expressed by 'terminus-durability'"
               },
               "link-properties": {
                 "type": "object",
@@ -3262,7 +3262,7 @@
               },
               "distribution-mode": {
                 "type": "string",
-                "description": "The AMQP distribution mode for receivers. Can be 'move' or 'copy'.  A value of 'move' indicates an exclusive lock on the message. A value of 'copy' indicates a non-exclusive lock on the message"
+                "description": "The AMQP source distribution mode. 'move' means a transferred message is removed from the node and is therefore seen by only one receiver. 'copy' means the message remains at the node after transfer and may also be transferred to other receivers. This does not describe message locking"
               },
               "connection-capabilities": {
                 "type": "array",
@@ -3302,11 +3302,11 @@
               },
               "sender-settle-mode": {
                 "type": "string",
-                "description": "AMQP sender settle mode"
+                "description": "AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the client for a producer endpoint, the remote node for a consumer endpoint"
               },
               "receiver-settle-mode": {
                 "type": "string",
-                "description": "AMQP receiver settle mode"
+                "description": "AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a producer endpoint, the client for a consumer endpoint"
               }
             }
           }
@@ -3375,7 +3375,7 @@
               },
               "topic": {
                 "type": "string",
-                "description": "MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
               },
               "qos": {
                 "type": "integer",
@@ -3470,7 +3470,7 @@
               },
               "topic": {
                 "type": "string",
-                "description": "The MQTT topic path that is used for communication with the endpoint unless overridden by the message"
+                "description": "The concrete MQTT topic name that is used for communication with the endpoint unless overridden by the message. It MUST NOT contain the '+' or '#' wildcard characters"
               },
               "qos": {
                 "type": "integer",
@@ -3481,13 +3481,9 @@
                 "type": "boolean",
                 "description": "The MQTT retain flag to use for publishers on ths endpoint"
               },
-              "cleansession": {
-                "type": "boolean",
-                "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
-              },
               "topicfilter": {
                 "type": "string",
-                "description": "MQTT subscribe topic filter"
+                "description": "MQTT subscribe topic filter. MAY contain the '+' and '#' wildcard characters"
               },
               "cleanstart": {
                 "type": "boolean",
@@ -3500,7 +3496,7 @@
               },
               "sharedsubscriptiongroup": {
                 "type": "string",
-                "description": "MQTT 5 shared subscription group"
+                "description": "MQTT 5 shared subscription group. It MUST only be used together with 'topicfilter' and MUST NOT include the '$share/' prefix"
               },
               "nolocal": {
                 "type": "boolean",
@@ -3617,7 +3613,7 @@
               },
               "consumergroup": {
                 "type": "string",
-                "description": "The Apache Kafka consumer group name to use for consumers"
+                "description": "The Apache Kafka consumer group name. It MUST be present and non-empty on a 'consumer' endpoint and MUST be absent on a 'subscriber' endpoint"
               },
               "headers": {
                 "type": "object",
@@ -3825,15 +3821,15 @@
               },
               "subject": {
                 "type": "string",
-                "description": "The NATS subject"
+                "description": "The concrete NATS publish subject. It MUST NOT contain the '*' or '>' wildcard tokens"
               },
               "subjectfilter": {
                 "type": "string",
-                "description": "The NATS subscription subject filter"
+                "description": "The NATS subscription subject filter. It MAY contain the '*' and '>' wildcard tokens"
               },
               "queuegroup": {
                 "type": "string",
-                "description": "The NATS queue group for queue subscriptions"
+                "description": "The NATS queue group for queue subscriptions. It MUST only be used together with 'subjectfilter'"
               }
             }
           }

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -3195,14 +3195,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "AMQP Addressing URL"
+                      "description": "AMQP Addressing URI"
                     }
                   }
                 }
@@ -3215,7 +3215,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -3226,20 +3230,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "node": {
                 "type": "string",
@@ -3280,6 +3277,36 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "source-filters": {
+                "type": "object",
+                "description": "AMQP source filters used for subscription/receive setup",
+                "additionalProperties": {}
+              },
+              "dynamic": {
+                "type": "boolean",
+                "description": "Whether a dynamic source or target is requested"
+              },
+              "terminus-durability": {
+                "type": "string",
+                "description": "Durability mode for the applicable source/target terminus"
+              },
+              "expiry-policy": {
+                "type": "string",
+                "description": "Expiry policy for the applicable source/target terminus"
+              },
+              "timeout": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Timeout in seconds for the applicable expiry policy"
+              },
+              "sender-settle-mode": {
+                "type": "string",
+                "description": "AMQP sender settle mode"
+              },
+              "receiver-settle-mode": {
+                "type": "string",
+                "description": "AMQP receiver settle mode"
               }
             }
           }
@@ -3303,14 +3330,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                      "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                     }
                   }
                 }
@@ -3323,7 +3350,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -3334,20 +3365,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "topic": {
                 "type": "string",
@@ -3365,6 +3389,10 @@
               "cleansession": {
                 "type": "boolean",
                 "description": "The MQTT clean session flag to use for publishers on this endpoint"
+              },
+              "topicfilter": {
+                "type": "string",
+                "description": "MQTT subscribe topic filter"
               },
               "willtopic": {
                 "type": "string",
@@ -3397,14 +3425,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "MQTT URL (mqtt, mqtts, or ws scheme)"
+                      "description": "MQTT URI (mqtt, mqtts, or ws scheme)"
                     }
                   }
                 }
@@ -3417,7 +3445,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -3428,20 +3460,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "topic": {
                 "type": "string",
@@ -3458,7 +3483,37 @@
               },
               "cleansession": {
                 "type": "boolean",
-                "description": "The MQTT clean session flag to use for publishers on this endpoint"
+                "description": "The MQTT 3.1.1 clean session flag. For MQTT 5.0, prefer cleanstart and sessionexpiryinterval"
+              },
+              "topicfilter": {
+                "type": "string",
+                "description": "MQTT subscribe topic filter"
+              },
+              "cleanstart": {
+                "type": "boolean",
+                "description": "MQTT 5 clean start flag"
+              },
+              "sessionexpiryinterval": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "MQTT 5 session expiry interval in seconds"
+              },
+              "sharedsubscriptiongroup": {
+                "type": "string",
+                "description": "MQTT 5 shared subscription group"
+              },
+              "nolocal": {
+                "type": "boolean",
+                "description": "MQTT 5 no-local subscription flag"
+              },
+              "retainaspublished": {
+                "type": "boolean",
+                "description": "MQTT 5 retain-as-published subscription flag"
+              },
+              "retainhandling": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "MQTT 5 retain-handling subscription mode"
               },
               "willtopic": {
                 "type": "string",
@@ -3491,7 +3546,7 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
@@ -3521,7 +3576,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -3532,20 +3591,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "topic": {
                 "type": "string",
@@ -3553,7 +3605,7 @@
               },
               "acks": {
                 "type": "integer",
-                "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is -1"
+                "description": "The Apache Kafka acks setting to use. If no acks setting is specified, the default is 1"
               },
               "key": {
                 "type": "string",
@@ -3581,6 +3633,14 @@
               "valueserializer": {
                 "type": "string",
                 "description": "The Kafka value serializer"
+              },
+              "autooffsetreset": {
+                "type": "string",
+                "description": "Consumer offset reset behavior when no valid committed offset exists"
+              },
+              "enableautocommit": {
+                "type": "boolean",
+                "description": "Whether the consumer commits offsets automatically"
               }
             }
           }
@@ -3604,14 +3664,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "HTTP URL"
+                      "description": "HTTP URI"
                     }
                   }
                 }
@@ -3624,7 +3684,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -3635,20 +3699,13 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "method": {
                 "type": "string",
@@ -3680,6 +3737,26 @@
                 "additionalProperties": {
                   "type": "string"
                 }
+              },
+              "apikeyname": {
+                "type": "string",
+                "description": "Name of the API key header/query carrier when authorization.type is APIKey"
+              },
+              "apikeyin": {
+                "type": "string",
+                "description": "Placement of API key metadata for HTTP when authorization.type is APIKey. Expected values: header or query"
+              },
+              "plainscheme": {
+                "type": "string",
+                "description": "HTTP transport pattern when authorization.type is Plain. Expected values: basic, form, or query"
+              },
+              "plainusernamefield": {
+                "type": "string",
+                "description": "Parameter or header field name carrying the username when plainscheme is form or query"
+              },
+              "plainpasswordfield": {
+                "type": "string",
+                "description": "Parameter or header field name carrying the password when plainscheme is form or query"
               }
             }
           }
@@ -3703,14 +3780,14 @@
             "properties": {
               "endpoints": {
                 "type": "array",
-                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URL just identifies a network host or links directly to a resource managed by the network host is protocol specific",
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "url": {
+                    "uri": {
                       "type": "string",
                       "format": "uri",
-                      "description": "NATS URL"
+                      "description": "NATS URI"
                     }
                   }
                 }
@@ -3723,7 +3800,11 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, and X509Cert are well-defined"
+                      "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+                    },
+                    "mechanism": {
+                      "type": "string",
+                      "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
                     },
                     "resourceuri": {
                       "type": "string",
@@ -3734,24 +3815,25 @@
                       "type": "string",
                       "format": "uri",
                       "description": "The authority uri where authorization shall be requested (if applicable)"
-                    },
-                    "granttypes": {
-                      "type": "array",
-                      "description": "The grant types that can be requested (if applicable)",
-                      "items": {
-                        "type": "string"
-                      }
                     }
                   }
                 }
               },
               "deployed": {
                 "type": "boolean",
-                "description": "If `true`, the endpoint metadata represents a public, live endpoint that is available for communication and a strict validator MAY test the liveness of the endpoint"
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
               },
               "subject": {
                 "type": "string",
                 "description": "The NATS subject"
+              },
+              "subjectfilter": {
+                "type": "string",
+                "description": "The NATS subscription subject filter"
+              },
+              "queuegroup": {
+                "type": "string",
+                "description": "The NATS queue group for queue subscriptions"
               }
             }
           }
@@ -3961,7 +4043,7 @@
           },
           "usage": {
             "type": "array",
-            "description": "Client's expected usage of this endpoint",
+            "description": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous.",
             "items": {
               "type": "string",
               "enum": [
@@ -3982,28 +4064,28 @@
               "effective": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint deprecation went into effect"
+                "description": "tbd"
               },
               "removal": {
                 "type": "string",
                 "format": "date-time",
-                "description": "date endpoint will be removed"
+                "description": "tbd"
               },
               "alternative": {
                 "type": "string",
                 "format": "uri",
-                "description": "alternative endpoint to consider"
+                "description": "tbd"
               },
               "docs": {
                 "type": "string",
                 "format": "uri",
-                "description": "additional information about deprecation"
+                "description": "tbd"
               }
             }
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
+            "description": "The message groups that are supported by this endpoint",
             "items": {
               "type": "string",
               "format": "uri"

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -530,7 +530,7 @@ This specification defines the following envelope options for the indicated
 ##### `CloudEvents/1.0`
 
 - `mode` : indicates whether the CloudEvent will use `binary` or `structured`
-  (mode)[https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message].
+  [mode](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message).
   When specified, its value MUST be one of: `binary` or `structured`, case
   sensitive. When not specified, the endpoint is indicating that either mode
   is acceptable.
@@ -596,9 +596,9 @@ This specification defines the following envelope options for the indicated
   address identifies a network host or links directly to a resource managed by
   the network host is protocol specific.
 
-  The addressing attribute is protocol specific. For `HTTP`, `AMQP/1.0`,
-  `MQTT/3.1.1`, `MQTT/5.0`, and `NATS` the address is carried in a `uri`
-  attribute. For `KAFKA` the address is carried in a `bootstrap.servers`
+  The shape of each entry is customized for the protocol in use. For `HTTP`,
+  `AMQP/1.0`, `MQTT/3.1.1`, `MQTT/5.0`, and `NATS` the address is carried in a
+  `uri` attribute. For `KAFKA` the address is carried in a `bootstrap.servers`
   attribute, which is an array of Kafka bootstrap server addresses, because
   Kafka clients are configured with a bootstrap server list rather than with a
   single destination URI.
@@ -607,10 +607,13 @@ This specification defines the following envelope options for the indicated
   - OPTIONAL.
   - Entries are ordered by preference; the first entry is the preferred
     address.
-  - For all protocols other than `KAFKA`, each object MUST contain a `uri`
-    attribute with a valid, absolute URI (URL).
-  - For `KAFKA`, each object MUST contain a non-empty `bootstrap.servers`
-    attribute. A `uri` attribute is not expected for `KAFKA` endpoints.
+  - Each object MUST carry the endpoint address in the attribute that the
+    endpoint's protocol defines for that purpose. Of the protocols defined in
+    this specification, `HTTP`, `AMQP/1.0`, `MQTT/3.1.1`, `MQTT/5.0`, and
+    `NATS` use a `uri` attribute holding a valid, absolute URI (URL), and
+    `KAFKA` uses a non-empty `bootstrap.servers` attribute. A protocol
+    defined outside of this specification MAY define a different addressing
+    attribute.
 - Examples:
   - `[ {"uri": "https://example.com" } ]`
   - ```
@@ -648,7 +651,7 @@ This specification defines the following envelope options for the indicated
 
 - Constraints:
   - OPTIONAL.
-  - MUST be an array of objects if present. It is not a map.
+  - MUST be an array of objects if present.
   - MUST only be used for authorization configuration.
   - MUST NOT be used for credential configuration.
 
@@ -657,21 +660,23 @@ This specification defines the following envelope options for the indicated
 - Type: String
 - Description: The type of the authorization configuration. The value SHOULD be
   one of the following:
-  - `OAuth2`: OAuth 2.0 authorization is used. The `authorityuri` SHOULD
-    reference authorization server metadata as defined by RFC 8414.
+  - `OAuth2`: [OAuth 2.0][RFC6749] authorization is used. The
+    [`authorityuri`](#protocoloptionsauthorizationauthorityuri) SHOULD
+    reference authorization server metadata as defined by [RFC 8414][RFC8414].
   - `Plain`: The client uses username with a plaintext password for
-    authentication and authorization. For HTTP, see protocol options
-    `plainscheme`, `plainusernamefield`, and `plainpasswordfield`; for other
-    protocols, equivalent transport-specific options MAY be defined as
-    protocol extensions.
-  - `SASL`: The client uses a SASL authentication mechanism. The
-    `mechanism` attribute SHOULD be provided when this type is selected.
-  - `X509Cert`: The client uses client certificate authentication and
-    authorization.
+    authentication and authorization. For HTTP, see the
+    [HTTP options](#http-options) `plainscheme`, `plainusernamefield`, and
+    `plainpasswordfield`; for other protocols, equivalent transport-specific
+    options MAY be defined as protocol extensions.
+  - `SASL`: The client uses a [SASL][RFC4422] authentication mechanism. The
+    [`mechanism`](#protocoloptionsauthorizationmechanism) attribute SHOULD be
+    provided when this type is selected.
+  - `X509Cert`: The client uses [X.509][RFC5280] client certificate
+    authentication and authorization.
   - `APIKey`: The client uses an API key for authentication and
-    authorization. For HTTP, see protocol options `apikeyname` and
-    `apikeyin`; for other protocols, equivalent carrier-specific options MAY
-    be defined as protocol extensions.
+    authorization. For HTTP, see the [HTTP options](#http-options)
+    `apikeyname` and `apikeyin`; for other protocols, equivalent
+    carrier-specific options MAY be defined as protocol extensions.
 
 - Constraints:
   - OPTIONAL.
@@ -692,9 +697,11 @@ This specification defines the following envelope options for the indicated
 ###### `protocoloptions.authorization.mechanism`
 
 - Type: String
-- Description: The SASL mechanism name for `authorization.type = "SASL"`
-  (for example `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, `OAUTHBEARER`,
-  or `EXTERNAL`).
+- Description: The SASL mechanism name for `authorization.type = "SASL"`, for
+  example `PLAIN` ([RFC4616][RFC4616]), `SCRAM-SHA-256` or `SCRAM-SHA-512`
+  ([RFC7677][RFC7677]), `OAUTHBEARER` ([RFC7628][RFC7628]), or `EXTERNAL`
+  ([RFC4422][RFC4422]). Mechanism names are those registered in the
+  [IANA SASL Mechanisms registry][IANA SASL Mechanisms].
 
 - Constraints:
   - OPTIONAL.
@@ -730,10 +737,7 @@ This specification defines the following envelope options for the indicated
 - Constraints:
   - OPTIONAL.
   - If present, MUST be either `true` or `false`, case-sensitive.
-  - When not specified, the default value is MUST be `true`.
-
-Protocol-specific options are direct children of `protocoloptions`.
-There is no nested `protocoloptions.options` object.
+  - When not specified, the default value MUST be `true`.
 
 #### `messagegroups`
 
@@ -817,15 +821,16 @@ constraint for their users.
 
 #### Protocol Options
 
-The following protocol options are direct children of `protocoloptions` for
-the respective protocols. All of these are OPTIONAL.
+For each protocol specified in the following sections there is a table that
+describes the set of protocol-specific options and the roles (Producer,
+Consumer, Subscriber) to which each option applies. All protocol options are
+OPTIONAL.
 
-This specification is descriptive for the applicability of protocol options to
-roles: the role columns guide clients on how to interpret metadata, and a
-validator need not reject every role-inapplicable option. Where a
-rule below is stated with MUST, MUST NOT, or REQUIRED, it is a conformance
-requirement of this specification and an implementation MUST reject metadata
-that violates it.
+The role applicability is descriptive: it guides clients on how to interpret
+metadata, and a validator need not reject every role-inapplicable option.
+Where a rule below is stated with MUST, MUST NOT, or REQUIRED, it is a
+conformance requirement of this specification and an implementation MUST
+reject metadata that violates it.
 
 In each table below, role applicability is shown as:
 - `✓`: The option applies to that role. Clients acting in that role SHOULD
@@ -1075,6 +1080,14 @@ Addressing constraints:
 [Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html
 [Apache Kafka consumer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html
 [HTTP Message Format]: https://www.rfc-editor.org/rfc/rfc9110#section-6
-[RFC7617]: https://www.rfc-editor.org/rfc/rfc7617
+[IANA SASL Mechanisms]: https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml
+[RFC4422]: https://www.rfc-editor.org/rfc/rfc4422
+[RFC4616]: https://www.rfc-editor.org/rfc/rfc4616
+[RFC5280]: https://www.rfc-editor.org/rfc/rfc5280
 [RFC6570]: https://www.rfc-editor.org/rfc/rfc6570
+[RFC6749]: https://www.rfc-editor.org/rfc/rfc6749
+[RFC7617]: https://www.rfc-editor.org/rfc/rfc7617
+[RFC7628]: https://www.rfc-editor.org/rfc/rfc7628
+[RFC7677]: https://www.rfc-editor.org/rfc/rfc7677
+[RFC8414]: https://www.rfc-editor.org/rfc/rfc8414
 [rfc3339]: https://tools.ietf.org/html/rfc3339

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -257,8 +257,8 @@ this form:
         "endpoints": [
           {
             "uri": "<URI>"                        # plus endpoint extensions
-          } *
-        ], ?
+          } *                                     # "KAFKA" uses
+        ], ?                                      # "bootstrap.servers" instead
         "authorization": [
           {
             "type": "<STRING>", ?
@@ -386,9 +386,15 @@ to the xRegistry-defined core
 
   The following values are defined for `usage`
 
-  - `subscriber`: The endpoint offers managing subscriptions for delivery of
-    messages to another endpoint, using the [CloudEvents Subscriptions
-    API][CloudEvents Subscriptions API].
+  - `subscriber`: The endpoint offers management of subscriptions that cause
+    messages to be delivered to some other endpoint. A `subscriber` endpoint
+    is a control-plane endpoint: it does not itself transfer messages.
+    Establishing subscription interest is the only interaction it describes.
+
+    Depending on the protocol, subscription interest is established by the
+    [CloudEvents Subscriptions API][CloudEvents Subscriptions API], an MQTT
+    `SUBSCRIBE` packet, establishment of an AMQP link with the endpoint node
+    as source, creation of a Kafka consumer group, or a NATS subscription.
 
     Some perspectives that might exist on a subscriber endpoint:
     - Application from which messages originate.
@@ -427,13 +433,20 @@ to the xRegistry-defined core
     - "consumer"
     - "producer"
   - MUST be an array of at least one.
-  - SHOULD declare exactly one usage value per endpoint.
-  - Mixed usage declarations SHOULD be used only when the same protocol
-    interface and the same endpoint contract unambiguously serve each declared
-    role.
-  - Declarations that mix `producer` with any other role are strongly
-    discouraged. Prefer separate endpoint declarations, connected with a shared
-    `channel` when correlation is useful.
+  - MUST declare exactly one usage value, except for the single combination
+    permitted below.
+  - MUST NOT combine `producer` with any other value.
+  - MUST NOT declare all three values.
+  - MAY declare `["subscriber", "consumer"]` only when the protocol is
+    `MQTT/3.1.1`, `MQTT/5.0`, `AMQP/1.0`, or `NATS`. In these protocols a
+    single client connection both establishes subscription interest and
+    receives the resulting messages, so the two roles are served by one
+    protocol interface and one endpoint contract.
+  - MUST NOT declare `["subscriber", "consumer"]` for `HTTP` or `KAFKA`
+    endpoints. In those protocols the two roles are distinct interfaces and
+    MUST be modeled as separate Endpoint resources.
+  - Endpoints that jointly describe more than one role SHOULD be declared
+    separately and correlated with a shared `channel` value.
 
 #### `channel`
 
@@ -576,15 +589,28 @@ This specification defines the following envelope options for the indicated
 ##### `protocoloptions.endpoints`
 
 - Type: Array of Objects
-- Description: An array of objects map where each object contains a `uri`
-  attribute with the network address to which clients can communicate with
-  the endpoint. The object MAY contain extension attributes that can be used
-  by clients to determine which URI to use, or to configure access to the
-  specific URI. Whether the URI identifies a network host or links directly to
-  a resource managed by the network host is protocol specific.
+- Description: An array of objects where each object describes one network
+  address at which clients can communicate with the endpoint. The object MAY
+  contain extension attributes that can be used by clients to determine which
+  address to use, or to configure access to the specific address. Whether the
+  address identifies a network host or links directly to a resource managed by
+  the network host is protocol specific.
+
+  The addressing attribute is protocol specific. For `HTTP`, `AMQP/1.0`,
+  `MQTT/3.1.1`, `MQTT/5.0`, and `NATS` the address is carried in a `uri`
+  attribute. For `KAFKA` the address is carried in a `bootstrap.servers`
+  attribute, which is an array of Kafka bootstrap server addresses, because
+  Kafka clients are configured with a bootstrap server list rather than with a
+  single destination URI.
+
 - Constraints:
   - OPTIONAL.
-  - Each object MUST contain a `uri` attribute with a valid, absolute URI (URL).
+  - Entries are ordered by preference; the first entry is the preferred
+    address.
+  - For all protocols other than `KAFKA`, each object MUST contain a `uri`
+    attribute with a valid, absolute URI (URL).
+  - For `KAFKA`, each object MUST contain a non-empty `bootstrap.servers`
+    attribute. A `uri` attribute is not expected for `KAFKA` endpoints.
 - Examples:
   - `[ {"uri": "https://example.com" } ]`
   - ```
@@ -610,17 +636,19 @@ This specification defines the following envelope options for the indicated
 
 ##### `protocoloptions.authorization`
 
-- Type: Map
+- Type: Array of Objects
 - Description: OPTIONAL authorization configuration details of the endpoint.
-  When specified, the authorization configuration MUST provide sufficient
-  metadata for clients to select the authorization mechanism
+  Each entry describes one authorization option that the endpoint accepts;
+  a client selects one of them. When specified, each entry MUST provide
+  sufficient metadata for clients to select the authorization mechanism
   and discover where authorization is obtained. Runtime credentials and
   deployment-specific values are expected to be supplied separately through
-  external configuration. The configuration keys below MUST be used as
-  defined. Additional endpoint-specific configuration keys MAY be added.
+  external configuration. The attribute names below MUST be used as
+  defined. Additional endpoint-specific extension attributes MAY be added.
 
 - Constraints:
   - OPTIONAL.
+  - MUST be an array of objects if present. It is not a map.
   - MUST only be used for authorization configuration.
   - MUST NOT be used for credential configuration.
 
@@ -792,9 +820,12 @@ constraint for their users.
 The following protocol options are direct children of `protocoloptions` for
 the respective protocols. All of these are OPTIONAL.
 
-This specification is primarily descriptive for protocol options: it guides
-clients on how to interpret metadata. It does not require a validator to reject
-every role-inapplicable option.
+This specification is descriptive for the applicability of protocol options to
+roles: the role columns guide clients on how to interpret metadata, and a
+validator need not reject every role-inapplicable option. Where a
+rule below is stated with MUST, MUST NOT, or REQUIRED, it is a conformance
+requirement of this specification and an implementation MUST reject metadata
+that violates it.
 
 In each table below, role applicability is shown as:
 - `✓`: The option applies to that role. Clients acting in that role SHOULD
@@ -807,8 +838,28 @@ The [endpoint URIs](#protocoloptionsendpoints) for "HTTP" endpoints MUST be
 valid HTTP URIs using the "http" or "https" scheme as defined in
 [HTTP Message Format].
 
-HTTP commonly uses separate endpoint declarations for subscriber, consumer,
-and producer interactions.
+HTTP has no single connection that serves several roles, so each HTTP role is
+a distinct interface with its own request contract. This specification
+distinguishes three HTTP roles:
+
+- Subscription manager (`usage` = `["subscriber"]`): an endpoint that accepts
+  requests to create, modify, and delete subscriptions, for example an
+  implementation of the [CloudEvents Subscriptions API][CloudEvents
+  Subscriptions API]. It does not transfer messages.
+- Delivery target, also called webhook target (`usage` = `["producer"]`): an
+  endpoint that accepts messages pushed to it by an originator or by a
+  delivery agent.
+- Pull consumer (`usage` = `["consumer"]`): an endpoint from which a client
+  retrieves messages with its own requests.
+
+Constraints:
+
+- An HTTP Endpoint MUST declare exactly one `usage` value and therefore MUST
+  represent exactly one of the three roles above.
+- An HTTP Endpoint MUST NOT declare `["subscriber", "consumer"]`.
+- A subscription manager, a delivery target, and a pull consumer that belong
+  to the same logical channel MUST be declared as separate Endpoint resources
+  and SHOULD be correlated with a shared `channel` value.
 
 | Name | Type | P | C | S | Description |
 |---|---|---|---|---|---|
@@ -842,19 +893,25 @@ The following options are defined for AMQP endpoints.
 | Name | Type | P | C | S | Description |
 |---|---|---|---|---|---|
 | `node` | string | ✓ | ✓ | ✓ | AMQP node (address). When set, it overrides the URI path. |
-| `durable` | boolean, default `false` | ✓ | - | - | AMQP durable flag. This does not imply a delivery guarantee and is distinct from terminus durability. |
+| `durable` | boolean, default `false` | ✓ | - | - | Whether the node identified by `node` is a durable node rather than a transient one. This is a property of the node. It is not the AMQP message header field of the same name and it is not terminus durability, which is expressed by `terminus-durability`. It does not by itself imply a delivery guarantee. |
 | `link-properties` | map of string to string | ✓ | ✓ | ✓ | AMQP link properties. |
 | `connection-properties` | map of string to string | ✓ | ✓ | ✓ | AMQP connection properties. |
-| `distribution-mode` | enum: `move`, `copy`, default `move` | - | ✓ | - | AMQP receive distribution mode. |
+| `distribution-mode` | enum: `move`, `copy`, default `move` | - | ✓ | ✓ | AMQP source distribution mode. `move` means a transferred message is removed from the node and is therefore transferred to at most one receiver. `copy` means the message remains at the node after transfer and can also be transferred to other receivers. This describes distribution between the node and its receivers; it does not describe message locking. |
 | `connection-capabilities` | array of string | ✓ | ✓ | ✓ | AMQP connection capabilities. |
 | `node-capabilities` | array of string | ✓ | ✓ | ✓ | AMQP node capabilities. |
 | `source-filters` | map of string to any | - | ✓ | ✓ | AMQP source filter expressions/descriptor keys for receive setup. |
 | `dynamic` | boolean | ✓ | ✓ | ✓ | Dynamic node creation for source/target setup, depending on role. |
-| `terminus-durability` | enum: `none`, `configuration`, `unsettled-state` | ✓ | ✓ | ✓ | Durability mode for the applicable source or target terminus. |
-| `expiry-policy` | enum: `link-detach`, `session-end`, `connection-close`, `never` | ✓ | ✓ | ✓ | Expiry policy for the applicable terminus. |
+| `terminus-durability` | enum: `none`, `configuration`, `unsettled-state` | ✓ | ✓ | ✓ | Durability mode for the applicable source or target terminus. For a `producer` endpoint this is the target terminus; for a `consumer` or `subscriber` endpoint it is the source terminus. |
+| `expiry-policy` | enum: `link-detach`, `session-end`, `connection-close`, `never` | ✓ | ✓ | ✓ | Expiry policy for the applicable terminus, selected as for `terminus-durability`. |
 | `timeout` | uinteger | ✓ | ✓ | ✓ | Timeout value used with terminus expiry policy. |
-| `sender-settle-mode` | enum: `unsettled`, `settled`, `mixed` | ✓ | ✓ | ✓ | AMQP sender settlement mode for the active sending side of the link. |
-| `receiver-settle-mode` | enum: `first`, `second` | ✓ | ✓ | ✓ | AMQP receiver settlement mode for the active receiving side of the link. |
+| `sender-settle-mode` | enum: `unsettled`, `settled`, `mixed` | ✓ | ✓ | ✓ | AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the local client for a `producer` endpoint, the remote node for a `consumer` or `subscriber` endpoint. |
+| `receiver-settle-mode` | enum: `first`, `second` | ✓ | ✓ | ✓ | AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a `producer` endpoint, the local client for a `consumer` or `subscriber` endpoint. |
+
+An AMQP Endpoint MAY declare `["subscriber", "consumer"]`, because a single
+AMQP receiving link both establishes interest in the source node and carries
+the resulting transfers. When it does, the `subscriber` role refers to the
+establishment of the link with the node as source and the `consumer` role
+refers to the transfers over that link.
 
 The values of all `link-properties` and `connection-properties` MAY contain
 placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the
@@ -874,12 +931,24 @@ The following options are defined for MQTT 3.1.1 and MQTT 5.0 endpoints.
 
 | Name | Type | P | C | S | Description |
 |---|---|---|---|---|---|
-| `topic` | string | ✓ | - | - | Concrete publish topic name. Prefer concrete destinations over filter syntax. |
+| `topic` | string | ✓ | - | - | Concrete publish topic name. |
 | `topicfilter` | string | - | - | ✓ | Subscribe topic filter. |
 | `qos` | enum: `0`, `1`, `2`, default `0` | ✓ | ✓ | ✓ | Role-relative QoS intent: publish QoS for producer, requested max QoS for subscriber, effective delivery QoS for consumer context. |
 | `retain` | boolean, default `false` | ✓ | - | - | MQTT retain flag for publish behavior. |
 | `willtopic` | string | ✓ | ✓ | ✓ | CONNECT Will topic configuration. |
 | `willmessage` | xid (message reference) | ✓ | ✓ | ✓ | CONNECT Will message definition reference. |
+
+Addressing constraints:
+
+- `topic` MUST be a concrete MQTT topic name. It MUST NOT contain the `+` or
+  `#` wildcard characters, since a wildcard is not a valid publish
+  destination.
+- `topicfilter` MAY contain the `+` and `#` wildcard characters as defined by
+  [MQTT 3.1.1] and [MQTT 5.0].
+- An MQTT Endpoint MUST NOT declare both `topic` and `topicfilter`.
+- An MQTT Endpoint MAY declare `["subscriber", "consumer"]`, because a single
+  MQTT connection both sends the `SUBSCRIBE` packet and receives the resulting
+  `PUBLISH` packets.
 
 MQTT 3.1.1 specific options:
 
@@ -893,13 +962,30 @@ MQTT 5.0 specific options:
 |---|---|---|---|---|---|
 | `cleanstart` | boolean | ✓ | ✓ | ✓ | MQTT 5 clean-start behavior for the connection. |
 | `sessionexpiryinterval` | uinteger (`0..4294967295`) | ✓ | ✓ | ✓ | MQTT 5 session expiry interval in seconds. |
-| `sharedsubscriptiongroup` | string | - | - | ✓ | Shared subscription group. Use with `topicfilter`. |
+| `sharedsubscriptiongroup` | string | - | - | ✓ | Shared subscription group name. |
 | `nolocal` | boolean | - | - | ✓ | MQTT 5 subscribe no-local flag. |
 | `retainaspublished` | boolean | - | - | ✓ | MQTT 5 subscribe retain-as-published flag. |
 | `retainhandling` | enum: `0`, `1`, `2` | - | - | ✓ | MQTT 5 retain-handling mode. |
 
-For MQTT 5.0, prefer `cleanstart` and `sessionexpiryinterval`; `cleansession`
-SHOULD NOT be used.
+`cleansession` is an MQTT 3.1.1 option only. It is not defined for `MQTT/5.0`
+endpoints and MUST NOT be used with them; `cleanstart` and
+`sessionexpiryinterval` express the equivalent MQTT 5 behavior and together
+supersede it.
+
+Shared subscription constraints:
+
+- `sharedsubscriptiongroup` MUST only be present when `topicfilter` is also
+  present.
+- The value of `sharedsubscriptiongroup` is the bare group name. It MUST NOT
+  include the `$share/` prefix and MUST NOT contain the `/` character.
+- When `sharedsubscriptiongroup` is present, a client MUST send the
+  subscription as the topic filter `$share/{sharedsubscriptiongroup}/{topicfilter}`,
+  where `{sharedsubscriptiongroup}` and `{topicfilter}` are the literal values
+  of those two options.
+
+MQTT 5 Subscription Identifiers are runtime subscription state established by
+the subscribing client. They are not endpoint metadata and are therefore not
+defined as protocol options by this specification.
 
 ##### KAFKA options
 
@@ -923,12 +1009,37 @@ The following options are defined for Kafka endpoints.
 | `autooffsetreset` | enum: `earliest`, `latest`, `none` | - | ✓ | - | Consumer offset reset behavior when no valid committed offset exists. |
 | `enableautocommit` | boolean | - | ✓ | - | Consumer automatic commit behavior. |
 
+Kafka does not have a subscription primitive that is separate from
+consumption; the group is the durable interest. This specification therefore
+discriminates the two roles by the presence of `consumergroup`:
+
+- A `subscriber` Kafka Endpoint describes the creation and configuration of a
+  consumer group as an act of registering interest. It MUST NOT declare
+  `consumergroup`, since the group is the resource being established rather
+  than a group to be joined.
+- A `consumer` Kafka Endpoint describes joining an existing consumer group.
+  It MUST declare `consumergroup` with a non-empty value.
+- A Kafka Endpoint MUST NOT declare `["subscriber", "consumer"]`. The two
+  roles MUST be declared as separate Endpoint resources and SHOULD be
+  correlated with a shared `channel` value.
+- `autooffsetreset` and `enableautocommit` describe group-based consumption.
+  They MUST NOT be used on a `producer` or `subscriber` Endpoint.
+- `autooffsetreset` expresses only the reset behavior when no valid committed
+  offset exists. A concrete starting offset or a starting timestamp is runtime
+  consumer state, not endpoint metadata, and MUST NOT be expressed through
+  this option.
+
 ##### NATS options
 
 The [endpoint URIs](#protocoloptionsendpoints) for "NATS" endpoints MUST be
 valid NATS URIs as described by [NATS]. The scheme MUST be "nats" or "tls" or
 "ws" and the URI MUST include a port number, e.g. `nats://<HOST>:<PORT>` or
 `tls://<HOST>:<PORT>`.
+
+The options below describe Core NATS publish and subscribe only. JetStream
+streams, consumers, and their durability and acknowledgement settings are out
+of scope for this specification and, if needed, MUST be expressed through
+extension attributes.
 
 The following options are defined for NATS endpoints.
 
@@ -937,6 +1048,18 @@ The following options are defined for NATS endpoints.
 | `subject` | string | ✓ | - | - | Concrete publish subject. |
 | `subjectfilter` | string | - | - | ✓ | Subscription subject filter. |
 | `queuegroup` | string | - | - | ✓ | Queue subscription group associated with a subject filter. |
+
+Addressing constraints:
+
+- `subject` MUST be a concrete NATS subject. It MUST NOT contain the `*` or
+  `>` wildcard tokens, since a wildcard is not a valid publish destination.
+- `subjectfilter` MAY contain the `*` and `>` wildcard tokens as defined by
+  [NATS].
+- `queuegroup` MUST only be present when `subjectfilter` is also present.
+- A NATS Endpoint MUST NOT declare both `subject` and `subjectfilter`.
+- A NATS Endpoint MAY declare `["subscriber", "consumer"]`, because a single
+  Core NATS connection both registers the subscription interest and receives
+  the resulting messages.
 
 [JSON Pointer]: https://www.rfc-editor.org/rfc/rfc6901
 [CloudEvents Types]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system
@@ -953,7 +1076,7 @@ The following options are defined for NATS endpoints.
 [MQTT 3.1.1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
 [CloudEvents]: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
 [CloudEvents Subscriptions API]: https://github.com/cloudevents/spec/blob/main/subscriptions/spec.md
-[NATS]: https://docs.nats.io/reference/reference-protocols/nats-protocol
+[NATS]: https://docs.nats.io/reference/protocols/client/
 [Apache Kafka]: https://kafka.apache.org/protocol
 [Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html
 [Apache Kafka consumer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -1,4 +1,4 @@
-# Endpoint Registry Service - Version 1.0-rc2
+# Endpoint Registry Service - Version 1.0-rc3
 <!-- words: apikeyname apikeyin plainscheme plainusernamefield plainpasswordfield sasl oauthbearer -->
 
 ## Abstract

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -1,4 +1,5 @@
-# Endpoint Registry Service - Version 1.0-rc3
+# Endpoint Registry Service - Version 1.0-rc2
+<!-- words: apikeyname apikeyin plainscheme plainusernamefield plainpasswordfield sasl oauthbearer -->
 
 ## Abstract
 
@@ -132,7 +133,7 @@ Endpoint definitions can be abstract or concrete, distinguished by the
 endpoint to be reachable on the network with the given parameters, assuming
 the client is within the same network scope. If the flag is set to `false`,
 the endpoint definition is to be treated like a template where configuration
-elements like the endpoint URL will have to be supplied by external
+elements like the endpoint URI will have to be supplied by external
 configuration for the client to become functional.
 
 A possible application of the latter are Endpoint definitions that define
@@ -252,34 +253,51 @@ this form:
         # Common protocol options
         "endpoints": [
           {
-            "url": "<URL>"                        # plus endpoint extensions
+            "uri": "<URI>"                        # plus endpoint extensions
           } *
         ], ?
-        "authorization": {
-          "type": "<STRING>", ?
-          "resourceuri": "URI", ?
-          "authorityuri": "URI", ?
-          "granttypes": [ "<STRING>" * ] ?
-        }, ?
+        "authorization": [
+          {
+            "type": "<STRING>", ?
+            "mechanism": "<STRING>", ?
+            "resourceuri": "<URI>", ?
+            "authorityuri": "<URI>" ?
+          } *
+        ], ?
         "deployed": <BOOLEAN>, ?
 
         # "HTTP" protocol options
         "method": "<STRING>", ?                          # Default: POST
         "headers": [ { "name": "<STRING>", "value": "<STRING>" } * ], ?
-        "query": { "<STRING>": "<STRING>" * } ?
+        "query": { "<STRING>": "<STRING>" * }, ?
+        "apikeyname": "<STRING>", ?
+        "apikeyin": "header" | "query" ?,              # Default: header
+        "plainscheme": "basic" | "form" | "query" ?, # Default: basic
+        "plainusernamefield": "<STRING>", ?
+        "plainpasswordfield": "<STRING>" ?
 
         # "AMQP/1.0" protocol options
         "node": "<STRING>", ?
         "durable": <BOOLEAN>, ?                          # Default: false
-        "linkproperties": { "<STRING>": "<STRING>" * }, ?
-        "connectionproperties": { "<STRING>": "<STRING>" * }, ?
-        "distributionmode": "move" | "copy" ?          # Default: move
+        "link-properties": { "<STRING>": "<STRING>" * }, ?
+        "connection-properties": { "<STRING>": "<STRING>" * }, ?
+        "distribution-mode": "move" | "copy" ?,         # Default: move
+        "connection-capabilities": [ "<STRING>" * ], ?
+        "node-capabilities": [ "<STRING>" * ], ?
+        "source-filters": { "<STRING>": <JSON-VALUE> * }, ?
+        "dynamic": <BOOLEAN>, ?
+        "terminus-durability": "none" | "configuration" | "unsettled-state" ?,
+        "expiry-policy": "link-detach" | "session-end" | "connection-close" | "never" ?,
+        "timeout": <UINTEGER>, ?
+        "sender-settle-mode": "unsettled" | "settled" | "mixed" ?,
+        "receiver-settle-mode": "first" | "second" ?
 
         # "MQTT/3.1.1" protocol options
         "topic": "<STRING>", ?
         "qos": <UINTEGER>, ?                             # Default: 0
         "retain": <BOOLEAN>, ?                           # Default: false
         "cleansession": <BOOLEAN>, ?                     # Default: true
+        "topicfilter": "<STRING>", ?
         "willtopic": "<STRING>", ?
         "willmessage": "<XID>" ?
 
@@ -287,7 +305,13 @@ this form:
         "topic": "<STRING>", ?
         "qos": <UINTEGER>, ?                             # Default: 0
         "retain": <BOOLEAN>, ?                           # Default: false
-        "cleansession": <BOOLEAN>, ?                     # Default: true
+        "topicfilter": "<STRING>", ?
+        "cleanstart": <BOOLEAN>, ?
+        "sessionexpiryinterval": <UINTEGER>, ?
+        "sharedsubscriptiongroup": "<STRING>", ?
+        "nolocal": <BOOLEAN>, ?
+        "retainaspublished": <BOOLEAN>, ?
+        "retainhandling": 0 | 1 | 2 ?,
         "willtopic": "<STRING>", ?
         "willmessage": "<XID>" ?
 
@@ -297,10 +321,16 @@ this form:
         "key": "<STRING>", ?
         "partition": <INTEGER>, ?
         "consumergroup": "<STRING>", ?
-        "headers": { "<STRING>": "<STRING>" * } ?
+        "headers": { "<STRING>": "<STRING>" * }, ?
+        "keyserializer": "<STRING>", ?
+        "valueserializer": "<STRING>", ?
+        "autooffsetreset": "earliest" | "latest" | "none" ?,
+        "enableautocommit": <BOOLEAN> ?
 
         # "NATS" protocol options
-        "subject": "<STRING>" ?
+        "subject": "<STRING>", ?
+        "subjectfilter": "<STRING>", ?
+        "queuegroup": "<STRING>" ?
       }, ?
 
       "messagegroups": [ XID * ], ?
@@ -394,6 +424,13 @@ to the xRegistry-defined core
     - "consumer"
     - "producer"
   - MUST be an array of at least one.
+  - SHOULD declare exactly one usage value per endpoint.
+  - Mixed usage declarations SHOULD be used only when the same protocol
+    interface and the same endpoint contract unambiguously serve each declared
+    role.
+  - Declarations that mix `producer` with any other role are strongly
+    discouraged. Prefer separate endpoint declarations, connected with a shared
+    `channel` when correlation is useful.
 
 #### `channel`
 
@@ -477,7 +514,7 @@ This specification defines the following envelope options for the indicated
 ##### `CloudEvents/1.0`
 
 - `mode` : indicates whether the CloudEvent will use `binary` or `structured`
-  [mode](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message).
+  (mode)[https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#message].
   When specified, its value MUST be one of: `binary` or `structured`, case
   sensitive. When not specified, the endpoint is indicating that either mode
   is acceptable.
@@ -528,6 +565,7 @@ This specification defines the following envelope options for the indicated
 - Description: Configuration details of the endpoint related to the protocol
   used to transmit the messages. An endpoint MAY be defined without detail
   configuration. In this case, the endpoint is considered to be "abstract".
+  For per-protocol option definitions, see [Protocol Options](#protocol-options).
 
 - Constraints:
   - OPTIONAL.
@@ -535,32 +573,32 @@ This specification defines the following envelope options for the indicated
 ##### `protocoloptions.endpoints`
 
 - Type: Array of Objects
-- Description: An array of objects map where each object contains a `url`
+- Description: An array of objects map where each object contains a `uri`
   attribute with the network address to which clients can communicate with
   the endpoint. The object MAY contain extension attributes that can be used
-  by clients to determine which URL to use, or to configure access to the
-  specific URL. Whether the URL identifies a network host or links directly to
+  by clients to determine which URI to use, or to configure access to the
+  specific URI. Whether the URI identifies a network host or links directly to
   a resource managed by the network host is protocol specific.
 - Constraints:
   - OPTIONAL.
-  - Each object MUST contain a `url` attribute with a valid, absolute URL.
+  - Each object MUST contain a `uri` attribute with a valid, absolute URI (URL).
 - Examples:
-  - `[ {"url": "https://example.com" } ]`
+  - `[ {"uri": "https://example.com" } ]`
   - ```
     [
-      { "url": "tcp://example.com" },
-      { "url": "wss://example.com" }
+      { "uri": "tcp://example.com" },
+      { "uri": "wss://example.com" }
     ]
     ```
   - ```
     [
       {
-        "url": "tcp://example.com",
+        "uri": "tcp://example.com",
         "priority": 1,
         "status": "down"
       },
       {
-        "url": "wss://example.com",
+        "uri": "wss://example.com",
         "priority": 2,
         "status": "up"
       }
@@ -571,9 +609,12 @@ This specification defines the following envelope options for the indicated
 
 - Type: Map
 - Description: OPTIONAL authorization configuration details of the endpoint.
-  When specified, the authorization configuration MUST be a map of non-empty
-  strings to non-empty strings. The configuration keys below MUST be used as
-  defined. Additional, endpoint-specific configuration keys MAY be added.
+  When specified, the authorization configuration MUST provide sufficient
+  metadata for clients to select the authorization mechanism
+  and discover where authorization is obtained. Runtime credentials and
+  deployment-specific values are expected to be supplied separately through
+  external configuration. The configuration keys below MUST be used as
+  defined. Additional endpoint-specific configuration keys MAY be added.
 
 - Constraints:
   - OPTIONAL.
@@ -585,16 +626,49 @@ This specification defines the following envelope options for the indicated
 - Type: String
 - Description: The type of the authorization configuration. The value SHOULD be
   one of the following:
-  - OAuth2: OAuth 2.0 authorization is used.
-  - Plain: The client uses username with a plaintext password for
-    authentication and authorization.
-  - X509Cert: The client uses client certificate authentication and
+  - `OAuth2`: OAuth 2.0 authorization is used. The `authorityuri` SHOULD
+    reference authorization server metadata as defined by RFC 8414.
+  - `Plain`: The client uses username with a plaintext password for
+    authentication and authorization. For HTTP, see protocol options
+    `plainscheme`, `plainusernamefield`, and `plainpasswordfield`; for other
+    protocols, equivalent transport-specific options MAY be defined as
+    protocol extensions.
+  - `SASL`: The client uses a SASL authentication mechanism. The
+    `mechanism` attribute SHOULD be provided when this type is selected.
+  - `X509Cert`: The client uses client certificate authentication and
     authorization.
-  - APIKey: The client uses an API key for authentication and authorization.
+  - `APIKey`: The client uses an API key for authentication and
+    authorization. For HTTP, see protocol options `apikeyname` and
+    `apikeyin`; for other protocols, equivalent carrier-specific options MAY
+    be defined as protocol extensions.
 
 - Constraints:
   - OPTIONAL.
   - MUST be a non-empty string if used.
+
+- Examples:
+  - `OAuth2`: `{ "type": "OAuth2", "authorityuri": "https://login.example.com/tenant/v2.0" }`.
+    This points clients to the OAuth 2.0 authorization server/issuer metadata.
+  - `Plain`: `{ "type": "Plain", "authorityuri": "https://docs.example.com/auth/plain" }`.
+    This points clients to product documentation for username/password-based authorization setup.
+  - `SASL`: `{ "type": "SASL", "mechanism": "SCRAM-SHA-256", "authorityuri": "https://docs.example.com/auth/sasl" }`.
+    This points clients to mechanism-specific setup guidance (for example SASL profile and parameter requirements).
+  - `X509Cert`: `{ "type": "X509Cert", "authorityuri": "https://docs.example.com/auth/x509" }`.
+    This points clients to certificate enrollment and trust-chain requirements.
+  - `APIKey`: `{ "type": "APIKey", "authorityuri": "https://docs.example.com/auth/apikey" }`.
+    This points clients to key provisioning and placement guidance (for example header/query usage).
+
+###### `protocoloptions.authorization.mechanism`
+
+- Type: String
+- Description: The SASL mechanism name for `authorization.type = "SASL"`
+  (for example `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, `OAUTHBEARER`,
+  or `EXTERNAL`).
+
+- Constraints:
+  - OPTIONAL.
+  - MUST be a non-empty string if used.
+  - MUST only be used when `protocoloptions.authorization.type` is `SASL`.
 
 ###### `protocoloptions.authorization.resourceuri`
 
@@ -617,48 +691,24 @@ This specification defines the following envelope options for the indicated
   - OPTIONAL.
   - MUST be a non-empty URI if used.
 
-###### `protocoloptions.authorization.granttypes`
-
-- Type: Array of Strings
-- Description: The supported authorization grant types. The value SHOULD be a
-  list of strings.
-
-- Constraints:
-  - OPTIONAL.
-  - MUST be a non-empty array if used.
-
 ##### `protocoloptions.deployed`
 
 - Type: Boolean
 - Description: If `true`, the endpoint metadata represents a public, live
-  endpoint that is available for communication and a strict validator MAY test
-  the liveness of the endpoint.
+  endpoint that is expected to be available for communication.
 - Constraints:
   - OPTIONAL.
   - If present, MUST be either `true` or `false`, case-sensitive.
-  - When not specified, the default value MUST be `true`.
+  - When not specified, the default value is MUST be `true`.
 
-##### `protocoloptions.options`
-
-- Type: Map
-- Description: Additional configuration options for the endpoint. The
-  configuration options are protocol specific and described in the
-  [protocol options](#protocol-options) section below.
-- Constraints:
-  - OPTIONAL.
-  - When specified, MUST be a map of non-empty strings to `ANY` type values.
-  - If `protocoloptions.protocol` is a well-known protocol, the options MUST be
-    compliant with the [protocol's options](#protocol-options).
+Protocol-specific options are direct children of `protocoloptions`.
+There is no nested `protocoloptions.options` object.
 
 #### `messagegroups`
 
-The `messagegroups` attribute is an array of URI to message definition groups.
-Relative references (beginning with `/`) are XIDs within the same registry.
-Absolute URIs reference message definition groups in external registries. The
-server stores absolute URIs as-is without resolving them.
-
-The `messagegroups` attribute is used to reference message definition groups
-that are not inlined in the endpoint definition.
+The `messagegroups` attribute is an array of XID-references to message
+definition groups. The `messagegroups` attribute is used to reference
+message definition groups that are not inlined in the endpoint definition.
 
 Example:
 
@@ -669,8 +719,7 @@ Example:
     "method": "POST"
   },
   "messagegroups": [
-    "/messagegroups/mygroup",
-    "https://other-catalog.example.com/messagegroups/external-group"
+    "/messagegroups/mygroup"
   ]
 }
 ```
@@ -737,232 +786,159 @@ constraint for their users.
 
 #### Protocol Options
 
-The following protocol options (`protocoloptions.options`) are defined for the
-respective protocols. All of these are OPTIONAL.
+The following protocol options are direct children of `protocoloptions` for
+the respective protocols. All of these are OPTIONAL.
+
+This specification is primarily descriptive for protocol options: it guides
+clients on how to interpret metadata. It does not require a validator to reject
+every role-inapplicable option.
+
+In each table below, role applicability is shown as:
+- `✓`: The option applies to that role. Clients acting in that role SHOULD
+  apply the option semantics.
+- `-`: The option does not apply to that role.
 
 ##### HTTP options
 
-The [endpoint URLs](#protocoloptionsendpoints) for "HTTP" endpoints MUST be
-valid HTTP URLs using the "http" or "https" scheme.
+The [endpoint URIs](#protocoloptionsendpoints) for "HTTP" endpoints MUST be
+valid HTTP URIs using the "http" or "https" scheme as defined in
+[HTTP Message Format].
 
-The following options are defined for HTTP:
+HTTP commonly uses separate endpoint declarations for subscriber, consumer,
+and producer interactions.
 
-- `method`: The HTTP method to use for the endpoint.
-  - When not specified, the default value MUST be `POST`.
-  - The value MUST be a valid HTTP method name.
-- `headers`: An array of HTTP headers to use for the endpoint. HTTP allows for
-  duplicate headers. The objects in the array have the following attributes:
-  - `name`: The name of the HTTP header. The value MUST be a non-empty string.
-  - `value`: The value of the HTTP header. The value MUST be a non-empty
-    string.
-- `query`: A map of HTTP query parameters to use for the endpoint. The value
-  MUST be a map of non-empty strings to non-empty strings.
+| Name | Type | P | C | S | Description |
+|---|---|---|---|---|---|
+| `method` | string (HTTP method), default `POST` | ✓ | ✓ | ✓ | HTTP method for the concrete operation represented by the endpoint. |
+| `headers` | array of `{name: string, value: string}` | ✓ | ✓ | ✓ | HTTP request headers. Duplicate names are allowed. |
+| `query` | map of string to string | ✓ | ✓ | ✓ | HTTP query parameters for the operation. |
+| `apikeyname` | string | ✓ | ✓ | ✓ | Name of the API key carrier when `authorization.type` is `APIKey` (for example `x-api-key`). |
+| `apikeyin` | enum: `header`, `query`, default `header` | ✓ | ✓ | ✓ | Placement of API key metadata when `authorization.type` is `APIKey`. `header` SHOULD be used; `query` SHOULD only be used when header placement is not possible. |
+| `plainscheme` | enum: `basic`, `form`, `query`, default `basic` | ✓ | ✓ | ✓ | Transport pattern for `authorization.type` = `Plain`. `basic` refers to HTTP Basic authentication ([RFC7617][RFC7617]). |
+| `plainusernamefield` | string | ✓ | ✓ | ✓ | Parameter or header field name carrying the username when `plainscheme` is `form` or `query`. |
+| `plainpasswordfield` | string | ✓ | ✓ | ✓ | Parameter or header field name carrying the password when `plainscheme` is `form` or `query`. |
 
 The values of all `query` and `headers` MAY contain placeholders using the
 [RFC6570][RFC6570] Level 1 URI Template syntax. When the same placeholder is
 used in multiple properties, the value of the placeholder is assumed to be
 identical.
 
-Example:
-
-```yaml
-{
-  "protocol": "HTTP/1.1",
-  "protocoloptions": {
-    "method": "POST",
-    "headers": [
-      {
-        "name": "Content-Type",
-        "value": "application/json"
-      }
-    ],
-    "query": {
-      "operation": "send"
-    }
-  }
-}
-```
+These options only define protocol-level placement and naming metadata.
+Credential values (API keys, usernames, passwords) MUST NOT be stored in
+endpoint metadata and MUST be supplied out-of-band.
 
 ##### AMQP options
 
-The [endpoint URLs](#protocoloptionsendpoints) for "AMQP" endpoints MUST be
-valid AMQP URLs using the "amqp" or "amqps" scheme. If the path portion of the
-URL is present, it MUST be a valid AMQP node name.
+The [endpoint URIs](#protocoloptionsendpoints) for "AMQP" endpoints MUST be
+valid AMQP URIs using the "amqp" or "amqps" scheme. If the path portion of the
+URI is present, it MUST be a valid AMQP node name according to
+[AMQP Addressing Version 1.0].
 
 The following options are defined for AMQP endpoints.
 
-- `node`: The name of the AMQP node (a queue or topic or some addressable
-  entity) to use for the endpoint.
-  - When specified, the value overrides the path portion of the Endpoint URL.
-- `durable`: If `true`, the AMQP `durable` flag is set on transfers.
-  - When not specified, the default value MUST be `false`.
-  - This option only applies to `usage:producer` endpoints.
-- `linkproperties`: A map of AMQP link properties to use for the endpoint.
-  - The value MUST be a map of non-empty strings to non-empty strings.
-- `connection-properties`: A map of AMQP connection properties to use for the
-  endpoint.
-  - The value MUST be a map of non-empty strings to non-empty strings.
-- `distributionmode`: Either `move` or `copy`.
-  - When not specified, the default value MUST be `move`.
-  - The distribution mode is AMQP's way of expressing whether a receiver
-    operates on copies of messages (it's a topic subscriber) or whether it
-    moves messages from the queue (it's a queue consumer). This option only
-    applies to `usage:consumer` endpoints.
+| Name | Type | P | C | S | Description |
+|---|---|---|---|---|---|
+| `node` | string | ✓ | ✓ | ✓ | AMQP node (address). When set, it overrides the URI path. |
+| `durable` | boolean, default `false` | ✓ | - | - | AMQP durable flag. This does not imply a delivery guarantee and is distinct from terminus durability. |
+| `link-properties` | map of string to string | ✓ | ✓ | ✓ | AMQP link properties. |
+| `connection-properties` | map of string to string | ✓ | ✓ | ✓ | AMQP connection properties. |
+| `distribution-mode` | enum: `move`, `copy`, default `move` | - | ✓ | - | AMQP receive distribution mode. |
+| `connection-capabilities` | array of string | ✓ | ✓ | ✓ | AMQP connection capabilities. |
+| `node-capabilities` | array of string | ✓ | ✓ | ✓ | AMQP node capabilities. |
+| `source-filters` | map of string to any | - | ✓ | ✓ | AMQP source filter expressions/descriptor keys for receive setup. |
+| `dynamic` | boolean | ✓ | ✓ | ✓ | Dynamic node creation for source/target setup, depending on role. |
+| `terminus-durability` | enum: `none`, `configuration`, `unsettled-state` | ✓ | ✓ | ✓ | Durability mode for the applicable source or target terminus. |
+| `expiry-policy` | enum: `link-detach`, `session-end`, `connection-close`, `never` | ✓ | ✓ | ✓ | Expiry policy for the applicable terminus. |
+| `timeout` | uinteger | ✓ | ✓ | ✓ | Timeout value used with terminus expiry policy. |
+| `sender-settle-mode` | enum: `unsettled`, `settled`, `mixed` | ✓ | ✓ | ✓ | AMQP sender settlement mode for the active sending side of the link. |
+| `receiver-settle-mode` | enum: `first`, `second` | ✓ | ✓ | ✓ | AMQP receiver settlement mode for the active receiving side of the link. |
 
-The values of all `linkproperties` and `connection-properties` MAY contain
+The values of all `link-properties` and `connection-properties` MAY contain
 placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the
 same placeholder is used in multiple properties, the value of the placeholder
 is assumed to be identical.
 
-Example:
-
-```yaml
-{
-  "usage": [ "producer" ],
-  "protocol": "AMQP/1.0",
-  "protocoloptions": {
-    "node": "myqueue",
-    "durable": true,
-    "linkproperties": {
-      "mylinkproperty": "mylinkpropertyvalue"
-    },
-    "connection-properties": {
-      "my-connection-property": "my-connection-property-value"
-    },
-    "distributionmode": "move"
-  }
-}
-```
-
 ##### MQTT options
 
-The [endpoint URLs](#protocoloptionsendpoints) for "MQTT" endpoints MUST be
-valid MQTT URLs using the (informal) "mqtt" or "mqtts" scheme. If the path
-portion of the URL is present, it MUST be a valid MQTT topic name. The informal
+The [endpoint URIs](#protocoloptionsendpoints) for "MQTT" endpoints MUST be
+valid MQTT URIs using the (informal) "mqtt" or "mqtts" scheme. If the path
+portion of the URI is present, it MUST be a valid MQTT topic name as described
+by [MQTT 3.1.1] and [MQTT 5.0]. The informal
 schemes "tcp" (plain TCP/1883), "ssl" (TLS TCP/8883), and "wss"
 (Websockets/443) MAY also be used, but MUST NOT have a path.
 
-The following options are defined for MQTT endpoints.
+The following options are defined for MQTT 3.1.1 and MQTT 5.0 endpoints.
 
-- `topic`: The MQTT topic to use for the endpoint.
-  - When specified, the value overrides the path portion of the Endpoint URL.
-  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
-    URI Template syntax.
-- `qos`: The MQTT Quality of Service (QoS) level to use for the endpoint.
-  - The value MUST be an integer between 0 and 2.
-  - When not specified, the default value MUST be 0.
-  - The value is overidden by the `qos` property of the
-    [MQTT message format](../message/spec.md#mqtt311-and-mqtt50-protocols).
-- `retain`: If `true`, the MQTT `retain` flag is set on transfers.
-  - When not specified, the default value is `false`.
-  - The value is overidden by the `retain` property of the [MQTT
-    message format](../message/spec.md#mqtt311-and-mqtt50-protocols). This
-    option only applies to `usage:producer` endpoints.
-- `cleansession`: If `true`, the MQTT `cleansession` flag is set on
-  connections.
-  - When not specified, the default value MUST be `true`.
-- `willtopic`: The MQTT `willtopic` to use for the endpoint.
-  - The value MUST be a non-empty string.
-  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
-    URI Template syntax.
-- `willmessage`: This is an XID that refers to the MQTT `willmessage` to use for
-  the endpoint.
-  - The value MUST be a non-empty XID.
-  - It MUST point to a valid
-  [´message´](../message/spec.md#message-definitions) that MUST either
-  use the ["CloudEvents/1.0"](../message/spec.md#cloudevents10) or
-  ["MQTT/3.1.1." or
-  "MQTT/5.0"](../message/spec.md#mqtt311-and-mqtt50-protocols)
-  [`envelope`](../message/spec.md#envelope).
+| Name | Type | P | C | S | Description |
+|---|---|---|---|---|---|
+| `topic` | string | ✓ | - | - | Concrete publish topic name. Prefer concrete destinations over filter syntax. |
+| `topicfilter` | string | - | - | ✓ | Subscribe topic filter. |
+| `qos` | enum: `0`, `1`, `2`, default `0` | ✓ | ✓ | ✓ | Role-relative QoS intent: publish QoS for producer, requested max QoS for subscriber, effective delivery QoS for consumer context. |
+| `retain` | boolean, default `false` | ✓ | - | - | MQTT retain flag for publish behavior. |
+| `willtopic` | string | ✓ | ✓ | ✓ | CONNECT Will topic configuration. |
+| `willmessage` | xid (message reference) | ✓ | ✓ | ✓ | CONNECT Will message definition reference. |
 
-Example:
+MQTT 3.1.1 specific options:
 
-```yaml
-{
-  "usage": [ "producer" ],
-  "protocol": "MQTT/5.0",
-  "protocoloptions": {
-    "topic": "mytopic",
-    "qos": 1,
-    "retain": false,
-    "cleansession": false,
-    "willtopic": "mytopic",
-    "willmessage": "/messagegroups/mygroup/messages/mywillmessage"
-  }
-}
-```
+| Name | Type | P | C | S | Description |
+|---|---|---|---|---|---|
+| `cleansession` | boolean, default `true` | ✓ | ✓ | ✓ | MQTT 3.1.1 clean-session behavior for the connection. |
+
+MQTT 5.0 specific options:
+
+| Name | Type | P | C | S | Description |
+|---|---|---|---|---|---|
+| `cleanstart` | boolean | ✓ | ✓ | ✓ | MQTT 5 clean-start behavior for the connection. |
+| `sessionexpiryinterval` | uinteger (`0..4294967295`) | ✓ | ✓ | ✓ | MQTT 5 session expiry interval in seconds. |
+| `sharedsubscriptiongroup` | string | - | - | ✓ | Shared subscription group. Use with `topicfilter`. |
+| `nolocal` | boolean | - | - | ✓ | MQTT 5 subscribe no-local flag. |
+| `retainaspublished` | boolean | - | - | ✓ | MQTT 5 subscribe retain-as-published flag. |
+| `retainhandling` | enum: `0`, `1`, `2` | - | - | ✓ | MQTT 5 retain-handling mode. |
+
+For MQTT 5.0, prefer `cleanstart` and `sessionexpiryinterval`; `cleansession`
+SHOULD NOT be used.
 
 ##### KAFKA options
 
-The [endpoint URLs](#protocoloptionsendpoints) for "Kafka" endpoints MUST be
+The [endpoint URIs](#protocoloptionsendpoints) for "Kafka" endpoints MUST be
 valid Kafka bootstrap server addresses. The scheme follows Kafka configuration
-usage, e.g. `SSL://<HOST>:<PORT>` or `PLAINTEXT://<HOST>:<PORT>`.
+usage as described in [Apache Kafka], e.g. `SSL://<HOST>:<PORT>` or
+`PLAINTEXT://<HOST>:<PORT>`.
 
 The following options are defined for Kafka endpoints.
 
-- `topic`: The Kafka topic to use for the endpoint.
-  - When specified, the value MUST be a non-empty string.
-  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
-    URI Template syntax.
-- `acks`: The Kafka `acks` setting to use for the endpoint.
-  - The value MUST be an integer between -1 and 1.
-  - When not specified, the default value MUST be 1.
-  - This option only applies to `usage:producer` endpoints.
-- `key`: The fixed Kafka key to use for this endpoint.
-  - When specified, the value MUST be a non-empty string.
-  - This option only applies to `usage:producer` endpoints.
-  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
-    URI Template syntax.
-- `partition`: The fixed Kafka partition to use for this endpoint.
-  - When specified, the value MUST be an integer.
-  - This option only applies to `usage:producer` endpoints.
-- `consumergroup`: The Kafka consumer group to use for this endpoint.
-  - When specified, the value MUST be a non-empty string.
-  - This option only applies to `usage:consumer` endpoints.
-  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
-    URI Template syntax.
-
-Example:
-
-```yaml
-{
-  "usage": [ "producer" ],
-  "protocol": "Kafka/2.0",
-  "protocoloptions": {
-    "topic": "mytopic",
-    "acks": 1,
-    "key": "mykey",
-  }
-}
-```
+| Name | Type | P | C | S | Description |
+|---|---|---|---|---|---|
+| `topic` | string | ✓ | ✓ | ✓ | Kafka topic name. |
+| `acks` | integer (`-1..1`), default `1` | ✓ | - | - | Producer acknowledgement setting. |
+| `key` | string | ✓ | - | - | Producer record key. |
+| `partition` | integer | ✓ | ✓ | - | Fixed producer partition target or explicit consumer partition selection. |
+| `consumergroup` | string | - | ✓ | - | Consumer group identifier for group-based consumption. |
+| `headers` | map of string to string | ✓ | - | - | Producer record headers. |
+| `keyserializer` | string | ✓ | - | - | Producer key serializer class/name. |
+| `valueserializer` | string | ✓ | - | - | Producer value serializer class/name. |
+| `autooffsetreset` | enum: `earliest`, `latest`, `none` | - | ✓ | - | Consumer offset reset behavior when no valid committed offset exists. |
+| `enableautocommit` | boolean | - | ✓ | - | Consumer automatic commit behavior. |
 
 ##### NATS options
 
-The [endpoint URLs](#protocoloptionsendpoints) for "NATS" endpoints MUST be
-valid NATS URLs. The scheme MUST be "nats" or "tls" or "ws" and the URL MUST
-include a port number, e.g. `nats://<HOST>:<PORT>` or `tls://<HOST>:<PORT>`.
+The [endpoint URIs](#protocoloptionsendpoints) for "NATS" endpoints MUST be
+valid NATS URIs as described by [NATS]. The scheme MUST be "nats" or "tls" or
+"ws" and the URI MUST include a port number, e.g. `nats://<HOST>:<PORT>` or
+`tls://<HOST>:<PORT>`.
 
 The following options are defined for NATS endpoints.
 
-- `subject`: The NATS subject to use.
-  - The value MAY contain placeholders using the [RFC6570][RFC6570] Level 1
-    URI Template syntax.
-
-Example:
-
-```yaml
-{
-  "usage": [ "producer" ],
-  "protocol": "NATS/1.0.0",
-  "protocoloptions": {
-    "subject": "mysubject"
-  }
-}
-```
+| Name | Type | P | C | S | Description |
+|---|---|---|---|---|---|
+| `subject` | string | ✓ | - | - | Concrete publish subject. |
+| `subjectfilter` | string | - | - | ✓ | Subscription subject filter. |
+| `queuegroup` | string | - | - | ✓ | Queue subscription group associated with a subject filter. |
 
 [JSON Pointer]: https://www.rfc-editor.org/rfc/rfc6901
 [CloudEvents Types]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system
 [AMQP 1.0]: https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-overview-v1.0-os.html
+[AMQP Addressing Version 1.0]: https://docs.oasis-open.org/amqp/addressing/v1.0/csd01/addressing-v1.0-csd01.html
 [AMQP 1.0 Message Format]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
 [AMQP 1.0 Message Properties]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties
 [AMQP 1.0 Application Properties]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties
@@ -979,5 +955,6 @@ Example:
 [Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html
 [Apache Kafka consumer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html
 [HTTP Message Format]: https://www.rfc-editor.org/rfc/rfc9110#section-6
+[RFC7617]: https://www.rfc-editor.org/rfc/rfc7617
 [RFC6570]: https://www.rfc-editor.org/rfc/rfc6570
 [rfc3339]: https://tools.ietf.org/html/rfc3339

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -1,5 +1,8 @@
 # Endpoint Registry Service - Version 1.0-rc3
 <!-- words: apikeyname apikeyin plainscheme plainusernamefield plainpasswordfield sasl oauthbearer -->
+<!-- words: cleanstart sessionexpiryinterval topicfilter retainhandling retainaspublished nolocal -->
+<!-- words: sharedsubscriptiongroup keyserializer valueserializer enableautocommit autooffsetreset -->
+<!-- words: serializer subjectfilter queuegroup usernames -->
 
 ## Abstract
 

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -255,10 +255,13 @@ this form:
 
         # Common protocol options
         "endpoints": [
-          {
-            "uri": "<URI>"                        # plus endpoint extensions
-          } *                                     # "KAFKA" uses
-        ], ?                                      # "bootstrap.servers" instead
+          {                                     # entry shape is protocol
+            "uri": "<URI>", ?                   #   specific: "uri" for all
+            "bootstrap.servers":                #   protocols except "KAFKA",
+              [ "<STRING>" * ], ?               #   which has no "uri" and
+            "<STRING>": <JSON-VALUE> *          #   uses "bootstrap.servers"
+          } *
+        ], ?
         "authorization": [
           {
             "type": "<STRING>", ?
@@ -624,6 +627,11 @@ This specification defines the following envelope options for the indicated
     ```
   - ```
     [
+      { "bootstrap.servers": [ "broker1:9092", "broker2:9092" ] }
+    ]
+    ```
+  - ```
+    [
       {
         "uri": "tcp://example.com",
         "priority": 1,
@@ -827,10 +835,10 @@ Consumer, Subscriber) to which each option applies. All protocol options are
 OPTIONAL.
 
 The role applicability is descriptive: it guides clients on how to interpret
-metadata, and a validator need not reject every role-inapplicable option.
-Where a rule below is stated with MUST, MUST NOT, or REQUIRED, it is a
-conformance requirement of this specification and an implementation MUST
-reject metadata that violates it.
+metadata. Where a rule below is stated with MUST, MUST NOT, or REQUIRED, it
+is a conformance requirement of this specification, and a client evaluating
+the metadata MUST treat a violation as an error. A Registry server is not
+obligated to check these rules.
 
 In each table below, role applicability is shown as:
 - `✓`: The option applies to that role. Clients acting in that role SHOULD
@@ -867,6 +875,13 @@ distinguishes three HTTP roles:
   delivery agent.
 - Pull consumer (`usage` = `["consumer"]`): an endpoint from which a client
   retrieves messages with its own requests.
+
+An "HTTP" Endpoint describes a profile for message and event transfer over
+HTTP, not a general-purpose HTTP API surface. Declaring exactly one role per
+Endpoint keeps the request contract of each interface unambiguous, so that a
+client knows what it can send and what it can expect without inspecting
+individual messages. Describing a general HTTP API is out of scope for this
+specification and is served by an API description language such as OpenAPI.
 
 Constraints:
 

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -2,7 +2,7 @@
 <!-- words: apikeyname apikeyin plainscheme plainusernamefield plainpasswordfield sasl oauthbearer -->
 <!-- words: cleanstart sessionexpiryinterval topicfilter retainhandling retainaspublished nolocal -->
 <!-- words: sharedsubscriptiongroup keyserializer valueserializer enableautocommit autooffsetreset -->
-<!-- words: serializer subjectfilter queuegroup usernames -->
+<!-- words: serializer subjectfilter queuegroup usernames tenantid -->
 
 ## Abstract
 
@@ -832,6 +832,17 @@ In each table below, role applicability is shown as:
   apply the option semantics.
 - `-`: The option does not apply to that role.
 
+Any string value of any protocol option MAY contain placeholders expressed
+with the [RFC6570][RFC6570] Level 1 URI Template expression syntax, for
+example `orders/{tenantid}/events`. This applies to plain
+string values, to the string items of arrays, and to the keys and values of
+maps, and it also applies to the `uri` values of
+[`protocoloptions.endpoints`](#protocoloptionsendpoints). Placeholders are
+resolved out-of-band by the client; this specification does not define how
+the values are supplied. When the same placeholder name occurs in more than
+one value of the same endpoint, all of its occurrences MUST resolve to the
+same value.
+
 ##### HTTP options
 
 The [endpoint URIs](#protocoloptionsendpoints) for "HTTP" endpoints MUST be
@@ -872,11 +883,6 @@ Constraints:
 | `plainusernamefield` | string | ✓ | ✓ | ✓ | Parameter or header field name carrying the username when `plainscheme` is `form` or `query`. |
 | `plainpasswordfield` | string | ✓ | ✓ | ✓ | Parameter or header field name carrying the password when `plainscheme` is `form` or `query`. |
 
-The values of all `query` and `headers` MAY contain placeholders using the
-[RFC6570][RFC6570] Level 1 URI Template syntax. When the same placeholder is
-used in multiple properties, the value of the placeholder is assumed to be
-identical.
-
 These options only define protocol-level placement and naming metadata.
 Credential values (API keys, usernames, passwords) MUST NOT be stored in
 endpoint metadata and MUST be supplied out-of-band.
@@ -912,11 +918,6 @@ AMQP receiving link both establishes interest in the source node and carries
 the resulting transfers. When it does, the `subscriber` role refers to the
 establishment of the link with the node as source and the `consumer` role
 refers to the transfers over that link.
-
-The values of all `link-properties` and `connection-properties` MAY contain
-placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the
-same placeholder is used in multiple properties, the value of the placeholder
-is assumed to be identical.
 
 ##### MQTT options
 
@@ -967,10 +968,6 @@ MQTT 5.0 specific options:
 | `retainaspublished` | boolean | - | - | ✓ | MQTT 5 subscribe retain-as-published flag. |
 | `retainhandling` | enum: `0`, `1`, `2` | - | - | ✓ | MQTT 5 retain-handling mode. |
 
-`cleansession` is an MQTT 3.1.1 option only. It is not defined for `MQTT/5.0`
-endpoints and MUST NOT be used with them; `cleanstart` and
-`sessionexpiryinterval` express the equivalent MQTT 5 behavior and together
-supersede it.
 
 Shared subscription constraints:
 
@@ -1036,10 +1033,7 @@ valid NATS URIs as described by [NATS]. The scheme MUST be "nats" or "tls" or
 "ws" and the URI MUST include a port number, e.g. `nats://<HOST>:<PORT>` or
 `tls://<HOST>:<PORT>`.
 
-The options below describe Core NATS publish and subscribe only. JetStream
-streams, consumers, and their durability and acknowledgement settings are out
-of scope for this specification and, if needed, MUST be expressed through
-extension attributes.
+The options below describe Core NATS publish and subscribe.
 
 The following options are defined for NATS endpoints.
 

--- a/message/spec.md
+++ b/message/spec.md
@@ -1404,7 +1404,7 @@ Example:
 [MQTT 5.0]: https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html
 [MQTT 3.1.1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
 [CloudEvents]: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
-[NATS]: https://docs.nats.io/reference/reference-protocols/nats-protocol
+[NATS]: https://docs.nats.io/reference/protocols/client/
 [Apache Kafka]: https://kafka.apache.org/protocol
 [Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html
 [Apache Kafka consumer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html


### PR DESCRIPTION
## Summary
- reference RFC8414 for OAuth2 authority metadata in endpoint authorization guidance
- add SASL authorization type and mechanism guidance
- add HTTP APIKey/Plain protocol options and align pseudo-schema with model
- add inline spec-level words comment for new endpoint vocabulary

## Validation
- python tools/verify.py endpoint

Fixes #505