### PR TITLE
Week of Aug 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ The project includes a "core" specification that defines the basic model and
 APIs of a Registry and a set of domain-specific specifications that extend that
 core for particular use cases. By leveraging the same "core" model/APIs,
 generic tooling and common patterns of Registry access can be developed which
-help create an interoperable (and standard) interface.
+help create an interoperable (and standard) interface. See
+[A Quick Introduction to
+xRegistry](core/primer.md#3-a-quick-introduction-to-xregistry) for more
+information.
 
 It is expected that further specifications will be developed, both as part
 of the xRegistry project and outside, that will leverage this framework for

--- a/core/model.json
+++ b/core/model.json
@@ -9,7 +9,6 @@
     },
     "registryid": {
       "type": "string",
-      "matchcase": true,
       "immutable": true,
       "readonly": true,
       "required": true

--- a/core/model.md
+++ b/core/model.md
@@ -354,10 +354,11 @@ The following describes the attributes of the Registry model:
 ### `attributes.<STRING>.readonly`
 - Type: Boolean.
 - OPTIONAL.
-- Indicates whether this attribute is modifiable by a client. During
-  creation, or update, of an entity if this attribute is specified, then
-  its value MUST be silently ignored by the server even if the value is
-  invalid.
+- Indicates whether this attribute is modifiable by a client. Unless otherwise
+  stated, during creation, or update, of an entity if this attribute is
+  specified, then its value MUST be silently ignored by the server even if the
+  value is invalid. Note that there are some readonly attributes that are
+  examined by a server during a write operation (e.g. `epoch` and IDs).
 
   Typically, attributes that are completely under the server's control
   will be `readonly` - e.g. `self`.

--- a/core/model.md
+++ b/core/model.md
@@ -1,7 +1,7 @@
 # xRegistry Service Model - Version 1.0-rc3
 
 <!-- words: compat validatecompatibility validateformat strictvalidation -->
-<!-- words: matchcase compatibilityvalidated formatvalidated -->
+<!-- words: compatibilityvalidated formatvalidated -->
 <!-- words: validators matchversions -->
 
 ## Abstract
@@ -81,7 +81,6 @@ The overall format of a model definition is as follows:
       "description": "<STRING>", ?
       "enum": [ <VALUE> * ], ?         # Array of scalars of type "<TYPE>"
       "strict": <BOOLEAN>, ?           # Just "enum" values or not. Default=true
-      "matchcase": <BOOLEAN>, ?        # Strings case-sensitive? Default=false
       "matchversions": <BOOLEAN>, ?    # Same for all Versions? Default=false
       "readonly": <BOOLEAN>, ?         # From client's POV. Default=false
       "immutable": <BOOLEAN>, ?        # Once set, can't change. Default=false
@@ -322,15 +321,6 @@ The following describes the attributes of the Registry model:
   This attribute has no impact when `enum` is absent or an empty array.
 - When not specified, the default value MUST be `true`.
 
-### `attributes.<STRING>.matchcase`
-- Type: Boolean.
-- OPTIONAL.
-- Indicates whether the `string` attribute's value MUST be compared with
-  a matching value in a case-sensitive way, or not.
-- This aspect MUST NOT be `true` if the owning attribute's `type` (or
-  `item.type` for non-scalars) is not `"string"`.
-- When not specified, the default value MUST be `false`.
-
 ### `attributes.<STRING>.matchversions`
 - Type: Boolean.
 - OPTIONAL.
@@ -346,9 +336,6 @@ The following describes the attributes of the Registry model:
   - Are statically defined. Meaning, not defined as part of an `ifvalues` clause
     or via a `*` extension definition
   - Are not defined within an array or map. Within an object is allowed.
