### PR TITLE
Fix invalid JSON in core/model.schema.json (two missing commas)

### DIFF
--- a/core/model.schema.json
+++ b/core/model.schema.json
@@ -99,9 +99,9 @@
                 "equals": {
                   "type": "string"
                 }
-              }
+              },
               "description": "Group level constraints over resources"
-            }
+            },
             "resources": {
               "type": "object",
               "description": "Resource types within this group",


### PR DESCRIPTION
## Problem

`core/model.schema.json` is not valid JSON. Two object members in the
`GroupDefinition.constraints` block are not separated by commas:

- between the `properties` object and its sibling `description`
- between the `constraints` object and its sibling `resources`

```
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 103 column 15
```

## Impact

`tools/validate-models.py` loads this schema before it validates any model, so
the syntax error makes it abort with an unhandled `JSONDecodeError`. The effect
is not cosmetic: **no model in the repository is validated at all**, and the
failure surfaces as a Python traceback rather than a validation message.

With the commas restored, the tool runs and the core models validate:

```
PASS: cloudevents\model.json
PASS: core\model.json
PASS: endpoint\model.json
PASS: message\model.json
FAIL: schema\model.json
```

## Scope

Two characters, one file. This is a pure syntax repair -- no schema semantics
are changed. The comma placement matches the surrounding style, and
`constraints` remains a sibling of `ximportresources` and `resources`.

## Relationship to #512

This is a **prerequisite** for #512, not a fix for it. #512 notes the
unparseable file under "Note on discoverability"; this PR is that repair
upstreamed. The remaining `FAIL: schema\model.json` above is exactly the
condition #512 describes, and its two defects -- the missing `validateformat` /
`validatecompatibility` / `strictvalidation` keys on `ResourceDefinition`, and
the `constraints` map being modelled one level too shallow -- are untouched
here and left for a separate change.
