### PR TITLE
Week of Aug 3

### DIFF
--- a/core/model.md
+++ b/core/model.md
@@ -868,6 +868,12 @@ Note that this feature has similar results as setting the Resource attribute's
     - Deleted Ancestor: if a Version's ancestor is deleted, then this Version
       MUST become a root, and its `ancestorid` value MUST be set to its
       `versionid` value.
+    - The name of this versionmode is a bit of a misnomer in that it is not
+      100% "manual". As stated above, as a convenience, by default new
+      Versions will point to the "latest" Version as its ancestor. If this
+      behavior is not desired, then during the "create" operation, the
+      `ancestorid` can be set to point to itself (or any other Version) if
+      desired.
 
   - `createdat`
     - Newest Version: MUST be determined by finding the Version with the

--- a/core/spec.md
+++ b/core/spec.md
@@ -4096,12 +4096,11 @@ when a query includes a filter expression, any nested xRegistry collections
 in the response SHOULD result in the specification of a `<COLLECTION>url`
 attribute that allows clients to easily traverse into that collection with
 the appropriated sub-filter expression to yield the same results as the
-original filter, but just for that nested collection. However, if the filters
-results in zero entities for a particular collection due to the filter
-excluding that collection entirely, rather than the `<COLLECTION>url` not
-having any filter expression at all (which would result in the full collection
-being returned), servers MUST use the special filter expression `excludeall`
-to indicate no results are to be returned for that URL.
+original filter, but just for that nested collection. However, if a collection
+has zero entities (regardless of whether the empty list is due to the filter
+or due to the collection being empty), server MUST use a special filter
+expression, `excludeall`, to indicate no results are to be returned for that
+URL.
 
 For example, using HTTP:
 ```yaml
@@ -4119,20 +4118,21 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-If the URL references a collection then an empty collection (`{}`) MUST be
-returned. If the URL references an entity, then an error
-([not_found](#not_found)) MUST be generated. If any other filter expression
-appear at the same time, then an error ([bad_filter](#bad_filter)) MUST be
-generated.
+URLs with the `excludeall` filter expression MUST adhere to the following:
+- If the URL references a collection then an empty collection (`{}`) MUST be
+  returned.
+- If the URL references an entity, then an error ([not_found](#not_found)) MUST
+  be generated.
+- If any other filter expression appears at the same time, then an error
+  ([bad_filter](#bad_filter)) MUST be generated.
+- This value is expected to only be used by servers in response to a query that
+  used a filter and produces a `<COLLECTION>url` to an empty collection.
 
-The special `filter` value `excludeall` MAY be used to indicate that no
-results are to be returned from the query. This value is expected to only be
-used by servers in response to a query that produces a `<COLLECTION>url`.
-
-If the request references an entity (not a collection), and the expression
-references an attribute in that entity (i.e. there is no `<PATH>`), then if the
-expression does not match the entity, that entity MUST NOT be returned. In
-other words, a `404 Not Found` would be generated in the HTTP protocol case.
+If the request references an entity (not a collection), and the filter
+expression references an attribute in that entity (i.e. there is no `<PATH>`),
+then if the expression does not match the entity, that entity MUST NOT be
+returned. In other words, a `404 Not Found` would be generated in the HTTP
+protocol case.
 
 Invalid filter expressions MUST generate an error ([bad_filter](#bad_filter)).
 

--- a/core/spec.md
+++ b/core/spec.md
@@ -1938,17 +1938,23 @@ The following defines the specification-defined capabilities:
   an error ([not_available](#not_available)).
 
 - Defined values:
-  - [`capabilities`](#registry-capabilities)
+  - [`capabilities`](#registry-capabilities) (MUST always be present in the
+    list)
   - [`capabilitiesoffered`](#offered-capabilities)
   - `entities` (xRegistry root entity, Groups, Resource and Versions. MUST
-    have a `mutable` value of `false`)
+    always be present in the list.)
   - [`export`](#single-document-view)
-  - [`model`](#model-attribute) (MUST have a `mutable` value of `false`)
+  - [`model`](#model-attribute) (MUST have a `mutable` value of `false`. MUST
+    always be present in the list.)
   - [`modelsource`](#modelsource-attribute)
-- When not specified, the default value MUST be just the `entities` value,
-  with a `"mutable"` value of `true`.
-- This capability MUST always include `entities` as a value, even if its
-  `mutable` attribute is `false`.
+- When not specified, the default value MUST be:
+  ```yaml
+  {
+    "capabilities": { "mutable": false },
+    "entities": { "mutable": true },
+    "model": { "mutable": false }
+  }
+  ```
 - Implementations MAY define additional values.
 - Implementations MAY define additional attributes for the nested Object.
 - It is STRONGLY RECOMMENDED that implementations also support at least

--- a/core/spec.md
+++ b/core/spec.md
@@ -1705,6 +1705,13 @@ The serialization of the Registry entity MUST adhere to this form:
 }
 ```
 
+This entity behaves like all other entities in the Registry with respect to
+how it is managed. However, since it contains attributes that are only visible
+upon request (e.g. `model` and `capabilities`), for clarity, when those
+attributes are modified the Registry entity is considered to be updated, and
+therefore its `epoch` and `modifiedat` values MUST be updated per their
+defined semantics.
+
 The Registry entity includes the following
 [common attributes](#common-attributes):
 - [`registryid`](#singularid-id-attribute) - REQUIRED in API and document
@@ -2071,9 +2078,6 @@ indicate that the server MUST replace `"*"` with the full set of items that
 are available. An error ([capability_wildcard](#capability_wildcard)) MUST be
 generated if `"*"` appears along with any other value in the list. `"*"`
 MUST NOT appear in the serialization in any server's response.
-
-Regardless of the mechanism used to update the capabilities, the Registry's
-`epoch` value MUST be incremented upon each update.
 
 The enum of values allows for some special cases:
 - String capabilities MAY include `*` as a wildcard character in a value


### PR DESCRIPTION
- make it clear the Registry's epoch/modifiedat are updated when model and capabilities are updated
- clarify 'manual' mode and make it clear '/model' must be supported and exposed via capabilities
- require the use of 'excludeall' for all empty collections when using filtering

Fixes #520 
Fixes #503
Fixes #513 