### PR TITLE
Reduce repetition in the core primer

### DIFF
--- a/core/model.md
+++ b/core/model.md
@@ -931,7 +931,7 @@ Note that this feature has similar results to setting the Resource attribute's
   values of this aspect.
 - See the
   [`singleversionroot` Policy
-  Enforcement](./primer.md#1119-singleversionroot-policy-enforcement) section of
+  Enforcement](./primer.md#singleversionroot-policy-enforcement) section of
   the Primer for more information.
 
 ### `groups.<STRING>.resources.<STRING>.validateformat`

--- a/core/primer.md
+++ b/core/primer.md
@@ -1,6 +1,6 @@
 # xRegistry Primer
 
-<!-- words: validatecompatibility validateformat strickvalidation -->
+<!-- words: validatecompatibility validateformat -->
 <!-- words: strictvalidation matchversions readme upserts -->
 
 <!-- no verify-specs -->
@@ -29,7 +29,6 @@ normative technical details.
     - [3.2.6. Errors](#326-errors)
   - [3.3. Defining a Basic Model](#33-defining-a-basic-model)
     - [3.3.1. Adding your own attributes (extensions)](#331-adding-your-own-attributes-extensions)
-  - [3.4. Where to go next](#34-where-to-go-next)
 - [4. History](#4-history)
 - [5. Value proposition](#5-value-proposition)
   - [5.1. Why build something new?](#51-why-build-something-new)
@@ -38,61 +37,56 @@ normative technical details.
   - [5.4. Versioning](#54-versioning)
   - [5.5. Schema validation](#55-schema-validation)
   - [5.6. Payload reduction](#56-payload-reduction)
-  - [5.7. Schema-based data contract generation](#57-schema-based-data-contract-generation)
-  - [5.8. Producer and consumer generation](#58-producer-and-consumer-generation)
-  - [5.9. Basis for further developments](#59-basis-for-further-developments)
-- [6. Motivation](#6-motivation)
-- [7. Design Goals](#7-design-goals)
-  - [7.1. Non-Goals](#71-non-goals)
-- [8. Representations](#8-representations)
-  - [8.1. File](#81-file)
-  - [8.2. Static File Server](#82-static-file-server)
-  - [8.3. API Server](#83-api-server)
-- [9. Embeddings, References, and Federation](#9-embeddings-references-and-federation)
-  - [9.1. Formats and Content/Media-Types](#91-formats-and-contentmedia-types)
-  - [9.2. Embeddings and Links](#92-embeddings-and-links)
-  - [9.3. Federation](#93-federation)
-    - [9.3.1. Composing registries in memory](#931-composing-registries-in-memory)
-    - [9.3.2. Shadowing](#932-shadowing)
-    - [9.3.3. Identifiers](#933-identifiers)
-    - [9.3.4. API Servers and Proxies](#934-api-servers-and-proxies)
-- [10. Possible Use Cases](#10-possible-use-cases)
-  - [10.1. CloudEvents](#101-cloudevents)
-  - [10.2. Business objects](#102-business-objects)
-  - [10.3. Metadata files in repositories](#103-metadata-files-in-repositories)
-- [11. Design decisions or topics of interest](#11-design-decisions-or-topics-of-interest)
-  - [11.1. Resource.ID vs Resource.Version.ID](#111-resourceid-vs-resourceversionid)
-  - [11.2. Valid Characters](#112-valid-characters)
-  - [11.3. Extensions](#113-extensions)
-  - [11.4. Group organization](#114-group-organization)
-  - [11.5. Deleting entities](#115-deleting-entities)
-  - [11.6. Detection of Referenced Resources](#116-detection-of-referenced-resources)
-  - [11.7. Shared/Referenced Resources](#117-sharedreferenced-resources)
-  - [11.8. Default Version and Maximum Versions](#118-default-version-and-maximum-versions)
-  - [11.9. Potential Extensions](#119-potential-extensions)
-  - [11.10. Why Epoch?](#1110-why-epoch)
-  - [11.11. Naming and Case Sensitivity](#1111-naming-and-case-sensitivity)
-  - [11.12. Why the lower character limit on some Group and Resource type names?](#1112-why-the-lower-character-limit-on-some-group-and-resource-type-names)
-  - [11.13. Why must Group type and Resource type names be valid attribute names?](#1113-why-must-group-type-and-resource-type-names-be-valid-attribute-names)
-  - [11.14. Choosing unique Group and Resource names](#1114-choosing-unique-group-and-resource-names)
-  - [11.15. Are `self` and `shortself` attributes static?](#1115-are-self-and-shortself-attributes-static)
-  - [11.16. Why does an unknown query parameter not generate an error?](#1116-why-does-an-unknown-query-parameter-not-generate-an-error)
-  - [11.17. Updating attributes with `ifvalues`](#1117-updating-attributes-with-ifvalues)
-  - [11.18. Multi-root ancestor hierarchies](#1118-multi-root-ancestor-hierarchies)
-  - [11.19. `singleversionroot` Policy Enforcement](#1119-singleversionroot-policy-enforcement)
-  - [11.20. Pruning Versions with `singleversionroot` enabled](#1120-pruning-versions-with-singleversionroot-enabled)
-  - [11.21. What's the oldest/newest Version of a Resource?](#1121-whats-the-oldestnewest-version-of-a-resource)
-  - [11.22. Can `validatecompatibility` and `validateformat` be `true` for file-servers?](#1122-can-validatecompatibility-and-validateformat-be-true-for-file-servers)
-  - [11.23. Detecting circular references between Versions](#1123-detecting-circular-references-between-versions)
-  - [11.24. Optional required fields in requests](#1124-optional-required-fields-in-requests)
-  - [11.25. Deprecation of entities in an xRegistry](#1125-deprecation-of-entities-in-an-xregistry)
-- [12. The `format` attribute in the Schema spec](#12-the-format-attribute-in-the-schema-spec)
-- [13. Problematic characters in attributes](#13-problematic-characters-in-attributes)
-- [14. Why do Resources have 3 levels of data?](#14-why-do-resources-have-3-levels-of-data)
-- [15. Why are some (conditional) read-only attributes not ignored?](#15-why-are-some-conditional-read-only-attributes-not-ignored)
-- [16. Why isn't `PUT` idempotent?](#16-why-isnt-put-idempotent)
-- [17. Defining Extensions](#17-defining-extensions)
-- [18. Validation](#18-validation)
+  - [5.7. Schema-based contract and client generation](#57-schema-based-contract-and-client-generation)
+  - [5.8. Basis for further developments](#59-basis-for-further-developments)
+- [6. Non-Goals](#7-design-goals)
+- [7. Representations](#8-representations)
+  - [7.1. File](#81-file)
+  - [7.2. Static File Server](#82-static-file-server)
+  - [7.3. API Server](#83-api-server)
+- [8. Embeddings, References, and Federation](#9-embeddings-references-and-federation)
+  - [8.1. Formats and Content/Media-Types](#91-formats-and-contentmedia-types)
+  - [8.2. Embeddings and Links](#92-embeddings-and-links)
+  - [8.3. Federation](#93-federation)
+    - [8.3.1. Composing registries in memory](#931-composing-registries-in-memory)
+    - [8.3.2. Shadowing](#932-shadowing)
+    - [8.3.3. Identifiers](#933-identifiers)
+    - [8.3.4. API Servers and Proxies](#934-api-servers-and-proxies)
+- [9. Possible Use Cases](#10-possible-use-cases)
+  - [9.1. CloudEvents](#101-cloudevents)
+  - [9.2. Business objects](#102-business-objects)
+  - [9.3. Metadata files in repositories](#103-metadata-files-in-repositories)
+- [10. Design decisions or topics of interest](#11-design-decisions-or-topics-of-interest)
+  - [10.1. Resource.ID vs Resource.Version.ID](#111-resourceid-vs-resourceversionid)
+  - [10.2. Valid Characters](#112-valid-characters)
+  - [10.3. Extensions](#113-extensions)
+  - [10.4. Group organization](#114-group-organization)
+  - [10.5. Deleting entities](#115-deleting-entities)
+  - [10.6. Detection of Referenced Resources](#116-detection-of-referenced-resources)
+  - [10.7. Shared/Referenced Resources](#117-sharedreferenced-resources)
+  - [10.8. Default Version and Maximum Versions](#118-default-version-and-maximum-versions)
+  - [10.9. Why Epoch?](#1110-why-epoch)
+  - [10.10. Naming and Case Sensitivity](#1111-naming-and-case-sensitivity)
+  - [10.11. Why are Group and Resource type names more restricted?](#1112-why-the-lower-character-limit-on-some-group-and-resource-type-names)
+  - [10.12. Choosing unique Group and Resource names](#1114-choosing-unique-group-and-resource-names)
+  - [10.13. Are `self` and `shortself` attributes static?](#1115-are-self-and-shortself-attributes-static)
+  - [10.14. Why does an unknown query parameter not generate an error?](#1116-why-does-an-unknown-query-parameter-not-generate-an-error)
+  - [10.15. Updating attributes with `ifvalues`](#1117-updating-attributes-with-ifvalues)
+  - [10.16. Multi-root ancestor hierarchies](#1118-multi-root-ancestor-hierarchies)
+  - [10.17. `singleversionroot` Policy Enforcement](#1119-singleversionroot-policy-enforcement)
+  - [10.18. Pruning Versions with `singleversionroot` enabled](#1120-pruning-versions-with-singleversionroot-enabled)
+  - [10.19. What's the oldest/newest Version of a Resource?](#1121-whats-the-oldestnewest-version-of-a-resource)
+  - [10.20. Can `validatecompatibility` and `validateformat` be `true` for file-servers?](#1122-can-validatecompatibility-and-validateformat-be-true-for-file-servers)
+  - [10.21. Detecting circular references between Versions](#1123-detecting-circular-references-between-versions)
+  - [10.22. Optional required fields in requests](#1124-optional-required-fields-in-requests)
+  - [10.23. Deprecation of entities in an xRegistry](#1125-deprecation-of-entities-in-an-xregistry)
+- [11. Problematic characters in values](#13-problematic-characters-in-values)
+- [12. Why do Resources have 3 levels of data?](#14-why-do-resources-have-3-levels-of-data)
+- [13. Why are some (conditional) read-only attributes not ignored?](#15-why-are-some-conditional-read-only-attributes-not-ignored)
+- [14. Why isn't `PUT` idempotent?](#16-why-isnt-put-idempotent)
+- [15. Validation edge cases](#18-validation-edge-cases)
+  - [15.1. Empty format capabilities](#181-empty-format-capabilities)
+  - [15.2. Constraints and `matchversions`](#182-constraints-and-matchversions)
 
 
 ## 3. A Quick Introduction to xRegistry
@@ -126,7 +120,7 @@ Think of it like a filesystem exposed over HTTP:
   or more Versions over time. If you don't care about versioning, just
   ignore Versions and treat the Resource as if it has one version.
 
-A picture is worth it:
+The entity hierarchy is:
 
 ```
 Registry
@@ -177,7 +171,9 @@ defines (e.g. `endpoints`, `messages`) - they're not literal.
 
 #### 3.2.1. Reading things
 
-A plain `GET` on any entity returns its metadata as JSON:
+A plain `GET` on a Registry, Group, metadata-only Resource, or Version returns
+its metadata as JSON. Document Resources are the exception described in
+section 3.2.3.
 
 ```
 GET /endpoints/ep1
@@ -233,10 +229,9 @@ HTTP/1.1 201 Created
 
 #### 3.2.3. Resources: metadata vs. the actual document
 
-This is the one twist compared to a plain REST API. A Resource (e.g. a
-`message` or a `schema`) can have its own domain-specific "document" (its
-actual content) in addition to its xRegistry metadata (`epoch`, `name`,
-etc).
+Document Resources differ from metadata-only Resources. A Resource such as a
+`message` or `schema` can have domain-specific content in addition to its
+xRegistry metadata (`epoch`, `name`, etc.).
 
 - `GET /endpoints/ep1/messages/msg1` → returns the Resource's **document**
   (its raw content) directly in the HTTP body.
@@ -244,9 +239,8 @@ etc).
   **metadata** as JSON instead (with the document's metadata such as
   `contenttype`, but not the document body itself).
 
-Same idea applies for `PUT`: `PUT .../msg1` with a raw body sets the
-document content; `PUT .../msg1$details` with a JSON body sets/updates just
-the metadata.
+For `PUT`, `PUT .../msg1` with a raw body sets the document content, while
+`PUT .../msg1$details` with a JSON body updates only the metadata.
 
 If a Resource type doesn't have its own separate document (just metadata),
 then `$details` isn't needed - plain requests just return the metadata.
@@ -359,20 +353,9 @@ Common `type` values you'll use most often: `string`, `boolean`, `integer`,
 attribute flags: `required`, `default`, `readonly`, `enum` (restrict to a
 fixed set of values).
 
-That's genuinely enough to get going. Everything else in the full model
-spec (constraints, versioning policies, `xid` targets, `ifvalues`, etc.) is
-there for more advanced scenarios - come back to [`model.md`](./model.md)
-when you need it.
-
-### 3.4. Where to go next
-
-- [`spec.md`](./spec.md) - the full core specification (concepts, entities,
-  capabilities).
-- [`http.md`](./http.md) - the full HTTP binding (every API, header, and
-  query parameter in detail).
-- [`model.md`](./model.md) - the full model specification (every model
-  attribute and option).
-
+This model is sufficient to create Groups and Resources. The full model
+specification covers constraints, versioning policies, `xid` targets,
+`ifvalues`, and other advanced scenarios; see [`model.md`](./model.md).
 
 ## 4. History
 
@@ -429,29 +412,23 @@ that can be used to manage and discover the full metadata graph of a system,
 given models that declare the respective resource types.
 
 Existing registry standards like OCI, Maven, or NPM can indeed be projected into
-the xRegistry resource model shape, allowing for a consistent way to manage
-metadata about these resources and, most importantly, to enable
-cross-referencing between these diverse resources. A container image contains an
-application made available as a package that exposes an endpoint that can accept
-events whose payloads have particular schemas. The xRegistry model allows all
-these resources and their relationships to be expressed in a single model, and
-it can yet leave the authoritative management of the individual resources to
-the respective registries as those can be proxied with an xRegistry API or
-import/exported into an xRegistry representation.
+the xRegistry resource model. This provides consistent metadata and
+cross-references while the source registries remain authoritative. For example,
+a container image can contain an application, published as a package, that
+exposes an endpoint for events with particular payload schemas. Section
+[8.3.4](#934-api-servers-and-proxies) explains how an xRegistry API can project
+resources managed by another registry.
 
 ### 5.2. Discovery
 
 One of the pain points of event-driven systems is the need to create and
 maintain documentation about endpoints and the events they expose, enabling
-consumers from other teams or even other organizations to have all relevant
-information required to implement their use cases successfully. By relying on a
-centralized registry, individual teams who want to discover, query, produce and
-consume events from endpoints have a single point of truth to refer to. In
-addition, xRegistry allows specifying extensions and metadata that can further
-describe events on more detailed levels. As an example, it is possible to define
-an event, and mark specific metadata that are required. Due to its rich metadata
-model, metadata can also be expressed in human language, making it easier for
-developers, data-analysts, or even business analysts to understand.
+consumers from other teams or even other organizations to find the information
+they need. A centralized registry gives teams one place to discover and query
+endpoints and the events they produce or consume. Extensions can describe these
+events in more detail, including which metadata are required. Descriptions can
+also be written for people rather than tools, so developers, data analysts, and
+business analysts can use the same registry.
 
 ### 5.3. Vendor-agnostic
 
@@ -476,67 +453,44 @@ across these offerings.
 ### 5.4. Versioning
 
 As systems evolve, the endpoints that emit events may change, as may the events
-themselves. Changes can sometimes break consumers making compatibility
-strategies essential to indicate to consumers how they may expect events or
-endpoints to evolve. xRegistry allows indicating a registry’s compatibility
-strategy which is enforced when making changes to the registry, avoiding
-mistakes. The specifications further also enables marking endpoints as
-deprecated, possibly providing an alternative endpoint, making these easier to
-discover for consumers. Finally, event schemas are also version aware, storing
-multiple versions of an event’s data schema.
+themselves. These changes can break consumers, so compatibility strategies must
+tell consumers how events and endpoints may evolve. xRegistry lets a registry
+declare a compatibility strategy and enforces that strategy when the registry
+changes. The specifications also allow endpoints to be marked as deprecated and
+can identify an alternative endpoint. Event schemas are version-aware and can
+retain multiple versions of a data schema.
 
 ### 5.5. Schema validation
 
-The registry contains granular definitions for events defining their schemas,
-which serve as a contract between publishers and consumers. This doesn’t only
-apply to the message payload, but also to the message metadata, allowing
-granular control of required fields on the metadata level. The registry does not
-only serve as a definition of the required schemas, but can also be used to
-enforce it. A registry service could use the registry to perform validation
-on-publish, rejecting any events that don’t adhere to the schema for that
-context, avoiding the problem of poison messages.
+The registry contains granular event definitions and schemas that serve as a
+contract between publishers and consumers. This applies to both the message
+payload and its metadata. Implementations can also use these definitions for
+enforcement. For example, an event service could validate events when they are
+published and reject events that do not conform to the schema for that context.
 
 ### 5.6. Payload reduction
 
 Schema information enables real-time analysis of incoming data based on its
-contextual meaning, which is why applications often use serialization mechanisms
-which include schema information (such as JSON) in payloads. Having a
-centralized registry, enables applications to rely on lighter weight
-serialization formats, significantly reducing bandwidth, while still allowing
-accurate real-time analysis of incoming data using the registry.
+context. Applications therefore often use serialization formats such as JSON
+that carry structural information in each payload. With that information
+available from a centralized registry, applications can use lighter-weight
+serialization formats and reduce bandwidth without giving up contextual
+analysis.
 
-### 5.7. Schema-based data contract generation
+### 5.7. Schema-based contract and client generation
 
-xRegistry provides a specification to manage metadata in files which can be
-stored next to the corresponding source code. This enables storing versions of
-the model with their corresponding code in source control. This greatly
-simplifies accurate recreation of the state of the system or environment, as all
-schema-information is stored side-by-side with the code, avoiding issues in
-reconciling the version of the code with the version of the schema.
-
-Alternatively, metadata can also be managed in a Registry service, assuming it
-adheres to the xRegistry API specification. The Registry service acts as a
-central component that can be queried by any service that needs to interact with
-the metadata.
-
-This enables teams to use code generation to generate relevant data contracts
-when interacting with endpoints. This removes the need for shared code packages
-and avoids any bugs on the data contract level.
-
-### 5.8. Producer and consumer generation
-
-Further, building upon the idea of schema-based data contract generation, even
-client-code can be generated. When the schema is defined in a vendor-agnostic,
-well-defined format, tooling can be built upon this foundation to generate
-broker-specific consumers that can consume events from endpoints defined in the
-registry. This is not only limited to event consumers, but may also include
-generation of event store inserts. This can further speed up and streamline the
-development of both producers and consumers, significantly reducing development
-and testing time and minimizing the risk of introducing bugs at this level.
+The [file and API representations](#8-representations) can both supply versioned
+model input to code generators. Teams can generate the data contracts needed to
+interact with endpoints instead of maintaining shared packages for those
+contracts by hand. A schema in a
+vendor-agnostic, well-defined format can drive tools that generate
+broker-specific consumers or event-store inserts. Generated producers and
+consumers reduce the amount of contract code that teams must write and test.
 Clemens Vasters built a proof-of-concept that shows this approach in
 the [Avrotize VS Code Extension](https://github.com/clemensv/avrotize).
 
-### 5.9. Basis for further developments
+<a id="59-basis-for-further-developments"></a>
+### 5.8. Basis for further developments
 
 CloudEvents serve as a mechanism to aid in the delivery of events from a
 producer to a consumer, which is applicable independently of the protocol (MQTT,
@@ -545,61 +499,14 @@ further builds upon this by providing a specification to define resources that
 correlate specific events to endpoints, providing versioning information and
 more extensive metadata.
 
-The xRegistry specification serves as a strong foundation to further build upon
-in subsequent versions and/or outside of xRegistry, by correlating events and
-endpoints system-wide. This will eventually lead to the definition of event
-flows, making these discoverable and predictable, as opposed to relying on
-human-produced documentation or observability on emerging behavior to understand
-complex flows.
+Correlating events and endpoints across a system also provides the information
+needed to define event flows. Those flows can then be discovered directly
+instead of reconstructed from manually maintained documentation or observed
+runtime behavior.
 
-## 6. Motivation
-
-While CloudEvents are harmonizing different event structures across event
-providers and increase interoperability between different brokers and their
-protocols, they do not address:
-
-- **Discovery:** Where to produce/consume events? What endpoints exist?
-- **Validation:** How to validate event structures?
-- **Versioning:** How to version metadata describing events – and see which
-  versions exist?
-- **Serialization:** How are events serialized? How do their envelope (if any)
-  and formats (XML / JSON Schema) look like?
-- **Extension Discovery:** How to identify which events using which specific
-  extensions?
-
-Schema registries can provide an answer to these questions, but just like event
-brokers, there are multiple registries, such as the Confluent Schema Registry,
-the Azure Event Hubs Registry or the Apicurio Registry. When an event travels
-through multiple brokers, its schema has to be introduced to the broker's
-registry and clients later have to deal with the implementation differences
-between different registries, for example when trying to validate an event
-structure. This hinders the interoperability of event brokers CloudEvents had in
-mind. xRegistry therefore comes in with a similar motivation to CloudEvents:
-Harmonize another piece of technology in the messaging / eventing ecosystem to
-increase interoperability and decouple event handling from broker products and
-protocols.
-
-Even though xRegistry was built with eventing in mind, the concept of this
-registry specification is far more powerful and can be used for the exchange for
-any type of message. Take a look at the [Possible Use
-Cases](#10-possible-use-cases) for examples outside the eventing world.
-
-## 7. Design Goals
-
-- **Interoperability:** Enable effortless discovery, validation and versioning
-  of resources.
-- **Standardization:** Establish a high level structure for managing resource
-  metadata behind which vendors can unite.
-- **Extensibility:** Accommodate future innovations by allowing for the
-  definition of custom attributes and extensions tailored to specific needs
-  – not only for the happy path, but errors as well.
-- **Flexibility:** Support various resource types, protocols (MQTT, AMQP, Kafka,
-  NATS, HTTP..) and schema languages (JSON Schema, Avro Schema, Protobuf..)
-  – not just CloudEvents.
-- **Simplicity:** Allow simple use cases that do not need versioning of
-  resources or a full-blown schema registry on the server.
-
-### 7.1. Non-Goals
+<a id="7-design-goals"></a>
+<a id="71-non-goals"></a>
+## 6. Non-Goals
 
 - **Authentication and Authorization:** Rely on established security standards
   depending on the registry representation.
@@ -607,36 +514,31 @@ Cases](#10-possible-use-cases) for examples outside the eventing world.
   single event channel before standardizing the relationships between event
   channels.
 
-## 8. Representations
+<a id="8-representations"></a>
+## 7. Representations
 
-An xRegistry can be represented in a few different ways: a JSON file, a static
-file server and an API server - with some further nuances. Resources
+An xRegistry can be represented as a JSON file, a static file server, or an API
+server. Resources
 (user-supplied data) will most often be embedded in the registry, but the
 resource metadata might also point to an external location where such data
 exists; also see the discussion about [embeddings and
 references](#9-embeddings-references-and-federation).
 
-When building up this spec, the API server had the highest priority, followed
-by the file representation and the static file server as an option to
-transition between the first two. To enable this transition, one of the
-design goals is the symmetry between all representations.
+The representations are symmetric so that data can move between them. Choose a
+representation according to the required write path and deployment model.
 
-Whenever registries get large or need to be shared with many people or systems,
-you will realistically want to use the API server or CLI to create the registry
-and then use its export function to generate files for the file or static file
-server representation.
-
-### 8.1. File
+<a id="81-file"></a>
+### 7.1. File
 
 The registry is represented as a single JSON file.
 
 The primary use case for this representation is a registry whose purpose is to
 be used where file-based access is preferred over network-based access.
 
-This could be a project on your local machine or a public git repository, where
-the registry basically becomes a declaration manifest of the application(s). If
-you are new to xRegistry and are just trying to get the idea of the project,
-this is a great point to start.
+This could be a project on your local machine or a public Git repository, where
+the registry becomes a declaration manifest for the applications. Keeping the
+file beside source code also keeps each revision of the registry metadata with
+the corresponding code revision.
 
 It is anticipated that application modules that need to share resources with
 others, like the shape of raised events and associated schemas, will have one or
@@ -645,25 +547,22 @@ these files can later be merged into another xRegistry when the module is
 deployed, so that other participants in the system can understand the
 raised events.
 
-Writing up a registry by hand can be a great way of getting the idea, but it can
-get tedious quickly. This is when you want to use the API server.
+Writing a registry by hand is useful for learning or small projects. Larger or
+shared registries will usually need tooling or an API server.
 
-### 8.2. Static File Server
+<a id="82-static-file-server"></a>
+### 7.2. Static File Server
 
 The registry is represented by multiple JSON files, where each one represents a
 single entity within the registry, served via a static file server (e.g. S3 or
 similar) that follows the folder and file structure of the API server.
 
-The primary use case for this representation is the transition between File and
-API Server representation. To allow for sharing of individual entities of the
-registry rather than the entire registry as a single JSON document, splitting up
-your single JSON file into multiple ones and structuring them in different
-folders can keep things easy.
+This representation allows clients to retrieve individual entities instead of
+the entire registry as one JSON document. It can also serve data exported from
+an API server.
 
-Another benefit of this representation is that you only have to rent storage,
-but no compute units. You could spin up an xRegistry using GitHub Pages, just
-like a Helm registry. You save money and don't have to worry about maintaining a
-compute unit.
+It requires storage but no continuously running compute. For example, an
+xRegistry can be hosted on GitHub Pages, much like a Helm registry.
 
 Since the static file server is read-only, adding resources to the registry is
 only possible by rebuilding the server and file structure, e.g. via pipelines.
@@ -672,26 +571,22 @@ filtering, you might consider using the API server instead. Adding server logic
 to the static file server to make up for the features of the API server is
 considered an anti pattern.
 
-### 8.3. API Server
+<a id="83-api-server"></a>
+### 7.3. API Server
 
-The API server is the most sophisticated representation of xRegistry. When you
-have multiple teams that are using the same registry with distributed ownership
-of the managed resources, therefore differentiated authorization – then the API
-server is your way to go. This could apply to large organizations, enterprises
-etc.
+An API server suits registries shared by multiple teams, especially when
+resources have distributed ownership and require different authorization
+policies.
 
-The primary use case of the API server is sharing resources with multiple
-end-users and allowing direct write access to the server. You won't have to
-generate files and split them up in directories like in the static file server
-and can make use of the server-side logic like searching, filtering and export
-options.
+It allows direct writes and can provide server-side searching, filtering, and
+export without requiring users to generate a static directory structure.
 
 Running the API server requires you to set up a host and a persistence
-layer and maintain both. In exchange you get all the benefits listed above.
-While starting with the API server might be a little more work upfront, it saves
-you from migrating representations as your registry grows.
+layer and maintain both. Start with this representation when direct writes,
+authorization, or server-side queries are already required.
 
-## 9. Embeddings, References, and Federation
+<a id="9-embeddings-references-and-federation"></a>
+## 8. Embeddings, References, and Federation
 
 The purpose of a registry is to act as a catalog more than as a container.
 
@@ -702,11 +597,12 @@ quite obviously not exist inside of it.
 
 However, when a model declares a resource to be of the
 ["document"](spec.md#document-resources-vs-metadata-only-resources) type,
-xRegistry can indeed embed content, like schema documents. The shape of those
-documents is not declared by the model, but may be constrained by convention
-(and implementation choice) based on the [`format`](spec.md#format-attribute) attribute.
+xRegistry can embed content such as schema documents. The following sections
+separate document format metadata from the choice to embed, encode, or link the
+document.
 
-### 9.1. Formats and Content/Media-Types
+<a id="91-formats-and-contentmedia-types"></a>
+### 8.1. Formats and Content/Media-Types
 
 `format` and the supported values are a convention chosen for this
 specification because the IANA "media-types" are not consistently available for
@@ -716,20 +612,26 @@ each document, that provides the corresponding media-type. An example for this
 is that Apache Avro schema has no official media type, so that the content type
 might be "application/json", but the `format` is "Avro/1.12".
 
-Some xRegistry implementations, including the reference server implementation,
-might choose to provide validation capabilities for well-known formats like
-Apache Avro schema, and even version-to-version compatibility checks. These
-validation capabilities per-se are not defined in the specification, but the
-specification allows the server to provide indicators about whether they are
-available and whether they have been applied. Metadata declared in the models
-allows the server to validate embedded data directly.
+Some xRegistry implementations, including the reference server, validate
+well-known formats such as Apache Avro schema and check compatibility between
+versions. The specification does not define those validation implementations.
+It defines indicators through which a server reports whether validation is
+available and has been applied. Model metadata gives the server the information
+needed to validate embedded data.
 
 A registry server can only enforce validation constraints on embedded documents
 that are under its own control. If a document is external, meaning that the
 resource entry does not embed it but links to it, the document might change at
 the external location without the registry knowing.
 
-### 9.2. Embeddings and Links
+<a id="12-the-format-attribute-in-the-schema-spec"></a>
+The Schema specification requires `format` when `compatibility` is anything
+other than `none`, even when an implementation supports only one format. This
+keeps the format explicit in exports so that another server, including one that
+supports several formats, can import them without ambiguity.
+
+<a id="92-embeddings-and-links"></a>
+### 8.2. Embeddings and Links
 
 When the resource is declared to be a document, it can be stored inside the
 registry either as a directly [embedded object](spec.md#resource-attribute), a
@@ -753,23 +655,15 @@ character encoding as the hosting JSON document. Any other document will be
 base64 encoded and stored in `schemabase64`. The `schemacontenttype` is meant
 to hold media-type and encoding of that data.
 
-You can also refer to the target document externally using `schemaurl` and
-point to a location from where that document can be directly obtained wither
-using an HTTP GET or resolving a file system file.
+You can also refer to the target document through a `<RESOURCE>url` attribute.
+The URL can identify an HTTP resource or a file-system location, which allows
+documents in an existing registry or public repository to remain in place. The
+`format` and `contenttype` information still needs to exist in xRegistry so
+that clients can interpret the document before resolving it. The registry does
+not resolve the URL or load the content; clients do that.
 
-External links are very handy if you already have an existing registry of some
-kind, possibly just files in a public repo, and want to catalog those with
-xRegistry. Using the `<RESOURCE>url` patterns, all your documents can remain
-in their place. The `format` and `contenttype` information still needs to
-exist in xRegistry so that clients can understand this information before
-trying to resolve the document. When a resource is registered with a URL, the
-registry will not resolve it and load the content; that is left to clients.
-
-External links also make it possible to overlay xRegistry on top of a
-completely different registry model, proxy the metadata through an xRegistry
-API, but provide passthrough access to the other registry's content.
-
-### 9.3. Federation
+<a id="93-federation"></a>
+### 8.3. Federation
 
 xRegistry does not have a synchronization API, by intent. Since xRegistry is
 both a document format model and an API, the integration of multiple registries
@@ -777,15 +671,16 @@ both a document format model and an API, the integration of multiple registries
 cross-referencing and "shadowing" across the [representations](#8-representations)
 described earlier.
 
-#### 9.3.1. Composing registries in memory
+<a id="931-composing-registries-in-memory"></a>
+#### 8.3.1. Composing registries in memory
 
 A registry document, whether a single [file](#81-file) or the root of a
 [static file server](#82-static-file-server) layout, is meant to be loaded into
-an application as a local, in-memory registry. While a document technically
-needs to embed a model to be valid, servers often choose to allow that the
-models they know about are implicitly available, so that a registry document
-can just contain the resources and their metadata, without the model. There
-are several examples of such documents in the
+an application as a local, in-memory registry. A registry document used on its
+own must embed a model to be valid. A server may nevertheless accept source
+input that contains only resources and metadata, supply a model it already
+knows, and construct a valid registry from both. There are several examples of
+such source documents in the
 [cloudevents/samples](../cloudevents/samples/README.md) folder.
 
 When the registry is split across multiple files in a folder structure, the
@@ -795,20 +690,19 @@ root document with only those branches that are relevant to the application. The
 same applies when the root sits behind an [API server](#83-api-server) or proxy:
 the client fetches and caches just the branches it needs.
 
-#### 9.3.2. Shadowing
+<a id="932-shadowing"></a>
+#### 8.3.2. Shadowing
 
 Federation in xRegistry is intended to be built on *shadowing*: an application's
 view is a layered combination of registries, where a local registry can override
 or extend entries from an underlying one without modifying it. We say "intended"
-because the specification does not define any particular protocol for this, but
-the design of the registry model and API allows for it to be implemented in a
-very natural way.
+because the specification does not define a protocol for this composition.
 
-Layering registries and selective shadowing allows keeping a local copy of
-selected resources that can be changed freely, while still referring to the
-original registry for everything that hasn't been touched - with no
-synchronization protocol and no risk of conflicts between different users or
-applications.
+Layering registries and selective shadowing lets an application keep locally
+modified copies of selected resources while continuing to read untouched
+resources from the underlying registry. Layer precedence resolves duplicate
+entries, but incompatible models or constraints can still make the composed
+registry invalid.
 
 When dealing with files, applications load files in order and merge the
 content, with later files taking precedence over earlier ones.
@@ -826,7 +720,8 @@ composition and shadowing is the best approach to federation, but the project
 will need to gain more experience with it in practice before it can be
 formalized.
 
-#### 9.3.3. Identifiers
+<a id="933-identifiers"></a>
+#### 8.3.3. Identifiers
 
 For shadowing and cross-referencing to work, identifiers need to be stable
 across registries. Group identifiers should be treated as globally unique, so
@@ -835,17 +730,15 @@ identifiers are only unique within a group, so a cross-registry reference should
 always use the combination of group identifier (group name and id) and resource
 identifier (resource name and id).
 
-The authority portion of a URL into a registry is only an endpoint identifier
-for the hosting registry, not a unique identifier for the resource itself. The
-same resource may be available in multiple registries, and applications can
-refer to it using the same *relative URI* regardless of which registry hosts it.
-This matters in practice: an application in a private network might not be able
-to reach a registry hosted in a public cloud, so the same content may need to be
-served from a local registry on a private DNS name. Treating the authority as an
-endpoint identifier rather than a resource identifier is what makes that
-possible.
+The authority portion of a URL into a registry identifies the hosting endpoint,
+not the resource itself. The same resource may be available in multiple
+registries, and applications can refer to it using the same *relative URI*
+regardless of which registry hosts it. For example, an application in a private
+network may resolve the URI against a local registry when it cannot reach the
+public registry.
 
-#### 9.3.4. API Servers and Proxies
+<a id="934-api-servers-and-proxies"></a>
+#### 8.3.4. API Servers and Proxies
 
 An API server can also act as a proxy that presents multiple underlying
 registries - including non-xRegistry ones - through a single xRegistry
@@ -858,9 +751,11 @@ Shadowing applies here too: any API client can shadow the API server with a
 local registry to add or modify entries without affecting the underlying
 registry, and a proxying API server can do the same on behalf of its clients.
 
-## 10. Possible Use Cases
+<a id="10-possible-use-cases"></a>
+## 9. Possible Use Cases
 
-### 10.1. CloudEvents
+<a id="101-cloudevents"></a>
+### 9.1. CloudEvents
 
 Since xRegistry emerged from the CloudEvents project and initially was called
 "CloudEvents Discovery" the obvious use case is to manage all the CloudEvents of
@@ -871,24 +766,26 @@ specific use-case even though the original spec marks them as optional. In
 addition, the `dataschema` attribute of a CloudEvent can then point to a
 xRegistry schema document making this two projects that work hand in hand.
 
-### 10.2. Business objects
+<a id="102-business-objects"></a>
+### 9.2. Business objects
 
 When defining the schemas of business objects in an enterprise, xRegistry can be
 the schema store for these definitions. One can then reference them in a data
 catalogue as well as in OpenAPI and AsyncAPI documents without repeating the
 schemas for the actual business objects.
 
-### 10.3. Metadata files in repositories
+<a id="103-metadata-files-in-repositories"></a>
+### 9.3. Metadata files in repositories
 
-Open source repositories could provide an xRegistry represented as a simple JSON
-file on the top level of the folder structure and list all metadata files this
-repository contains like a `package.json`. This would allow machine-readable
-access to project dependencies and configurations as well as consistent
-management of metadata across different tools and environments.
+The [file representation](#81-file) supports a repository-level manifest similar
+to `package.json`. Such a manifest can list the repository's metadata files and
+provide machine-readable access to project dependencies and configuration.
 
-## 11. Design decisions or topics of interest
+<a id="11-design-decisions-or-topics-of-interest"></a>
+## 10. Design decisions or topics of interest
 
-### 11.1. Resource.ID vs Resource.Version.ID
+<a id="111-resourceid-vs-resourceversionid"></a>
+### 10.1. Resource.ID vs Resource.Version.ID
 
 Resources, like all xRegistry entities, have unique `id` values. Resource
 `id`s are often user-friendly values that often have an implied semantic
@@ -907,77 +804,43 @@ xRegistry model. As a result, implementations might want to avoid using `id`
 values that could appear on a Resource and one of its Versions simply to avoid
 potential confusion for their end-users.
 
-### 11.2. Valid Characters
+<a id="112-valid-characters"></a>
+### 10.2. Valid Characters
 
-The xRegistry specification restricts the allowable characters for attribute
-and map key names. While it can be considered overly restrictive, for example
-uppercase characters are not permitted, this was done because considerations
-had to be made to take into account where these names might appear.
+Attribute names appear in JSON objects, HTTP headers, URLs, and generated code.
+The specification therefore uses a restricted character set that works across
+those contexts. Section [10.10](#1111-naming-and-case-sensitivity) explains the
+casing rules. Section 10.11 explains the additional restrictions on Group and
+Resource type names.
 
-Some of the challenges:
+The specification permits underscores in attribute names, but some proxies,
+including nginx with its default configuration, drop HTTP headers containing
+underscores. Implementations that expose attributes as headers need to account
+for that behavior.
 
-- attribute and key name might appear as HTTP headers, which are
-  case-insensitive. On the surface this would mean that simply not allowing
-  more than one name of different cases would suffice. However, in the case
-  of the name being part of a open-ended extension (e.g. allowable due to a
-  `*` defined attribute), the server has no way of knowing its proper case.
-  And when they're serialized in the HTTP body, case then matters.
-- some network proxying software limit the allowable characters that can
-  appear in HTTP header names by default. For example, nginx will drop all
-  HTTP headers that include underscore (`_`) characters. While there are most
-  likely configuration flags to disable this behavior, it might not always
-  be possible (or easy) for xRegistry implementations to modify those
-  networking components.
-- often attribute names, or object property names, are mapped into code
-  variable or properties within code structures. While many programming
-  languages allow for a mapping from those names to their serialization
-  names, often these mapping can introduce pain - either because they require
-  additional work/configuration or simply due to errors being introduced
-  by not using the language specific default mapping.
+Map keys allow more characters than attribute names because they are normally
+stored as strings rather than mapped to named fields in code structures.
 
-So rather than raising the bar for installation, maintenance, and debugging
-(detecting the possible issues mentioned above), it was deemed better to
-simply avoid the problem (and hopefully increase interoperability) by just
-limiting the allowable characters.
+<a id="113-extensions"></a>
+### 10.3. Extensions
 
-Note though, map key names allow more characters than well-define object
-attribute names because map key names are not usually mapped to well-defined
-variable or structure property names - they're usually just stored as
-"strings" a map data structure.
+Extensions SHOULD be defined in the model. A model can also define a `*`
+extension to allow attributes supplied at runtime. Extension names follow the
+[valid character](#112-valid-characters) and
+[casing](#1111-naming-and-case-sensitivity) rules for all attributes.
 
-### 11.3. Extensions
+Required aspects apply at each level of a nested extension. In particular,
+`clientrequired=true` also requires `serverrequired=true`; otherwise the model
+is invalid.
 
-- it's RECOMMENDED that all extensions be defined in advance as part of the
-  model. However, the spec does support an extension of "\*" to allow for
-  unknown/runtime-provided extensions. Since extensions can appear in case-
-  insensitive situations (e.g. http header) we can't know the case of them
-  when storing in the backend. As a result, all attributes and key names MUST
-  be lowercase.
+<a id="119-potential-extensions"></a>
+Implementations that track the identity responsible for a change might define
+`createdby` and `modifiedby` extensions alongside `createdat` and `modifiedat`.
+The core specification does not define them because it does not define
+authentication or identity tracking.
 
-- "default" Resource is just a pointer, NOT a set of default values
-- we allow for implicit creation of a resource's tree rather than requiring
-  multiple create operations - just for convenience
-- if/when we support serializing in non-json formats, we'll need to define
-  the serialization rules. E.g. when attributes appear as xml attributes vs
-  nested elements
-- when hasdocument=false, we might need to talk about when ?meta appears on the
-  various URLs (self, defaultversionurl, location,...). Right now its presence
-  will match what was used in the request (either explicitly or implicitly).
-  So GET resource?meta or GET group?inline both ask for metadata
-- xRegistry- headers: first "-" separates xRegistry from attribute name,
-  next "." separates attribute name from key, any subsequent "." is part
-  of the key name. E.g. xRegistry-labels.abc.def:xxx => labels["abc.def"]=xxx
-- impact of "\*required" flags at multiple levels
-- why we don't use underscore in our property names, tho legal to do so
-  - not all http proxies (e.g. nginx) pass them along by default
-  - so, while spec allows underscores, use at your own risk
-- discuss any potential semantic gotchas when one attribute is required
-  but a nested attribute is optional, or also required (and visa-versa)
-  - reminder: clientrequired=true means serverrequired=true as well, else error
-- how MIGHT someone implement multi-tenancy with xRegistry
-  - and layers of xRegistries to get multi-level grouping ??
-
-### 11.4. Group organization
+<a id="114-group-organization"></a>
+### 10.4. Group organization
 
 Groups are intentionally a single organizational dimension above Resources:
 the model is always Registry → Group → Resource → Version, and Groups
@@ -987,25 +850,21 @@ model, the URL space, traversal and filter semantics, access-control
 reasoning, and tooling, without adding expressive power that cannot be
 achieved by other means.
 
-Where a hierarchical organization is useful, xRegistry instead relies on
+Where hierarchical organization is useful, xRegistry instead relies on
 dot-notation in Group identifiers. Because Group IDs may contain dots, an
 identifier like `Contoso.ERP.Orders` naturally expresses a logical
 hierarchy (`Contoso` → `ERP` → `Orders`) while keeping the underlying
-collection flat. This gives implementers and users the readability and
-grouping behavior of a hierarchy — including prefix-based filtering — without
-the structural complexity of nested containers.
+collection flat. Prefix filters can select related identifiers without adding
+nested containers to the model.
 
-The second, orthogonal organizational tool is `labels`. Labels are
-free-form name/value pairs that can be attached to Registries, Groups,
-Resources, Meta entities, and Versions, and they allow entities to be
-classified along as many independent axes as needed (for example
-`stage=dev`, `team=payments`, `tier=gold`). Server implementations may,
-and are encouraged to, support filtering and lookup by labels (see the
-filter examples in the core spec), which makes labels a powerful
-complement to the single Group dimension for cross-cutting discovery
-scenarios that a strict hierarchy could not express.
+Labels provide independent classification dimensions. They are free-form
+name/value pairs attached to Registries, Groups, Resources, Meta entities, and
+Versions, for example `stage=dev`, `team=payments`, or `tier=gold`. Server
+implementations may support filtering and lookup by labels; see the filter
+examples in the core specification.
 
-### 11.5. Deleting entities
+<a id="115-deleting-entities"></a>
+### 10.5. Deleting entities
 
 The "delete" operation typically has two variants:
 
@@ -1013,8 +872,7 @@ The "delete" operation typically has two variants:
 - `DELETE .../<COLLECTION>[?setdefaultversionid=VID]`
 
 where the first will delete a single entity, and the second can be used to
-delete multiple entities. In the second case there are a couple of design
-points worth noting:
+delete multiple entities. For collection deletion:
 
 - if the HTTP body is empty, then the entire collection will be deleted.
   If the collection is `versions`, then the owning Resource must also be
@@ -1034,7 +892,8 @@ points worth noting:
   Version isn't being deleted. Note that a `404` in the `DELETE .../<ID>` case
   is an error and no changes to the "default" Version will occur.
 
-### 11.6. Detection of Referenced Resources
+<a id="116-detection-of-referenced-resources"></a>
+### 10.6. Detection of Referenced Resources
 
 The xRegistry specification allows for Resources to appear in multiple Groups
 via use of the `xref` feature. This could lead to situations where a user
@@ -1049,11 +908,11 @@ some kind of "xref counter" extension on the target Resource. The specification
 might consider adding some feature to address this in the future, but as of now
 it is left as an implementation choice.
 
-### 11.7. Shared/Referenced Resources
+<a id="117-sharedreferenced-resources"></a>
+### 10.7. Shared/Referenced Resources
 
-As discussed above, Resource may appear in multiple Groups via use of the
-`xref` feature. Users of the Registry may wish to consider how best to manage
-these "shared" Resources within their associated Groups. For example, if a
+Beyond detecting dangling references, users need to decide how shared Resources
+are owned. For example, if a
 Resource might be removed from any of the Groups it is a member of, then it
 might be best to create a dedicated "shared resources" type of Group so that
 it can have a lifecycle that is independent of its association of any other
@@ -1065,7 +924,8 @@ Additionally, how the implementation of the xRegistry manages
 access-control-rights of Resources (often via Groups) might influence the
 initial placement into a Group of a new Resource.
 
-### 11.8. Default Version and Maximum Versions
+<a id="118-default-version-and-maximum-versions"></a>
+### 10.8. Default Version and Maximum Versions
 
 Each Resource type can specify the maximum number of Versions that the
 server must save. Once that limit is reached then it must delete Versions
@@ -1100,20 +960,8 @@ Let's walk through a complex example:
 - The result is: v8 regardless of whether v8 was created with isdefault=true or
   not
 
-### 11.9. Potential Extensions
-
-- `createdby`, `modifiedby`<br>
-  These are related to the `createdat` and `modifiedat` attributes in that
-  they would normally be updated at the same time as their corresponding
-  `*at` attribute, and are use to track the identity of the person or
-  component that performed the related operation.
-
-  The xRegistry specification does not define these since it does not define
-  any authentication mechanisms, or even manage tracking of these identities.
-  However, if an implementation does track this information, these attributes
-  might be of interest.
-
-### 11.10. Why Epoch?
+<a id="1110-why-epoch"></a>
+### 10.9. Why Epoch?
 
 Why such an unusual name? As the specification describes, `epoch` is used as a
 way to help detect when an entity has been modified. It is very similar to
@@ -1132,7 +980,8 @@ they know what it means due to some other usage in this technology space
 seemed unlikely. In fact, use of this word might pique people's curiosity
 and cause them to look it up in the specification to find out more about it.
 
-### 11.11. Naming and Case Sensitivity
+<a id="1111-naming-and-case-sensitivity"></a>
+### 10.10. Naming and Case Sensitivity
 
 The following explains some of the reasoning behind the casing and case
 sensitivity rules in the specification.
@@ -1194,10 +1043,11 @@ sensitivity rules in the specification.
   entity, it is possible that one of those users would end up seeing an
   unexpected casing and could be confused or believe there was an error.
 
-  All of these concerns are avoided by requiring IDs to be stored and compared
-  in case insensitively.
+  The specification therefore requires case-sensitive lookup while prohibiting
+  IDs that differ only by case within the same parent.
 
-### 11.12. Why the lower character limit on some Group and Resource type names?
+<a id="1112-why-the-lower-character-limit-on-some-group-and-resource-type-names"></a>
+### 10.11. Why are Group and Resource type names more restricted?
 
 Attribute names and key names are limited to 63 characters, so why are some
 Group and Resource names limited to less? Because when they appear as part of
@@ -1207,13 +1057,13 @@ we need to take into account the length of those phrases. As a result, both
 Group and Resource type names (both singular and plural) are limited to
 57 characters.
 
-### 11.13. Why must Group type and Resource type names be valid attribute names?
-
+<a id="1113-why-must-group-type-and-resource-type-names-be-valid-attribute-names"></a>
 Since Group type and Resource type names will appear as attribute names (e.g.
 `<GROUPS>count` and `<RESOURCE>url`), the character set (and length) of their
 names need to be restricted in the same way as a attribute names.
 
-### 11.14. Choosing unique Group and Resource names
+<a id="1114-choosing-unique-group-and-resource-names"></a>
+### 10.12. Choosing unique Group and Resource names
 
 Aside from choosing names that give some descriptive meaning to the purpose
 of these entities, care should be taken when choosing names for entities that
@@ -1223,7 +1073,12 @@ name collisions with other similarly named entities. This might be useful
 for Resource names too (if they might co-exist under shared Groups), but
 normally ensuring uniqueness at the Group level is sufficient.
 
-### 11.15. Are `self` and `shortself` attributes static?
+<a id="17-defining-extensions"></a>
+The same collision guidance applies to model extensions and new APIs; their
+names should remain clear of future xRegistry additions.
+
+<a id="1115-are-self-and-shortself-attributes-static"></a>
+### 10.13. Are `self` and `shortself` attributes static?
 
 In general any URL reference to an entity in the Registry should remain
 static for the lifetime of the entity, otherwise anything persisting that
@@ -1240,7 +1095,8 @@ values need to change.
 Obviously, situations like these should be rare but the specification needs
 to allow for them.
 
-### 11.16. Why does an unknown query parameter not generate an error?
+<a id="1116-why-does-an-unknown-query-parameter-not-generate-an-error"></a>
+### 10.14. Why does an unknown query parameter not generate an error?
 
 People have identified cases where query parameters might be added to request
 URLs without the client (or developer) having control to prevent it. It might
@@ -1248,12 +1104,12 @@ be client-side tooling or intermediaries (e.g. proxies) that might modify
 the URL - for example to add tracking or end-to-end tracing information.
 
 To avoid these clients not being able to interact with an xRegistry deployment,
-the authors chose to have the server ignore unknown query parameters. It is
-worth noting that the specification says they SHOULD be ignored, not that they
-MUST be ignored. So there is room for an implementation to be very picky if
-needed, but at the risk of potentially causing interoperability problems.
+the authors chose to have the server ignore unknown query parameters. The
+specification says they SHOULD be ignored, not that they MUST be ignored. An
+implementation can reject them, but doing so risks interoperability problems.
 
-### 11.17. Updating attributes with `ifvalues`
+<a id="1117-updating-attributes-with-ifvalues"></a>
+### 10.15. Updating attributes with `ifvalues`
 
 The `ifvalues` feature might be a new concept for some readers, so a point
 of clarification might be useful. If an attribute is defined with an `ifvalues`
@@ -1270,18 +1126,15 @@ in the entity in order to be model compliant.
 Likewise, implementations of the server must validate the entire entity
 against the new model, not just a subset of the entity's attributes.
 
-### 11.18. Multi-root ancestor hierarchies
+<a id="1118-multi-root-ancestor-hierarchies"></a>
+### 10.16. Multi-root ancestor hierarchies
 
-The [`ancestorid` attribute](./spec.md#ancestorid-attribute) is used to build a
-hierarchy of Versions to facilitate compatibility checking when the
-[`compatibility` attribute](./spec.md#compatibility-attribute) is set. There
-are cases in which it's desirable to create multiple roots. In some
-cases it may even be unavoidable, for example when the `maxversions`
-attribute (see `groups.resources.maxversions` under
-[Resource Model](./model.md#registry-model)) is set to a value that forces
-pruning of the Version tree. In such cases, when deleting the oldest Version,
-this could result in a new root being created when there are multiple
-decedents of the deleted Version.
+The [`ancestorid` attribute](./spec.md#ancestorid-attribute) builds a Version
+hierarchy for compatibility checking when the
+[`compatibility` attribute](./spec.md#compatibility-attribute) is set. Some
+use cases need multiple roots. Pruning can also create additional roots;
+section [10.18](#1120-pruning-versions-with-singleversionroot-enabled)
+describes the case in which `singleversionroot` prevents that operation.
 
 To signal that a Version represents a root of a hierarchy, the `ancestorid`
 attribute has its value set to the Version's `versionid` attribute. This
@@ -1289,7 +1142,8 @@ makes the ancestor explicit, and the possible ambiguity of using another
 value such as null which, based on the scenario, could mean "no ancestor" or
 "default to the newest".
 
-### 11.19. `singleversionroot` Policy Enforcement
+<a id="1119-singleversionroot-policy-enforcement"></a>
+### 10.17. `singleversionroot` Policy Enforcement
 
 Related to the previous discussions concerning the `ancestorid` attribute,
 the [Resource Model](./model.md#registry-model) `singleversionroot` attribute
@@ -1322,7 +1176,8 @@ These examples are not meant to be complete. The flexibility of the
 specification allows for model authors to choose the most appropriate value
 for their needs.
 
-### 11.20. Pruning Versions with `singleversionroot` enabled
+<a id="1120-pruning-versions-with-singleversionroot-enabled"></a>
+### 10.18. Pruning Versions with `singleversionroot` enabled
 
 There are cases in which the server will need to prune Versions. For
 example, this can happen when attempting to create a new Version that would
@@ -1347,7 +1202,8 @@ creation of a new Version. To resolve this, the user will have to manually
 delete v2 or v3 to allow the server to prune the oldest Version (v1) before
 creating a new Version.
 
-### 11.21. What's the oldest/newest Version of a Resource?
+<a id="1121-whats-the-oldestnewest-version-of-a-resource"></a>
+### 10.19. What's the oldest/newest Version of a Resource?
 
 The oldest Version of a Resource isn't necessarily the one with the oldest
 `createdat` timestamp, because the `ancestorid` attribute takes precedence
@@ -1365,25 +1221,20 @@ Versions exist with the same `createdat` timestamp, those Versions are
 sorted in an descending alphabetical order, and the first is the newest
 Version.
 
-### 11.22. Can `validatecompatibility` and `validateformat` be `true` for file-servers?
+<a id="1122-can-validatecompatibility-and-validateformat-be-true-for-file-servers"></a>
+### 10.20. Can `validatecompatibility` and `validateformat` be `true` for file-servers?
 
-In general, the `validatecompatibility` and `validateformat` attributes are
-meant to enable server-side policy validation. However, they also convey to
-clients that the data within the Registry adheres to the specified
-`compatibility` and `format` values. In cases where the xRegistry is being
-hosted by a file-server, where such validation code does not exist, but the
-server would still like to indicate to its clients that the data has in fact
-been validated, it is appropriate for the xRegistry metadata to reflect this
-situation by exposing these attributes with a value of `true`.
+`validatecompatibility` and `validateformat` report both policy and validation
+state. A file server cannot enforce those policies on write, but it can expose
+either attribute as `true` when the published data was validated before
+deployment.
 
-For example, if the file-server based xRegistry is an alternative
-mechanism to retrieve data from another xRegistry service that did validate
-the data (i.e. it was exported to the file-server), and there's a desire to
-not expose this implementation/deployment choice to the end-user. In other
-words, the use of the file-server as a caching service should be transparent
-to their users.
+For example, an API server can validate data before exporting it to a file
+server. Clients can then use either representation without needing to account
+for that deployment choice.
 
-### 11.23. Detecting circular references between Versions
+<a id="1123-detecting-circular-references-between-versions"></a>
+### 10.21. Detecting circular references between Versions
 
 The specification mentions that the Version's `ancestorid` attribute should not
 be set in such a way as to cause a circular dependency list between Versions.
@@ -1403,7 +1254,8 @@ checking, they may need to add extra logic to ensure they don't go caught in
 an infinite loop. Additionally, implementations should also document that they
 do not enforce this check to set the proper expectation levels for their users.
 
-### 11.24. Optional required fields in requests
+<a id="1124-optional-required-fields-in-requests"></a>
+### 10.22. Optional required fields in requests
 
 One of the design principles of the specification was to try to make each
 object be fully self-describing, within reason. For example, this is why when
@@ -1440,7 +1292,8 @@ messages (aside from when special flags, like the `?doc` flag, is enabled)
 must include all required attributes, even if they are duplicated elsewhere
 in the message.
 
-### 11.25. Deprecation of entities in an xRegistry
+<a id="1125-deprecation-of-entities-in-an-xregistry"></a>
+### 10.23. Deprecation of entities in an xRegistry
 
 The core specification defines a `deprecated` attribute that may appear
 under a Resource's `meta` sub-object. This attribute was added to the Resource
@@ -1451,37 +1304,24 @@ that the use of this feature might not be useful at the Version-level or even
 at the Group-level. However, for those cases, custom models may define
 an extension at the appropriate location in the model to meet their needs.
 When doing so it is recommended to use the same attribute definition as
-defined in the core specification for consistency. It is worth noting that
-the Endpoint [specification](../endpoint/spec.md) does exactly this to
-indicate when an Endpoint (i.e. a Group) is deprecated.
+defined in the core specification for consistency. The Endpoint
+[specification](../endpoint/spec.md) does exactly this to indicate when an
+Endpoint (i.e. a Group) is deprecated.
 
-## 12. The `format` attribute in the Schema spec
+<a id="13-problematic-characters-in-values"></a>
+## 11. Problematic characters in values
 
-The `format` attribute in the Schema spec is required when the
-`compatibility` attribute is set to a value other than `none`. This may
-appear to be overly restrictive, especially if your Registry implementation
-only supports a single format. The reason for making this field required, is
-to ease interoperability of registries through export-import functionality.
-That means that when exporting a Schema Registry that only supports a single
-format, the `format` attribute will already be set, avoiding issues when
-importing this Registry into a server that may support multiple formats.
+Attribute values can be used outside the scope of the xRegistry specification.
+For example, a `name` or ID value might become a file name. The character rules
+for values cannot account for every constraint imposed by those external
+systems, such as the restriction on colons (`:`) in Windows file names.
 
-## 13. Problematic characters in attributes
+Tooling must decide how to handle such cases. It can convert or escape the
+value, reject it, or require the user to choose a value that is valid in the
+target system. The specification does not prescribe that behavior.
 
-Certain attributes might be used for purposes outside of the scope of the
-xRegistry specification. For example, the `name` or ID-values might be used
-as a file name. While some care was taken to limit the allowable characters
-in some of these cases to the most common uses, not every possible use
-could be taken into account. Therefore, in situations where a value's allowable
-character set might be problematic (e.g. colon (`:`) in a file name on
-Windows), the tooling being used is expected to deal with any potential
-problems that might arise. For example, it may choose to convert or escape
-problematic characters. The specification makes no statement as to how
-these situations are handled, or even if they're supported. In other words,
-tooling might reject such cases, or force uses to use non-problematic
-characters.
-
-## 14. Why do Resources have 3 levels of data?
+<a id="14-why-do-resources-have-3-levels-of-data"></a>
+## 12. Why do Resources have 3 levels of data?
 
 Resource attributes are split into 3 categories:
 
@@ -1545,7 +1385,8 @@ Version should be driven by whether the use cases being supported by the
 Resource type definition requires that attribute to be consistent across all
 Versions or have a Version-specific value.
 
-## 15. Why are some (conditional) read-only attributes not ignored?
+<a id="15-why-are-some-conditional-read-only-attributes-not-ignored"></a>
+## 13. Why are some (conditional) read-only attributes not ignored?
 
 Attributes that are always defined as "read-only" normally have semantics such
 that attempts to update them are silently ignored. This is especially useful
@@ -1566,7 +1407,8 @@ aspect set to `false` then the `meta.defaultversionid` attribute of instances
 of that Resource becomes "read-only". And any attempt to update it will result
 in an error being generated.
 
-## 16. Why isn't `PUT` idempotent?
+<a id="16-why-isnt-put-idempotent"></a>
+## 14. Why isn't `PUT` idempotent?
 
 As stated in the [core](./spec.md) specification, the `PUT` operations are
 almost idempotent, per the HTTP specification. For the most part, multiple
@@ -1578,34 +1420,30 @@ of check on all attributes to determine if anything changed, and then only
 expensive or ambiguous check to perform, so it was determined it would be best
 to avoid it all together.
 
-## 17. Defining Extensions
+<a id="18-validation-edge-cases"></a>
+## 15. Validation edge cases
 
-When defining extensions for xRegistry, whether it is via a model definition
-or by extending the functionality of the specification itself (e.g. adding
-new APIs), care should be taken to limit the possibility of overlapping with
-any future xRegistry work. While it is impossible to predict the future, some
-steps can be taken to lessen the concern. For example, using domain, or
-company, specific terms when naming things.
+Sections [5.5](#55-schema-validation) and
+[8.1](#91-formats-and-contentmedia-types) explain the purpose and boundaries of
+validation. The following cases cover two less obvious interactions between
+validation settings.
 
-## 18. Validation
+<a id="181-empty-format-capabilities"></a>
+### 15.1. Empty format capabilities
 
-There is one scenario worth pointing out with respect to `format` and
-`compatibility` validation. If a Resource's model definition has both the
-`validateformat` and `strictvalidation` aspects set to `true`, and the
-Registry's `capabilities` does not define any `format` values, then any
-attempt to create a Resource of that Resource type with a non-empty `format`
-value will always be rejected with an "unknown format" type of error.
+If a Resource model sets both `validateformat` and `strictvalidation` to `true`,
+but the Registry's `capabilities` declares no `format` values, the server will
+reject every non-empty `format` value as unknown.
 
-This is being called out because for light-weight server implementations that
-do not support validation checks, a user might define a Resource type with
-those aspects enabled without realizing they're defining a potentially
-unusable Resource type - if clients use the `format` attribute.
+A lightweight server that performs no validation can therefore expose an
+unusable Resource type if its model enables those aspects and clients supply
+`format`.
 
-## Constraints and MatchVersions Features
+<a id="constraints-and-matchversions-features"></a>
+<a id="182-constraints-and-matchversions"></a>
+### 15.2. Constraints and `matchversions`
 
-These features limit the validation of attributes down to simple attributes
-(scalars in objects). Supporting attributes that are more complex, for example
-within maps, arrays, `ifvalues` clauses or `*` extensions, might be possible
-but the decision to limit it was made to ensure broad support across as many
-possible implementation choices as possible, while also keeping the code
-complexity burden to a minimum.
+`constraints` and `matchversions` validate only scalar attributes in objects.
+They do not apply inside maps, arrays, `ifvalues` clauses, or `*` extensions.
+Extending validation into those structures would increase implementation
+complexity and make consistent support across servers less likely.

--- a/core/primer.md
+++ b/core/primer.md
@@ -29,6 +29,7 @@ normative technical details.
     - [3.2.6. Errors](#326-errors)
   - [3.3. Defining a Basic Model](#33-defining-a-basic-model)
     - [3.3.1. Adding your own attributes (extensions)](#331-adding-your-own-attributes-extensions)
+  - [3.4. Where to go next](#34-where-to-go-next)
 - [4. History](#4-history)
 - [5. Value proposition](#5-value-proposition)
   - [5.1. Why build something new?](#51-why-build-something-new)
@@ -38,55 +39,73 @@ normative technical details.
   - [5.5. Schema validation](#55-schema-validation)
   - [5.6. Payload reduction](#56-payload-reduction)
   - [5.7. Schema-based contract and client generation](#57-schema-based-contract-and-client-generation)
-  - [5.8. Basis for further developments](#59-basis-for-further-developments)
-- [6. Non-Goals](#7-design-goals)
-- [7. Representations](#8-representations)
-  - [7.1. File](#81-file)
-  - [7.2. Static File Server](#82-static-file-server)
-  - [7.3. API Server](#83-api-server)
-- [8. Embeddings, References, and Federation](#9-embeddings-references-and-federation)
-  - [8.1. Formats and Content/Media-Types](#91-formats-and-contentmedia-types)
-  - [8.2. Embeddings and Links](#92-embeddings-and-links)
-  - [8.3. Federation](#93-federation)
-    - [8.3.1. Composing registries in memory](#931-composing-registries-in-memory)
-    - [8.3.2. Shadowing](#932-shadowing)
-    - [8.3.3. Identifiers](#933-identifiers)
-    - [8.3.4. API Servers and Proxies](#934-api-servers-and-proxies)
-- [9. Possible Use Cases](#10-possible-use-cases)
-  - [9.1. CloudEvents](#101-cloudevents)
-  - [9.2. Business objects](#102-business-objects)
-  - [9.3. Metadata files in repositories](#103-metadata-files-in-repositories)
-- [10. Design decisions or topics of interest](#11-design-decisions-or-topics-of-interest)
-  - [10.1. Resource.ID vs Resource.Version.ID](#111-resourceid-vs-resourceversionid)
-  - [10.2. Valid Characters](#112-valid-characters)
-  - [10.3. Extensions](#113-extensions)
-  - [10.4. Group organization](#114-group-organization)
-  - [10.5. Deleting entities](#115-deleting-entities)
-  - [10.6. Detection of Referenced Resources](#116-detection-of-referenced-resources)
-  - [10.7. Shared/Referenced Resources](#117-sharedreferenced-resources)
-  - [10.8. Default Version and Maximum Versions](#118-default-version-and-maximum-versions)
-  - [10.9. Why Epoch?](#1110-why-epoch)
-  - [10.10. Naming and Case Sensitivity](#1111-naming-and-case-sensitivity)
-  - [10.11. Why are Group and Resource type names more restricted?](#1112-why-the-lower-character-limit-on-some-group-and-resource-type-names)
-  - [10.12. Choosing unique Group and Resource names](#1114-choosing-unique-group-and-resource-names)
-  - [10.13. Are `self` and `shortself` attributes static?](#1115-are-self-and-shortself-attributes-static)
-  - [10.14. Why does an unknown query parameter not generate an error?](#1116-why-does-an-unknown-query-parameter-not-generate-an-error)
-  - [10.15. Updating attributes with `ifvalues`](#1117-updating-attributes-with-ifvalues)
-  - [10.16. Multi-root ancestor hierarchies](#1118-multi-root-ancestor-hierarchies)
-  - [10.17. `singleversionroot` Policy Enforcement](#1119-singleversionroot-policy-enforcement)
-  - [10.18. Pruning Versions with `singleversionroot` enabled](#1120-pruning-versions-with-singleversionroot-enabled)
-  - [10.19. What's the oldest/newest Version of a Resource?](#1121-whats-the-oldestnewest-version-of-a-resource)
-  - [10.20. Can `validatecompatibility` and `validateformat` be `true` for file-servers?](#1122-can-validatecompatibility-and-validateformat-be-true-for-file-servers)
-  - [10.21. Detecting circular references between Versions](#1123-detecting-circular-references-between-versions)
-  - [10.22. Optional required fields in requests](#1124-optional-required-fields-in-requests)
-  - [10.23. Deprecation of entities in an xRegistry](#1125-deprecation-of-entities-in-an-xregistry)
-- [11. Problematic characters in values](#13-problematic-characters-in-values)
-- [12. Why do Resources have 3 levels of data?](#14-why-do-resources-have-3-levels-of-data)
-- [13. Why are some (conditional) read-only attributes not ignored?](#15-why-are-some-conditional-read-only-attributes-not-ignored)
-- [14. Why isn't `PUT` idempotent?](#16-why-isnt-put-idempotent)
-- [15. Validation edge cases](#18-validation-edge-cases)
-  - [15.1. Empty format capabilities](#181-empty-format-capabilities)
-  - [15.2. Constraints and `matchversions`](#182-constraints-and-matchversions)
+  - [5.8. Basis for further developments](#basis-for-further-developments)
+- [6. Non-Goals](#non-goals)
+- [7. Representations](#representations)
+  - [7.1. File](#file)
+  - [7.2. Static File Server](#static-file-server)
+  - [7.3. API Server](#api-server)
+- [8. Embeddings, References, and
+  Federation](#embeddings-references-and-federation)
+  - [8.1. Formats and Content/Media-Types](#formats-and-contentmedia-types)
+  - [8.2. Embeddings and Links](#embeddings-and-links)
+  - [8.3. Federation](#federation)
+    - [8.3.1. Composing registries in memory](#composing-registries-in-memory)
+    - [8.3.2. Shadowing](#shadowing)
+    - [8.3.3. Identifiers](#identifiers)
+    - [8.3.4. API Servers and Proxies](#api-servers-and-proxies)
+- [9. Possible Use Cases](#possible-use-cases)
+  - [9.1. CloudEvents](#cloudevents)
+  - [9.2. Business objects](#business-objects)
+  - [9.3. Metadata files in repositories](#metadata-files-in-repositories)
+- [10. Design decisions or topics of
+  interest](#design-decisions-or-topics-of-interest)
+  - [10.1. Resource.ID vs Resource.Version.ID](#resourceid-vs-resourceversionid)
+  - [10.2. Valid Characters](#valid-characters)
+  - [10.3. Extensions](#extensions)
+  - [10.4. Group organization](#group-organization)
+  - [10.5. Deleting entities](#deleting-entities)
+  - [10.6. Detection of Referenced
+    Resources](#detection-of-referenced-resources)
+  - [10.7. Shared/Referenced Resources](#sharedreferenced-resources)
+  - [10.8. Default Version and Maximum
+    Versions](#default-version-and-maximum-versions)
+  - [10.9. Why Epoch?](#why-epoch)
+  - [10.10. Naming and Case Sensitivity](#naming-and-case-sensitivity)
+  - [10.11. Why are Group and Resource type names more
+    restricted?](#group-resource-type-name-limits)
+  - [10.12. Choosing unique Group and Resource
+    names](#choosing-unique-group-and-resource-names)
+  - [10.13. Are `self` and `shortself` attributes
+    static?](#are-self-and-shortself-attributes-static)
+  - [10.14. Why does an unknown query parameter not generate an
+    error?](#why-does-an-unknown-query-parameter-not-generate-an-error)
+  - [10.15. Updating attributes with
+    `ifvalues`](#updating-attributes-with-ifvalues)
+  - [10.16. Multi-root ancestor hierarchies](#multi-root-ancestor-hierarchies)
+  - [10.17. `singleversionroot` Policy
+    Enforcement](#singleversionroot-policy-enforcement)
+  - [10.18. Pruning Versions with `singleversionroot`
+    enabled](#pruning-versions-with-singleversionroot-enabled)
+  - [10.19. What's the oldest/newest Version of a
+    Resource?](#whats-the-oldestnewest-version-of-a-resource)
+  - [10.20. Can `validatecompatibility` and `validateformat` be `true` for
+    file-servers?](#validation-for-file-servers)
+  - [10.21. Detecting circular references between
+    Versions](#detecting-circular-references-between-versions)
+  - [10.22. Optional required fields in
+    requests](#optional-required-fields-in-requests)
+  - [10.23. Deprecation of entities in an
+    xRegistry](#deprecation-of-entities-in-an-xregistry)
+- [11. Problematic characters in values](#problematic-characters-in-values)
+- [12. Why do Resources have 3 levels of
+  data?](#why-do-resources-have-3-levels-of-data)
+- [13. Why are some (conditional) read-only attributes not
+  ignored?](#why-are-some-conditional-read-only-attributes-not-ignored)
+- [14. Why isn't `PUT` idempotent?](#why-isnt-put-idempotent)
+- [15. Validation edge cases](#validation-edge-cases)
+  - [15.1. Empty format capabilities](#empty-format-capabilities)
+  - [15.2. Constraints and `matchversions`](#constraints-and-matchversions)
 
 
 ## 3. A Quick Introduction to xRegistry
@@ -172,7 +191,8 @@ defines (e.g. `endpoints`, `messages`) - they're not literal.
 #### 3.2.1. Reading things
 
 A plain `GET` on a Registry, Group, metadata-only Resource, or Version returns
-its metadata as JSON. Document Resources are the exception described in
+its metadata as JSON. Resources with domain-specific documents, called
+Document Resources in the core specification, are the exception described in
 section 3.2.3.
 
 ```
@@ -243,8 +263,10 @@ xRegistry metadata (`epoch`, `name`, etc.).
   **metadata** as JSON instead (with the document's metadata such as
   `contenttype`, but not the document body itself).
 
-For `PUT`, `PUT .../msg1` with a raw body sets the document content, while
-`PUT .../msg1$details` with a JSON body updates only the metadata.
+For `PUT`, `PUT .../msg1` with a raw body sets the document content.
+`PUT .../msg1$details` accepts a JSON Resource body and can update both metadata
+and document content. The document can be supplied through the `message`,
+`messagebase64`, or `messageurl` attribute.
 
 If a Resource type doesn't have its own separate document (just metadata),
 then `$details` isn't needed - plain requests just return the metadata.
@@ -361,6 +383,15 @@ This model is sufficient to create Groups and Resources. The full model
 specification covers constraints, versioning policies, `xid` targets,
 `ifvalues`, and other advanced scenarios; see [`model.md`](./model.md).
 
+### 3.4. Where to go next
+
+- [`spec.md`](./spec.md) - the full core specification (concepts, entities,
+  capabilities).
+- [`http.md`](./http.md) - the full HTTP binding (every API, header, and
+  query parameter in detail).
+- [`model.md`](./model.md) - the full model specification (every model
+  attribute and option).
+
 ## 4. History
 
 The CNCF Serverless Working group was originally created by the CNCF's Technical
@@ -381,7 +412,7 @@ xRegistry provides a specification to define metadata and extensions for
 resources in an abstract model that can be used to centralize and standardize
 information about resources in a system. The core specification defines the
 basic building blocks for managing metadata about resources and provides
-multiple formats to [represent](#8-representations) this information.
+multiple formats to [represent](#representations) this information.
 
 xRegistry can be used to represent any type of metadata, as long as it adheres
 to the basic model in which a registry consists of groups, which in turn
@@ -389,7 +420,7 @@ consists of multiple resources which can have multiple versions defined. This
 model is useful for any metadata that is crucial to the operation of a system or
 helps facilitate the interaction between systems. The use cases for xRegistry
 are therefore very broad. See
-[possible use cases](#10-possible-use-cases) for more examples.
+[possible use cases](#possible-use-cases) for more examples.
 
 In addition to the core specification, xRegistry provides secondary
 specifications for [endpoints](../endpoint/spec.md),
@@ -420,7 +451,7 @@ the xRegistry resource model. This provides consistent metadata and
 cross-references while the source registries remain authoritative. For example,
 a container image can contain an application, published as a package, that
 exposes an endpoint for events with particular payload schemas. Section
-[8.3.4](#934-api-servers-and-proxies) explains how an xRegistry API can project
+[8.3.4](#api-servers-and-proxies) explains how an xRegistry API can project
 resources managed by another registry.
 
 ### 5.2. Discovery
@@ -429,10 +460,11 @@ One of the pain points of event-driven systems is the need to create and
 maintain documentation about endpoints and the events they expose, enabling
 consumers from other teams or even other organizations to find the information
 they need. A centralized registry gives teams one place to discover and query
-endpoints and the events they produce or consume. Extensions can describe these
-events in more detail, including which metadata are required. Descriptions can
-also be written for people rather than tools, so developers, data analysts, and
-business analysts can use the same registry.
+endpoints and the events they produce or consume. Extensions can add
+domain-specific metadata that describes these events in greater detail. An
+extension's model can declare which of those attributes are required.
+Descriptions can also be written for people rather than tools, so developers,
+data analysts, and business analysts can use the same registry.
 
 ### 5.3. Vendor-agnostic
 
@@ -475,15 +507,17 @@ published and reject events that do not conform to the schema for that context.
 ### 5.6. Payload reduction
 
 Schema information enables real-time analysis of incoming data based on its
-context. Applications therefore often use serialization formats such as JSON
-that carry structural information in each payload. With that information
-available from a centralized registry, applications can use lighter-weight
-serialization formats and reduce bandwidth without giving up contextual
-analysis.
+context. Self-describing encodings such as JSON repeat field names and other
+structural information in each payload. When applications can resolve the
+applicable schema through registry metadata, they can use compact serialization
+formats that omit this repetition without giving up contextual analysis.
+Generated contracts can be created on demand or published alongside a model
+version as reusable libraries, allowing consumers to use them without
+installing the generator tooling.
 
 ### 5.7. Schema-based contract and client generation
 
-The [file and API representations](#8-representations) can both supply versioned
+The [file and API representations](#representations) can both supply versioned
 model input to code generators. Teams can generate the data contracts needed to
 interact with endpoints instead of maintaining shared packages for those
 contracts by hand. A schema in a
@@ -493,8 +527,12 @@ consumers reduce the amount of contract code that teams must write and test.
 Clemens Vasters built a proof-of-concept that shows this approach in
 the [Avrotize VS Code Extension](https://github.com/clemensv/avrotize).
 
-<a id="59-basis-for-further-developments"></a>
+<a id="basis-for-further-developments"></a>
 ### 5.8. Basis for further developments
+
+The core xRegistry resource model is independent of messaging protocols.
+Domain-specific specifications can describe resources associated with MQTT,
+HTTP, Kafka, AMQP, or other protocols without changing that common model.
 
 CloudEvents serve as a mechanism to aid in the delivery of events from a
 producer to a consumer, which is applicable independently of the protocol (MQTT,
@@ -508,17 +546,17 @@ needed to define event flows. Those flows can then be discovered directly
 instead of reconstructed from manually maintained documentation or observed
 runtime behavior.
 
-<a id="7-design-goals"></a>
-<a id="71-non-goals"></a>
+<a id="design-goals"></a>
+<a id="non-goals"></a>
 ## 6. Non-Goals
 
 - **Authentication and Authorization:** Rely on established security standards
   depending on the registry representation.
-- **Relationships between event channels:** Focus on precisely describing a
-  single event channel before standardizing the relationships between event
-  channels.
+- **Relationships between event channels:** The Endpoint specification focuses
+  on describing individual event channels and does not standardize relationships
+  between them.
 
-<a id="8-representations"></a>
+<a id="representations"></a>
 ## 7. Representations
 
 An xRegistry can be represented as a JSON file, a static file server, or an API
@@ -526,12 +564,12 @@ server. Resources
 (user-supplied data) will most often be embedded in the registry, but the
 resource metadata might also point to an external location where such data
 exists; also see the discussion about [embeddings and
-references](#9-embeddings-references-and-federation).
+references](#embeddings-references-and-federation).
 
 The representations are symmetric so that data can move between them. Choose a
-representation according to the required write path and deployment model.
+representation based on how the registry will be updated and deployed.
 
-<a id="81-file"></a>
+<a id="file"></a>
 ### 7.1. File
 
 The registry is represented as a single JSON file.
@@ -554,7 +592,7 @@ raised events.
 Writing a registry by hand is useful for learning or small projects. Larger or
 shared registries will usually need tooling or an API server.
 
-<a id="82-static-file-server"></a>
+<a id="static-file-server"></a>
 ### 7.2. Static File Server
 
 The registry is represented by multiple JSON files, where each one represents a
@@ -565,8 +603,9 @@ This representation allows clients to retrieve individual entities instead of
 the entire registry as one JSON document. It can also serve data exported from
 an API server.
 
-It requires storage but no continuously running compute. For example, an
-xRegistry can be hosted on GitHub Pages, much like a Helm registry.
+It requires storage but no continuously running compute. For example, the
+[xRegistry specification registry](https://xregistry.io/xreg/) is hosted on
+GitHub Pages.
 
 Since the static file server is read-only, adding resources to the registry is
 only possible by rebuilding the server and file structure, e.g. via pipelines.
@@ -575,7 +614,7 @@ filtering, you might consider using the API server instead. Adding server logic
 to the static file server to make up for the features of the API server is
 considered an anti pattern.
 
-<a id="83-api-server"></a>
+<a id="api-server"></a>
 ### 7.3. API Server
 
 An API server suits registries shared by multiple teams, especially when
@@ -589,7 +628,7 @@ Running the API server requires you to set up a host and a persistence
 layer and maintain both. Start with this representation when direct writes,
 authorization, or server-side queries are already required.
 
-<a id="9-embeddings-references-and-federation"></a>
+<a id="embeddings-references-and-federation"></a>
 ## 8. Embeddings, References, and Federation
 
 The purpose of a registry is to act as a catalog more than as a container.
@@ -609,7 +648,7 @@ The model declares document metadata but does not define the document's
 internal shape. Implementations may interpret and validate that shape according
 to `format`.
 
-<a id="91-formats-and-contentmedia-types"></a>
+<a id="formats-and-contentmedia-types"></a>
 ### 8.1. Formats and Content/Media-Types
 
 `format` and the supported values are a convention chosen for this
@@ -632,13 +671,13 @@ that are under its own control. If a document is external, meaning that the
 resource entry does not embed it but links to it, the document might change at
 the external location without the registry knowing.
 
-<a id="12-the-format-attribute-in-the-schema-spec"></a>
-The Schema specification requires `format` when `compatibility` is anything
-other than `none`, even when an implementation supports only one format. This
-keeps the format explicit in exports so that another server, including one that
-supports several formats, can import them without ambiguity.
+<a id="the-format-attribute-in-the-schema-spec"></a>
+The Schema specification requires `format` when `compatibility` is present,
+even when an implementation supports only one format. This keeps the format
+explicit in exports so that another server, including one that supports several
+formats, can import them without ambiguity.
 
-<a id="92-embeddings-and-links"></a>
+<a id="embeddings-and-links"></a>
 ### 8.2. Embeddings and Links
 
 When the resource is declared to be a document, it can be stored inside the
@@ -671,37 +710,39 @@ The URL can identify an HTTP resource or a file-system location, which allows
 documents in an existing registry or public repository to remain in place. The
 `format` and `contenttype` information still needs to exist in xRegistry so
 that clients can interpret the document before resolving it. The registry does
-not resolve the URL or load the content; clients do that.
+not resolve the URL or load the content; clients do that. API servers can also
+use external links when proxying content from non-xRegistry registries; see
+[API Servers and Proxies](#api-servers-and-proxies).
 
-<a id="93-federation"></a>
+<a id="federation"></a>
 ### 8.3. Federation
 
 xRegistry does not have a synchronization API, by intent. Since xRegistry is
 both a document format model and an API, the integration of multiple registries
 ("federation") does not rely on making copies but is intended to work via
-cross-referencing and "shadowing" across the [representations](#8-representations)
+cross-referencing and "shadowing" across the [representations](#representations)
 described earlier.
 
-<a id="931-composing-registries-in-memory"></a>
+<a id="composing-registries-in-memory"></a>
 #### 8.3.1. Composing registries in memory
 
-A registry document, whether a single [file](#81-file) or the root of a
-[static file server](#82-static-file-server) layout, is meant to be loaded into
-an application as a local, in-memory registry. A registry document used on its
-own must embed a model to be valid. A server may nevertheless accept source
-input that contains only resources and metadata, supply a model it already
-knows, and construct a valid registry from both. There are several examples of
-such source documents in the
+A registry document, whether a single [file](#file) or the root of a
+[static file server](#static-file-server) layout, is meant to be loaded into
+an application as a local, in-memory registry. For standalone use, a registry
+document embeds its model. A server may instead accept source input that
+contains only resources and metadata, supply a model it already knows, and
+construct a registry from both. There are several examples of such source
+documents in the
 [cloudevents/samples](../cloudevents/samples/README.md) folder.
 
 When the registry is split across multiple files in a folder structure, the
 application can load the root document and traverse `<RESOURCE>url` links to
 individual documents on demand, building an in-memory view that combines the
 root document with only those branches that are relevant to the application. The
-same applies when the root sits behind an [API server](#83-api-server) or proxy:
+same applies when the root sits behind an [API server](#api-server) or proxy:
 the client fetches and caches just the branches it needs.
 
-<a id="932-shadowing"></a>
+<a id="shadowing"></a>
 #### 8.3.2. Shadowing
 
 Federation in xRegistry is intended to be built on *shadowing*: an application's
@@ -731,7 +772,7 @@ composition and shadowing is the best approach to federation, but the project
 will need to gain more experience with it in practice before it can be
 formalized.
 
-<a id="933-identifiers"></a>
+<a id="identifiers"></a>
 #### 8.3.3. Identifiers
 
 For shadowing and cross-referencing to work, identifiers need to be stable
@@ -748,7 +789,7 @@ regardless of which registry hosts it. For example, an application in a private
 network may resolve the URI against a local registry when it cannot reach the
 public registry.
 
-<a id="934-api-servers-and-proxies"></a>
+<a id="api-servers-and-proxies"></a>
 #### 8.3.4. API Servers and Proxies
 
 An API server can also act as a proxy that presents multiple underlying
@@ -762,10 +803,10 @@ Shadowing applies here too: any API client can shadow the API server with a
 local registry to add or modify entries without affecting the underlying
 registry, and a proxying API server can do the same on behalf of its clients.
 
-<a id="10-possible-use-cases"></a>
+<a id="possible-use-cases"></a>
 ## 9. Possible Use Cases
 
-<a id="101-cloudevents"></a>
+<a id="cloudevents"></a>
 ### 9.1. CloudEvents
 
 Since xRegistry emerged from the CloudEvents project and initially was called
@@ -777,7 +818,7 @@ specific use-case even though the original spec marks them as optional. In
 addition, the `dataschema` attribute of a CloudEvent can then point to a
 xRegistry schema document making this two projects that work hand in hand.
 
-<a id="102-business-objects"></a>
+<a id="business-objects"></a>
 ### 9.2. Business objects
 
 When defining the schemas of business objects in an enterprise, xRegistry can be
@@ -785,17 +826,17 @@ the schema store for these definitions. One can then reference them in a data
 catalogue as well as in OpenAPI and AsyncAPI documents without repeating the
 schemas for the actual business objects.
 
-<a id="103-metadata-files-in-repositories"></a>
+<a id="metadata-files-in-repositories"></a>
 ### 9.3. Metadata files in repositories
 
-The [file representation](#81-file) supports a repository-level manifest similar
+The [file representation](#file) supports a repository-level manifest similar
 to `package.json`. Such a manifest can list the repository's metadata files and
 provide machine-readable access to project dependencies and configuration.
 
-<a id="11-design-decisions-or-topics-of-interest"></a>
+<a id="design-decisions-or-topics-of-interest"></a>
 ## 10. Design decisions or topics of interest
 
-<a id="111-resourceid-vs-resourceversionid"></a>
+<a id="resourceid-vs-resourceversionid"></a>
 ### 10.1. Resource.ID vs Resource.Version.ID
 
 Resources, like all xRegistry entities, have unique `id` values. Resource
@@ -815,12 +856,12 @@ xRegistry model. As a result, implementations might want to avoid using `id`
 values that could appear on a Resource and one of its Versions simply to avoid
 potential confusion for their end-users.
 
-<a id="112-valid-characters"></a>
+<a id="valid-characters"></a>
 ### 10.2. Valid Characters
 
 Attribute names appear in JSON objects, HTTP headers, URLs, and generated code.
 The specification therefore uses a restricted character set that works across
-those contexts. Section [10.10](#1111-naming-and-case-sensitivity) explains the
+those contexts. Section [10.10](#naming-and-case-sensitivity) explains the
 casing rules. Section 10.11 explains the additional restrictions on Group and
 Resource type names.
 
@@ -832,25 +873,25 @@ for that behavior.
 Map keys allow more characters than attribute names because they are normally
 stored as strings rather than mapped to named fields in code structures.
 
-<a id="113-extensions"></a>
+<a id="extensions"></a>
 ### 10.3. Extensions
 
 Extensions SHOULD be defined in the model. A model can also define a `*`
 extension to allow attributes supplied at runtime. Extension names follow the
-[valid character](#112-valid-characters) and
-[casing](#1111-naming-and-case-sensitivity) rules for all attributes.
+[valid character](#valid-characters) and
+[casing](#naming-and-case-sensitivity) rules for all attributes.
 
 Required aspects apply at each level of a nested extension. In particular,
 `clientrequired=true` also requires `serverrequired=true`; otherwise the model
 is invalid.
 
-<a id="119-potential-extensions"></a>
+<a id="potential-extensions"></a>
 Implementations that track the identity responsible for a change might define
 `createdby` and `modifiedby` extensions alongside `createdat` and `modifiedat`.
 The core specification does not define them because it does not define
 authentication or identity tracking.
 
-<a id="114-group-organization"></a>
+<a id="group-organization"></a>
 ### 10.4. Group organization
 
 Groups are intentionally a single organizational dimension above Resources:
@@ -874,7 +915,7 @@ Versions, for example `stage=dev`, `team=payments`, or `tier=gold`. Server
 implementations may support filtering and lookup by labels; see the filter
 examples in the core specification.
 
-<a id="115-deleting-entities"></a>
+<a id="deleting-entities"></a>
 ### 10.5. Deleting entities
 
 The "delete" operation typically has two variants:
@@ -903,7 +944,7 @@ delete multiple entities. For collection deletion:
   Version isn't being deleted. Note that a `404` in the `DELETE .../<ID>` case
   is an error and no changes to the "default" Version will occur.
 
-<a id="116-detection-of-referenced-resources"></a>
+<a id="detection-of-referenced-resources"></a>
 ### 10.6. Detection of Referenced Resources
 
 The xRegistry specification allows for Resources to appear in multiple Groups
@@ -919,7 +960,7 @@ some kind of "xref counter" extension on the target Resource. The specification
 might consider adding some feature to address this in the future, but as of now
 it is left as an implementation choice.
 
-<a id="117-sharedreferenced-resources"></a>
+<a id="sharedreferenced-resources"></a>
 ### 10.7. Shared/Referenced Resources
 
 Beyond detecting dangling references, users need to decide how shared Resources
@@ -935,7 +976,7 @@ Additionally, how the implementation of the xRegistry manages
 access-control-rights of Resources (often via Groups) might influence the
 initial placement into a Group of a new Resource.
 
-<a id="118-default-version-and-maximum-versions"></a>
+<a id="default-version-and-maximum-versions"></a>
 ### 10.8. Default Version and Maximum Versions
 
 Each Resource type can specify the maximum number of Versions that the
@@ -971,7 +1012,7 @@ Let's walk through a complex example:
 - The result is: v8 regardless of whether v8 was created with isdefault=true or
   not
 
-<a id="1110-why-epoch"></a>
+<a id="why-epoch"></a>
 ### 10.9. Why Epoch?
 
 Why such an unusual name? As the specification describes, `epoch` is used as a
@@ -991,7 +1032,7 @@ they know what it means due to some other usage in this technology space
 seemed unlikely. In fact, use of this word might pique people's curiosity
 and cause them to look it up in the specification to find out more about it.
 
-<a id="1111-naming-and-case-sensitivity"></a>
+<a id="naming-and-case-sensitivity"></a>
 ### 10.10. Naming and Case Sensitivity
 
 The following explains some of the reasoning behind the casing and case
@@ -1057,7 +1098,7 @@ sensitivity rules in the specification.
   The specification therefore requires case-sensitive lookup while prohibiting
   IDs that differ only by case within the same parent.
 
-<a id="1112-why-the-lower-character-limit-on-some-group-and-resource-type-names"></a>
+<a id="group-resource-type-name-limits"></a>
 ### 10.11. Why are Group and Resource type names more restricted?
 
 Attribute names and key names are limited to 63 characters, so why are some
@@ -1068,12 +1109,12 @@ we need to take into account the length of those phrases. As a result, both
 Group and Resource type names (both singular and plural) are limited to
 57 characters.
 
-<a id="1113-why-must-group-type-and-resource-type-names-be-valid-attribute-names"></a>
+<a id="why-group-resource-type-names-are-limited"></a>
 Since Group type and Resource type names will appear as attribute names (e.g.
 `<GROUPS>count` and `<RESOURCE>url`), the character set (and length) of their
 names need to be restricted in the same way as a attribute names.
 
-<a id="1114-choosing-unique-group-and-resource-names"></a>
+<a id="choosing-unique-group-and-resource-names"></a>
 ### 10.12. Choosing unique Group and Resource names
 
 Aside from choosing names that give some descriptive meaning to the purpose
@@ -1084,11 +1125,11 @@ name collisions with other similarly named entities. This might be useful
 for Resource names too (if they might co-exist under shared Groups), but
 normally ensuring uniqueness at the Group level is sufficient.
 
-<a id="17-defining-extensions"></a>
+<a id="defining-extensions"></a>
 The same collision guidance applies to model extensions and new APIs; their
 names should remain clear of future xRegistry additions.
 
-<a id="1115-are-self-and-shortself-attributes-static"></a>
+<a id="are-self-and-shortself-attributes-static"></a>
 ### 10.13. Are `self` and `shortself` attributes static?
 
 In general any URL reference to an entity in the Registry should remain
@@ -1106,7 +1147,7 @@ values need to change.
 Obviously, situations like these should be rare but the specification needs
 to allow for them.
 
-<a id="1116-why-does-an-unknown-query-parameter-not-generate-an-error"></a>
+<a id="why-does-an-unknown-query-parameter-not-generate-an-error"></a>
 ### 10.14. Why does an unknown query parameter not generate an error?
 
 People have identified cases where query parameters might be added to request
@@ -1119,7 +1160,7 @@ the authors chose to have the server ignore unknown query parameters. The
 specification says they SHOULD be ignored, not that they MUST be ignored. An
 implementation can reject them, but doing so risks interoperability problems.
 
-<a id="1117-updating-attributes-with-ifvalues"></a>
+<a id="updating-attributes-with-ifvalues"></a>
 ### 10.15. Updating attributes with `ifvalues`
 
 The `ifvalues` feature might be a new concept for some readers, so a point
@@ -1137,14 +1178,14 @@ in the entity in order to be model compliant.
 Likewise, implementations of the server must validate the entire entity
 against the new model, not just a subset of the entity's attributes.
 
-<a id="1118-multi-root-ancestor-hierarchies"></a>
+<a id="multi-root-ancestor-hierarchies"></a>
 ### 10.16. Multi-root ancestor hierarchies
 
 The [`ancestorid` attribute](./spec.md#ancestorid-attribute) builds a Version
 hierarchy for compatibility checking when the
 [`compatibility` attribute](./spec.md#compatibility-attribute) is set. Some
 use cases need multiple roots. Pruning can also create additional roots;
-section [10.18](#1120-pruning-versions-with-singleversionroot-enabled)
+section [10.18](#pruning-versions-with-singleversionroot-enabled)
 describes the case in which `singleversionroot` prevents that operation.
 
 To signal that a Version represents a root of a hierarchy, the `ancestorid`
@@ -1153,7 +1194,7 @@ makes the ancestor explicit, and the possible ambiguity of using another
 value such as null which, based on the scenario, could mean "no ancestor" or
 "default to the newest".
 
-<a id="1119-singleversionroot-policy-enforcement"></a>
+<a id="singleversionroot-policy-enforcement"></a>
 ### 10.17. `singleversionroot` Policy Enforcement
 
 Related to the previous discussions concerning the `ancestorid` attribute,
@@ -1187,7 +1228,7 @@ These examples are not meant to be complete. The flexibility of the
 specification allows for model authors to choose the most appropriate value
 for their needs.
 
-<a id="1120-pruning-versions-with-singleversionroot-enabled"></a>
+<a id="pruning-versions-with-singleversionroot-enabled"></a>
 ### 10.18. Pruning Versions with `singleversionroot` enabled
 
 There are cases in which the server will need to prune Versions. For
@@ -1213,7 +1254,7 @@ creation of a new Version. To resolve this, the user will have to manually
 delete v2 or v3 to allow the server to prune the oldest Version (v1) before
 creating a new Version.
 
-<a id="1121-whats-the-oldestnewest-version-of-a-resource"></a>
+<a id="whats-the-oldestnewest-version-of-a-resource"></a>
 ### 10.19. What's the oldest/newest Version of a Resource?
 
 The oldest Version of a Resource isn't necessarily the one with the oldest
@@ -1232,7 +1273,7 @@ Versions exist with the same `createdat` timestamp, those Versions are
 sorted in an descending alphabetical order, and the first is the newest
 Version.
 
-<a id="1122-can-validatecompatibility-and-validateformat-be-true-for-file-servers"></a>
+<a id="validation-for-file-servers"></a>
 ### 10.20. Can `validatecompatibility` and `validateformat` be `true` for file-servers?
 
 `validatecompatibility` and `validateformat` report both policy and validation
@@ -1244,7 +1285,7 @@ For example, an API server can validate data before exporting it to a file
 server. Clients can then use either representation without needing to account
 for that deployment choice.
 
-<a id="1123-detecting-circular-references-between-versions"></a>
+<a id="detecting-circular-references-between-versions"></a>
 ### 10.21. Detecting circular references between Versions
 
 The specification mentions that the Version's `ancestorid` attribute should not
@@ -1265,7 +1306,7 @@ checking, they may need to add extra logic to ensure they don't go caught in
 an infinite loop. Additionally, implementations should also document that they
 do not enforce this check to set the proper expectation levels for their users.
 
-<a id="1124-optional-required-fields-in-requests"></a>
+<a id="optional-required-fields-in-requests"></a>
 ### 10.22. Optional required fields in requests
 
 One of the design principles of the specification was to try to make each
@@ -1303,7 +1344,7 @@ messages (aside from when special flags, like the `?doc` flag, is enabled)
 must include all required attributes, even if they are duplicated elsewhere
 in the message.
 
-<a id="1125-deprecation-of-entities-in-an-xregistry"></a>
+<a id="deprecation-of-entities-in-an-xregistry"></a>
 ### 10.23. Deprecation of entities in an xRegistry
 
 The core specification defines a `deprecated` attribute that may appear
@@ -1319,7 +1360,7 @@ defined in the core specification for consistency. The Endpoint
 [specification](../endpoint/spec.md) does exactly this to indicate when an
 Endpoint (i.e. a Group) is deprecated.
 
-<a id="13-problematic-characters-in-values"></a>
+<a id="problematic-characters-in-values"></a>
 ## 11. Problematic characters in values
 
 Attribute values can be used outside the scope of the xRegistry specification.
@@ -1331,7 +1372,7 @@ Tooling must decide how to handle such cases. It can convert or escape the
 value, reject it, or require the user to choose a value that is valid in the
 target system. The specification does not prescribe that behavior.
 
-<a id="14-why-do-resources-have-3-levels-of-data"></a>
+<a id="why-do-resources-have-3-levels-of-data"></a>
 ## 12. Why do Resources have 3 levels of data?
 
 Resource attributes are split into 3 categories:
@@ -1396,7 +1437,7 @@ Version should be driven by whether the use cases being supported by the
 Resource type definition requires that attribute to be consistent across all
 Versions or have a Version-specific value.
 
-<a id="15-why-are-some-conditional-read-only-attributes-not-ignored"></a>
+<a id="why-are-some-conditional-read-only-attributes-not-ignored"></a>
 ## 13. Why are some (conditional) read-only attributes not ignored?
 
 Attributes that are always defined as "read-only" normally have semantics such
@@ -1418,7 +1459,7 @@ aspect set to `false` then the `meta.defaultversionid` attribute of instances
 of that Resource becomes "read-only". And any attempt to update it will result
 in an error being generated.
 
-<a id="16-why-isnt-put-idempotent"></a>
+<a id="why-isnt-put-idempotent"></a>
 ## 14. Why isn't `PUT` idempotent?
 
 As stated in the [core](./spec.md) specification, the `PUT` operations are
@@ -1431,15 +1472,15 @@ of check on all attributes to determine if anything changed, and then only
 expensive or ambiguous check to perform, so it was determined it would be best
 to avoid it all together.
 
-<a id="18-validation-edge-cases"></a>
+<a id="validation-edge-cases"></a>
 ## 15. Validation edge cases
 
 Sections [5.5](#55-schema-validation) and
-[8.1](#91-formats-and-contentmedia-types) explain the purpose and boundaries of
+[8.1](#formats-and-contentmedia-types) explain the purpose and boundaries of
 validation. The following cases cover two less obvious interactions between
 validation settings.
 
-<a id="181-empty-format-capabilities"></a>
+<a id="empty-format-capabilities"></a>
 ### 15.1. Empty format capabilities
 
 If a Resource model sets both `validateformat` and `strictvalidation` to `true`,
@@ -1451,7 +1492,7 @@ unusable Resource type if its model enables those aspects and clients supply
 `format`.
 
 <a id="constraints-and-matchversions-features"></a>
-<a id="182-constraints-and-matchversions"></a>
+<a id="constraints-and-matchversions"></a>
 ### 15.2. Constraints and `matchversions`
 
 `constraints` and `matchversions` validate only scalar attributes in objects.

--- a/core/primer.md
+++ b/core/primer.md
@@ -1,7 +1,8 @@
 # xRegistry Primer
 
 <!-- words: validatecompatibility validateformat -->
-<!-- words: strictvalidation matchversions readme upserts -->
+<!-- words: strictvalidation matchversions messageurl -->
+<!-- words: readme standalone upserts -->
 
 <!-- no verify-specs -->
 

--- a/core/primer.md
+++ b/core/primer.md
@@ -205,6 +205,10 @@ for everything in it.
   - `PATCH` = partial update (only what you include is changed; `null`
     deletes an attribute).
 
+Creating a nested entity also creates any missing parent entities. A parent
+with required attributes must be created explicitly first; otherwise creation
+of the nested entity fails.
+
 Example - create a Group:
 
 ```
@@ -601,6 +605,10 @@ xRegistry can embed content such as schema documents. The following sections
 separate document format metadata from the choice to embed, encode, or link the
 document.
 
+The model declares document metadata but does not define the document's
+internal shape. Implementations may interpret and validate that shape according
+to `format`.
+
 <a id="91-formats-and-contentmedia-types"></a>
 ### 8.1. Formats and Content/Media-Types
 
@@ -647,6 +655,9 @@ registry document for the [embedded object](spec.md#resource-attribute) variant.
 At present, all examples and implementations use JSON and so it might appear
 that this is a JSON-related feature, but it's very feasible to encode the entire
 registry in Avro binary and there is a formal schema for Avro.
+
+The core specification defines only JSON serialization. Another registry
+encoding requires a separately defined serialization binding.
 
 In JSON, we can embed JSON-data like an Avro Schema into `schema` and we can
 also embed a single string for a text file into `schema` as long as we are


### PR DESCRIPTION
## Summary

- consolidate repeated explanations in the core primer
- remove sections that no longer carry independent technical value
- correct ID casing and shadowing explanations
- preserve historical heading links with explicit compatibility anchors

## Validation

- `py -3 tools/verify.py core`
- repository-equivalent spelling and whitespace checks
- `git diff --check`

Relates to #525.