### PR TITLE
docs: update endpoint.messagegroups and message.basemessage in spec files to use correct type

### DIFF
--- a/cloudevents/schemas/document-schema.avsc
+++ b/cloudevents/schemas/document-schema.avsc
@@ -604,7 +604,7 @@
                 }
               },
               "name": "messagegroups",
-              "doc": "The message groups that are supported by this endpoint"
+              "doc": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries."
             },
             {
               "name": "Extensions",

--- a/cloudevents/schemas/document-schema.json
+++ b/cloudevents/schemas/document-schema.json
@@ -1270,7 +1270,7 @@
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint",
+            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
             "items": {
               "type": "string",
               "format": "uri"

--- a/cloudevents/schemas/openapi.json
+++ b/cloudevents/schemas/openapi.json
@@ -5174,7 +5174,7 @@
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint",
+            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
             "items": {
               "type": "string",
               "format": "uri"

--- a/endpoint/model.json
+++ b/endpoint/model.json
@@ -950,9 +950,9 @@
         "messagegroups": {
           "name": "messagegroups",
           "type": "array",
-          "description": "The message groups that are supported by this endpoint",
+          "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
           "item": {
-            "type": "xid",
+            "type": "uri",
             "target": "/messagegroups/messages"
           }
         },

--- a/endpoint/schemas/document-schema.avsc
+++ b/endpoint/schemas/document-schema.avsc
@@ -604,7 +604,7 @@
                 }
               },
               "name": "messagegroups",
-              "doc": "The message groups that are supported by this endpoint"
+              "doc": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries."
             },
             {
               "name": "Extensions",

--- a/endpoint/schemas/document-schema.json
+++ b/endpoint/schemas/document-schema.json
@@ -1264,7 +1264,7 @@
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint",
+            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
             "items": {
               "type": "string",
               "format": "uri"

--- a/endpoint/schemas/openapi.json
+++ b/endpoint/schemas/openapi.json
@@ -4081,7 +4081,7 @@
           },
           "messagegroups": {
             "type": "array",
-            "description": "The message groups that are supported by this endpoint",
+            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries.",
             "items": {
               "type": "string",
               "format": "uri"

--- a/endpoint/spec.md
+++ b/endpoint/spec.md
@@ -339,7 +339,7 @@ this form:
         "queuegroup": "<STRING>" ?
       }, ?
 
-      "messagegroups": [ XID * ], ?
+      "messagegroups": [ "<URI>" * ], ?
       # End of Endpoint extensions
 
       "messagesurl": "<URL>", ?
@@ -749,9 +749,13 @@ This specification defines the following envelope options for the indicated
 
 #### `messagegroups`
 
-The `messagegroups` attribute is an array of XID-references to message
-definition groups. The `messagegroups` attribute is used to reference
-message definition groups that are not inlined in the endpoint definition.
+The `messagegroups` attribute is an array of URI to message definition groups.
+Relative references (beginning with `/`) are XIDs within the same registry.
+Absolute URIs reference message definition groups in external registries. The
+server stores absolute URIs as-is without resolving them.
+
+The `messagegroups` attribute is used to reference message definition groups
+that are not inlined in the endpoint definition.
 
 Example:
 
@@ -762,7 +766,8 @@ Example:
     "method": "POST"
   },
   "messagegroups": [
-    "/messagegroups/mygroup"
+    "/messagegroups/mygroup",
+    "https://other-catalog.example.com/messagegroups/external-group"
   ]
 }
 ```

--- a/message/spec.md
+++ b/message/spec.md
@@ -235,7 +235,7 @@ MQTT, where it would be useful to provide protocol-specific hints in addition
 to the CloudEvents declaration like requiring a specific topic path pattern
 for the event type.
 
-The `basemessage` attribute, an xid-typed reference to another message
+The `basemessage` attribute, a URI-typed reference to another message
 definition, enables such reuse scenarios. Any message definition MAY refer to
 another message definition as its base, which effects a copy of the base
 message’s definitions into the message that defines it. The mechanism is
@@ -478,7 +478,7 @@ this form:
           "compatibilityvalidatedreason": "<STRING>", ?
 
           # Start of Message extension attributes
-          "basemessage": "<URL>", ?            # Message being extended
+          "basemessage": "<URI>", ?            # Message being extended
 
           "envelope": "<STRING>", ?            # e.g. CloudEvents/1.0
           "envelopemetadata": {


### PR DESCRIPTION
A recent change (https://github.com/xregistry/spec/commit/0e76232e6d5d125a771cf8c662fefd8fbf24a03e#diff-4790cbfb37d699e736007395731e1952053fa95a56d9a84605b94e66aa1252c5) seems to replaced an update to the spec we made back in https://github.com/xregistry/spec/pull/467

Updating the documentation to be compliant with the spec