### PR TITLE
Fix model schema resource validation definitions

### DIFF
--- a/core/model.schema.json
+++ b/core/model.schema.json
@@ -85,21 +85,28 @@
             },
             "constraints": {
               "type": "object",
-              "properties": {
-                "default": {
-                  "type": [ "string", "number", "integer", "boolean" ]
-                },
-                "enum": {
-                  "type": "array",
-                  "items": {
-                    "type": [ "string", "number", "integer", "boolean" ]
+              "patternProperties": {
+                "^[a-z][a-z0-9_]*\\..+$": {
+                  "type": "object",
+                  "properties": {
+                    "default": {
+                      "type": [ "string", "number", "integer", "boolean" ]
+                    },
+                    "enum": {
+                      "type": "array",
+                      "items": {
+                        "type": [ "string", "number", "integer", "boolean" ]
+                      },
+                      "minItems": 1
+                    },
+                    "equals": {
+                      "type": "string"
+                    }
                   },
-                  "minItems": 1
-                },
-                "equals": {
-                  "type": "string"
+                  "additionalProperties": false
                 }
               },
+              "additionalProperties": false,
               "description": "Group level constraints over resources"
             },
             "resources": {
@@ -173,6 +180,21 @@
               "type": "boolean",
               "default": false,
               "description": "Whether to enforce single root Version"
+            },
+            "validateformat": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to perform Version format checks"
+            },
+            "validatecompatibility": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to perform Version compatibility checks"
+            },
+            "strictvalidation": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether to reject unknown format and compatibility validators"
             },
             "typemap": {
               "type": "object",


### PR DESCRIPTION
## Summary

- model group constraints as a map keyed by resource attribute paths
- allow the three resource validation capabilities defined by the core model
- validate all current model documents, including Schema and OpenUSD

Fixes #512

## Validation

- `py -3 tools/validate-models.py`
- `py -3 tools/verify.py core`
- `py -3 -m pytest test_schema_generator.py test_verify.py` from `tools`