-- In the case of the attribute type being a `string`, the comparison MUST take
-  into account the [matchcase](#attributesstringmatchcase) aspect of the
-  attribute.
 - When not specified, the default value MUST be `false`.
 
 ### `attributes.<STRING>.readonly`
@@ -689,9 +676,7 @@ specified at all.
 
 When present, this aspect MUST contain the
 [dot (`.`) notation](spec.md#xregistry-dot--notation) path in the
-Group instance that the referenced Resource attribute MUST match. In the
-case of the attribute type being a `string`, the comparison MUST take into
-account the [matchcase](#attributesstringmatchcase) aspect of the attribute.
+Group instance that the referenced Resource attribute MUST match.
 
 If the Group and Resource attributes are not of the same scalar `type` then
 an error ([model_error])(./spec.md#model_error) MUST be generated.

--- a/core/model.schema.json
+++ b/core/model.schema.json
@@ -324,11 +324,6 @@
           "default": true,
           "description": "Whether to restrict values to enum only"
         },
-        "matchcase": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether string value comparisons are case-sensitive"
-        },
         "matchversions": {
           "type": "boolean",
           "default": false,

--- a/core/sample-model-full.json
+++ b/core/sample-model-full.json
@@ -10,7 +10,6 @@
     "registryid": {
       "name": "registryid",
       "type": "string",
-      "matchcase": true,
       "readonly": true,
       "immutable": true,
       "required": true
@@ -140,7 +139,6 @@
         "dirid": {
           "name": "dirid",
           "type": "string",
-          "matchcase": true,
           "immutable": true,
           "required": true
         },
@@ -296,14 +294,12 @@
             "fileid": {
               "name": "fileid",
               "type": "string",
-              "matchcase": true,
               "immutable": true,
               "required": true
             },
             "versionid": {
               "name": "versionid",
               "type": "string",
-              "matchcase": true,
               "immutable": true,
               "required": true
             },
@@ -376,7 +372,6 @@
             "ancestorid": {
               "name": "ancestorid",
               "type": "string",
-              "matchcase": true,
               "required": true
             },
             "contenttype": {
@@ -424,7 +419,6 @@
             "fileid": {
               "name": "fileid",
               "type": "string",
-              "matchcase": true,
               "immutable": true,
               "required": true
             },
@@ -496,7 +490,6 @@
             "fileid": {
               "name": "fileid",
               "type": "string",
-              "matchcase": true,
               "immutable": true,
               "required": true
             },
@@ -596,7 +589,6 @@
             "defaultversionid": {
               "name": "defaultversionid",
               "type": "string",
-              "matchcase": true,
               "required": true
             },
             "defaultversionurl": {

--- a/core/spec.md
+++ b/core/spec.md
@@ -700,13 +700,15 @@ in responses or to use this information.
 
 ### Design: Implicit Creation of Parent Entities
 
-To reduce the number of interactions needed when creating an entity, all
-nonexisting parent entities specified as part of `<PATH>` to the entity MUST
-be implicitly created. Each of those entities MUST be created with the
-appropriate `<SINGULAR>id` specified in the `<PATH>`. If any of those
-entities have REQUIRED attributes, then they cannot be implicitly created, and
-would need to be created directly. This also means that the creation of the
-original entity would fail and generate an error
+To reduce the number of interactions needed when creating an entity, if any of
+its parent entities do not exist, then they MUST be implicitly created. Each of
+those entities MUST be created with the appropriate `<SINGULAR>id` as specified
+by the protocol-specific mechanism by which the nested entity is identified.
+For example, in HTTP the `<PATH>` would include the `<SINGULAR>id` values
+of the parent entities. If any of those entities have REQUIRED attributes,
+then they cannot be implicitly created, and would need to be created directly.
+This also means that the creation of the original entity would fail and
+generate an error
 ([required_attribute_missing](./spec.md#required_attribute_missing)) for the
 appropriate parent entity.
 
@@ -1136,6 +1138,9 @@ of the existing entity. Then the existing entity would be deleted.
   values. In this sense, implementations might create a `shortself` that is
   known for the lifetime of the entity and the capability controls whether
   the attribute is serialized or not.
+
+  When the `shortself` capability is disabled, the attribute name `shortself`
+  is still a reserved attribute name and MUST NOT be used as an extension.
 
 - Constraints:
   - REQUIRED if the `shortself` capability is enabled.

--- a/core/spec.md
+++ b/core/spec.md
@@ -1,6 +1,6 @@
 # xRegistry Service - Version 1.0-rc3
 
-<!-- words: validatecompatibility validateformat strictvalidation matchcase -->
+<!-- words: validatecompatibility validateformat strictvalidation -->
 <!-- words: compat formatvalidated compatibilityvalidated -->
 <!-- words: compat formatvalidatedreason compatibilityvalidatedreason -->
 <!-- words: matchversions excludeall -->
@@ -468,7 +468,6 @@ For easy reference, the JSON serialization of a Registry adheres to this form:
         "description": "<STRING>", ?
         "enum": [ <VALUE> * ], ?        # Array of scalars of type `"type"`
         "strict": <BOOLEAN>, ?          # Just "enum" values? Default=true
-        "matchcase": <BOOLEAN>, ?       # Strings case-sensitive? Def=false
         "matchversions": <BOOLEAN>, ?   # Same for all Versions? Def=false
         "readonly": <BOOLEAN>, ?        # From client's POV. Default=false
         "immutable": <BOOLEAN>, ?       # Once set, can't change. Default=false
@@ -872,13 +871,13 @@ be one of the following data types:
   4.2](https://datatracker.ietf.org/doc/html/rfc3986#section-4.2) with the
   added "URL" constraints mentioned in [RFC 3986 Section
   1.1.3](https://datatracker.ietf.org/doc/html/rfc3986#section-1.1.3).
-- `xid` - MUST be a URL (xid) reference to another entity defined within
-  the Registry. The actual entity attribute value MAY reference a non-existing
-  entity (i.e. be a dangling pointer), but the syntax MUST reference a
-  defined/valid type in the Registry. This type of attribute is used in
-  place of `url` so that the Registry can do "type checking" to ensure the
-  value references the correct type of Registry entity. See the definition of
-  the [`target` model attribute](./model.md#attributesstringtarget) for more
+- `xid` - MUST be a case-sensitive URL (xid) reference to another entity
+  defined within the Registry. The actual entity attribute value MAY reference
+  a non-existing entity (i.e. be a dangling pointer), but the syntax MUST
+  reference a defined/valid type in the Registry. This type of attribute is
+  used in place of `url` so that the Registry can do "type checking" to ensure
+  the value references the correct type of Registry entity. See the definition
+  of the [`target` model attribute](./model.md#attributesstringtarget) for more
   information. Its value MUST start with a `/`.
 - `xidtype` - MUST be a URL reference to an
    [xRegistry model](./model.md#registry-model) type. The reference MUST point
@@ -1181,7 +1180,7 @@ of the existing entity. Then the existing entity would be deleted.
 - Constraints:
   - REQUIRED.
   - MUST be immutable.
-  - MUST be a non-empty relative URL to the current entity.
+  - MUST be a case-sensitive non-empty relative URL to the current entity.
   - MUST be of the form:
     `/[<GROUPS>/<GID>[/<RESOURCES>/<RID>[/meta | /versions/<VID>]]]` and
     reference valid Group and Resource types. Otherwise, an error
@@ -2978,7 +2977,8 @@ and the following Meta-level attributes:
 
 - Constraints:
   - OPTIONAL.
-  - If present, it MUST be the `xid` of a same-typed Resource in the Registry.
+  - If present, it MUST be the case-sensitive `xid` of a same-typed Resource
+    in the Registry.
 
 #### `readonly` Attribute
 - Type: Boolean
@@ -3053,7 +3053,8 @@ and the following Meta-level attributes:
 
 #### `defaultversionid` Attribute
 - Type: String
-- Description: The `versionid` of the default Version of the Resource.
+- Description: The case-sensitive `versionid` of the default Version of the
+  Resource.
 
 - Constraints:
   - REQUIRED.
@@ -3305,9 +3306,9 @@ and the following Version-level attributes:
 - Type: String
 - Description: The `versionid` of this Version's ancestor.
 
-  The `ancestorid` attribute MUST be set to the `versionid` of this Version's
-  ancestor. If this Version is a root of an ancestor hierarchy tree then it
-  MUST be set to its own `versionid` value.
+  The `ancestorid` attribute MUST be set to the case-sensitive `versionid` of
+  this Version's ancestor. If this Version is a root of an ancestor hierarchy
+  tree then it MUST be set to its own `versionid` value.
 
   See the Resource's
   [`versionmode`](./model.md#groupsstringresourcesstringversionmode) model
@@ -4390,8 +4391,9 @@ one being chosen temporarily.
 Use of this flag on an operation that allows for modifying multiple Resources
 MUST generate an error ([bad_flag](#bad_flag)).
 
-This flag MUST include a single parameter, a string containing the `versionid`
-of the Version that is to become the new default Version.
+This flag MUST include a single parameter, a string containing the
+case-sensitive `versionid` of the Version that is to become the new default
+Version.
 
 The following rules apply:
 - A value of `null` indicates that the client wishes to switch to the

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -67,16 +67,16 @@ models:
 	@# of 'xr' can be done
 	if which xr ; then \
 	  echo Using local xr ; \
-	  xr model verify */model.json workingdrafts/models/*/model.json -v ; \
+	  xr model verify */model.json workingdrafts/models/*/model.json -v && \
 	  xr model verify core/sample-model.json --full-model | \
 		jq 'del(.groups.dirs.resources.files.attributes.fileproxyurl)' \
 		> core/sample-model-full.json ; \
 	else \
-	  echo Using docker ghcr.io/xregistry/xr ; \
+	  echo Using docker ghcr.io/xregistry/xr && \
 	  docker run -t -v $$PWD:/xreg -w /xreg --entrypoint /bin/sh \
 		ghcr.io/xregistry/xr -c \
 			"/xr model verify */model.json \
-			workingdrafts/models/*/model.json -v" ; \
+			workingdrafts/models/*/model.json -v" && \
 	  docker run -t -v $$PWD:/xreg -w /xreg --entrypoint /bin/sh \
 		ghcr.io/xregistry/xr -c "/xr model verify core/sample-model.json \
 		--full-model" | \


### PR DESCRIPTION
- mention some readonly attributes are inspected by server
- make auto-creation of parents a non-http specific thing
- make it clear that even when shortself is disabled, the attr is still reserved
- drop support for matchcase

Fixes: #544
FIxes: #551 
