### PR TITLE
Resolve semantic drift in samples

### DIFF
--- a/cloudevents/samples/scenarios/contoso-erp-jsons07.xreg.json
+++ b/cloudevents/samples/scenarios/contoso-erp-jsons07.xreg.json
@@ -3,13 +3,15 @@
         "Contoso.ERP.Http": {
             "description": "HTTP producer endpoint for Contoso ERP eventing",
             "usage": [ "producer" ],
-            "deployed": false,
-            "endpoints": [
-                {
-                    "uri": "https://erpsystem.com/events"
-                }
-            ],
             "protocol": "HTTP",
+            "protocoloptions": {
+                "deployed": false,
+                "endpoints": [
+                    {
+                        "uri": "https://erpsystem.com/events"
+                    }
+                ]
+            },
             "messagegroups": [
                 "/messagegroups/Contoso.ERP.ReservationEvents",
                 "/messagegroups/Contoso.ERP.PaymentEvents",
@@ -25,12 +27,14 @@
             "description": "HTTP subscriber endpoint for Contoso ERP eventing",
             "usage": [ "subscriber"] ,
             "protocol": "HTTP",
-            "deployed": false,
-            "endpoints": [
-                {
-                    "uri": "https://erpsystem.com/events/subscriptions"
-                }
-            ],
+            "protocoloptions": {
+                "deployed": false,
+                "endpoints": [
+                    {
+                        "uri": "https://erpsystem.com/events/subscriptions"
+                    }
+                ]
+            },
             "messagegroups": [
                 "/messagegroups/Contoso.ERP.ReservationEvents",
                 "/messagegroups/Contoso.ERP.PaymentEvents",
@@ -47,18 +51,18 @@
             "channel": "myqueue",
             "usage": [ "consumer" ],
             "protocol": "AMQP/1.0",
-            "deployed": false,
-            "endpoints": [
-                {
-                    "uri": "amqps://cediscoveryinterop.example.com/queue"
-                }
-            ],
             "protocoloptions": {
+                "deployed": false,
+                "endpoints": [
+                    {
+                        "uri": "amqps://cediscoveryinterop.example.com/queue"
+                    }
+                ],
                 "node": "queue",
-                "link_properties": {
+                "link-properties": {
                     "myprop": "prop"
                 },
-                "distribution_mode": "copy"
+                "distribution-mode": "copy"
             },
             "messagegroups": [
                 "/messagegroups/Contoso.ERP.ReservationEvents",
@@ -77,18 +81,18 @@
             "usage": [ "producer" ],
             "protocol": "AMQP/1.0",
             "protocoloptions": {
+                "deployed": false,
+                "endpoints": [
+                    {
+                        "uri": "amqps://cediscoveryinterop.example.com/queue"
+                    }
+                ],
                 "node": "queue",
-                "link_properties": {
+                "link-properties": {
                     "myprop": "prop"
                 },
-                "distribution_mode": "copy"
+                "distribution-mode": "copy"
             },
-            "deployed": false,
-            "endpoints": [
-                {
-                    "uri": "amqps://cediscoveryinterop.example.com/queue"
-                }
-            ],
             "messagegroups": [
                 "/messagegroups/Contoso.ERP.ReservationEvents",
                 "/messagegroups/Contoso.ERP.PaymentEvents",
@@ -105,13 +109,15 @@
             "channel": "mytopic",
             "usage": [ "producer" ],
             "protocol": "KAFKA",
-            "deployed": false,
-            "endpoints": [
-                {
-                    "uri": "kafka://cediscoveryinterop.example.com:9093"
-                }
-            ],
             "protocoloptions": {
+                "deployed": false,
+                "endpoints": [
+                    {
+                        "bootstrap.servers": [
+                            "SSL://cediscoveryinterop.example.com:9093"
+                        ]
+                    }
+                ],
                 "topic": "mytopic",
                 "partition": 0
             },
@@ -131,13 +137,15 @@
             "channel": "mytopic",
             "usage": [ "consumer" ],
             "protocol": "KAFKA",
-            "deployed": false,
-            "endpoints": [
-                {
-                    "uri": "kafka://cediscoveryinterop.example.com:9093"
-                }
-            ],
             "protocoloptions": {
+                "deployed": false,
+                "endpoints": [
+                    {
+                        "bootstrap.servers": [
+                            "SSL://cediscoveryinterop.example.com:9093"
+                        ]
+                    }
+                ],
                 "topic": "mytopic",
                 "consumergroup": "mygroup"
             },

--- a/cloudevents/samples/scenarios/inkjet-proto3.xreg.json
+++ b/cloudevents/samples/scenarios/inkjet-proto3.xreg.json
@@ -147,7 +147,6 @@
             "schemas": {
                 "Fabrikam.InkJetPrinter.PrintJobStartedEventData": {
                     "format": "Protobuf/3",
-                    "defaultversionid": "1",
                     "versions": {
                         "1": {
                             "format": "Protobuf/3",
@@ -157,7 +156,6 @@
                 },
                 "Fabrikam.InkJetPrinter.PrintJobCompletedEventData": {
                     "format": "Protobuf/3",
-                    "defaultversionid": "1",
                     "versions": {
                         "1": {
                             "format": "Protobuf/3",
@@ -167,7 +165,6 @@
                 },
                 "Fabrikam.InkJetPrinter.InkLowEventData": {
                     "format": "Protobuf/3",
-                    "defaultversionid": "1",
                     "versions": {
                         "1": {
                             "format": "Protobuf/3",
@@ -177,7 +174,6 @@
                 },
                 "Fabrikam.InkJetPrinter.PaperJamEventData": {
                     "format": "Protobuf/3",
-                    "defaultversionid": "1",
                     "versions": {
                         "1": {
                             "format": "Protobuf/3",
@@ -187,7 +183,6 @@
                 },
                 "Fabrikam.InkJetPrinter.MaintenanceRequiredEventData": {
                     "format": "Protobuf/3",
-                    "defaultversionid": "1",
                     "versions": {
                         "1": {
                             "format": "Protobuf/3",

--- a/cloudevents/samples/scenarios/mqtt-sparkplugB.xreg.json
+++ b/cloudevents/samples/scenarios/mqtt-sparkplugB.xreg.json
@@ -6,9 +6,9 @@
         "producer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
       "protocoloptions": {
+        "deployed": false,
+        "endpoints": [],
         "cleansession": true,
         "willtopic": "spBv1.0/{group_id}/NDEATH/{edge_node_id}",
         "willmessage": "/messagegroups/Eclipse.SparkplugB.EdgeNode/messages/NDEATH"
@@ -24,9 +24,9 @@
         "consumer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
       "protocoloptions": {
+        "deployed": false,
+        "endpoints": [],
         "cleansession": true,
         "topicfilter": "spBv1.0/{group_id}/NCMD/{edge_node_id}",
         "qos": 1
@@ -42,9 +42,9 @@
         "consumer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
       "protocoloptions": {
+        "deployed": false,
+        "endpoints": [],
         "cleansession": true,
         "topicfilter": "spBv1.0/STATE/{sparkplug_host_id}",
         "qos": 1
@@ -59,9 +59,10 @@
         "producer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
-      "protocoloptions": {},
+      "protocoloptions": {
+        "deployed": false,
+        "endpoints": []
+      },
       "messagegroups": [
         "/messagegroups/Eclipse.SparkplugB.Device"
       ]
@@ -73,9 +74,9 @@
         "consumer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
       "protocoloptions": {
+        "deployed": false,
+        "endpoints": [],
         "cleansession": true,
         "topicfilter": "spBv1.0/{group_id}/DCMD/{edge_node_id}/{device_id}",
         "qos": 1
@@ -90,9 +91,9 @@
         "producer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
       "protocoloptions": {
+        "deployed": false,
+        "endpoints": [],
         "cleansession": true,
         "willtopic": "spBv1.0/STATE/{sparkplug_host_id}",
         "willmessage": "/messagegroups/Eclipse.SparkplugB.HostApplicationState/messages/STATE.Death"
@@ -110,9 +111,9 @@
         "consumer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
       "protocoloptions": {
+        "deployed": false,
+        "endpoints": [],
         "cleansession": true,
         "topicfilter": "spBv1.0/#",
         "qos": 1
@@ -129,9 +130,9 @@
         "consumer"
       ],
       "protocol": "MQTT/3.1.1",
-      "deployed": false,
-      "endpoints": [],
       "protocoloptions": {
+        "deployed": false,
+        "endpoints": [],
         "cleansession": true,
         "topicfilter": "spBv1.0/STATE/{sparkplug_host_id}",
         "qos": 1
@@ -154,8 +155,8 @@
             "qos": 0,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         },
         "NDATA": {
           "description": "Data payload for Sparkplug Edge Nodes",
@@ -165,8 +166,8 @@
             "qos": 0,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         },
         "NDEATH": {
           "description": "Death certificate for Sparkplug Edge Nodes, registered as the MQTT Will Message. Sparkplug requires Will QoS 1 and Will Retain false",
@@ -176,8 +177,8 @@
             "qos": 1,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         }
       }
     },
@@ -193,8 +194,8 @@
             "qos": 0,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         },
         "DDEATH": {
           "description": "Death certificate for Sparkplug Devices",
@@ -204,8 +205,8 @@
             "qos": 0,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         },
         "DDATA": {
           "description": "Device data telemetry message",
@@ -215,8 +216,8 @@
             "qos": 0,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         }
       }
     },
@@ -260,8 +261,8 @@
             "qos": 0,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         }
       }
     },
@@ -277,8 +278,8 @@
             "qos": 0,
             "retain": false
           },
-          "dataschemaformat": "Protobuf/2.0",
-          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0:Payload"
+          "dataschemaformat": "Protobuf/2",
+          "dataschemauri": "/schemagroups/Eclipse.Sparkplug/schemas/SparkplugB_Protobuf/versions/v1.0#Payload"
         }
       }
     }
@@ -353,11 +354,11 @@
         },
         "SparkplugB_Protobuf": {
           "description": "Eclipse Sparkplug B Schema",
-          "format": "Protobuf/2.0",
+          "format": "Protobuf/2",
           "versions": {
             "v1.0": {
               "description": "Eclipse Sparkplug B Schema Version 1.0",
-              "format": "Protobuf/2.0",
+              "format": "Protobuf/2",
               "schemaurl": "https://raw.githubusercontent.com/Cirrus-Link/Sparkplug/master/sparkplug_b/sparkplug_b.proto"
             }
           }

--- a/cloudevents/samples/schemas/schemastore_org.py
+++ b/cloudevents/samples/schemas/schemastore_org.py
@@ -38,7 +38,8 @@ def get_schema_draft(file_path):
         file_path (str): Path to the JSON file.
     
     Returns:
-        str: Detected JSON Schema draft version (e.g., "draft-07") or "unknown" if not found.
+        str or None: Detected JSON Schema draft version (e.g., "draft-07"),
+        or None if it cannot be identified.
     """
     try:
         with open(file_path, "r", encoding="utf-8") as f:
@@ -55,9 +56,9 @@ def get_schema_draft(file_path):
         elif "draft/2020-12" in schema_url:
             return "draft/2020-12"
         else:
-            return "unknown" if not schema_url else schema_url
-    except Exception as e:
-        return f"error: {e}"
+            return None
+    except Exception:
+        return None
 
 def group_files_by_base(directory):
     """
@@ -97,7 +98,8 @@ def build_registry(groups):
     """
     Constructs the registry document from the grouped file information.
     
-    Each version entry includes the "format" field set to "JSONSchema/Draft/<detected draft>".
+    Each version entry includes the "format" field when the JSON Schema draft
+    can be identified.
     
     Args:
         groups (dict): Grouped filenames with version and draft info.
@@ -118,13 +120,13 @@ def build_registry(groups):
     for base, versions in groups.items():
         version_entries = {}
         for ver, info in sorted(versions.items()):
-            # Capitalize the draft string (e.g. "draft-07" -> "Draft-07")
-            draft_cap = info["draft"].capitalize() if info["draft"] else "unknown"
-            version_entries[ver] = {
+            version_entry = {
                 "schemauri": BASE_URI + info["filename"],
-                "description": f"Schema for {info['filename']}",
-                "format": f"JSONSchema/{draft_cap}"
+                "description": f"Schema for {info['filename']}"
             }
+            if info["draft"]:
+                version_entry["format"] = f"JSONSchema/{info['draft'].capitalize()}"
+            version_entries[ver] = version_entry
         schemas[base] = {
             "versions": version_entries
         }

--- a/cloudevents/samples/schemas/schemastore_org.xreg.json
+++ b/cloudevents/samples/schemas/schemastore_org.xreg.json
@@ -595,8 +595,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/block.json",
-              "description": "Schema for block.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for block.json"
             }
           }
         },
@@ -2193,8 +2192,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/haxelib.json",
-              "description": "Schema for haxelib.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for haxelib.json"
             }
           }
         },
@@ -2633,8 +2631,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/ksp-avc.json",
-              "description": "Schema for ksp-avc.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for ksp-avc.json"
             }
           }
         },
@@ -2642,8 +2639,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/ksp-ckan.json",
-              "description": "Schema for ksp-ckan.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for ksp-ckan.json"
             }
           }
         },
@@ -2950,8 +2946,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/markdownlint.json",
-              "description": "Schema for markdownlint.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for markdownlint.json"
             }
           }
         },
@@ -3311,8 +3306,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/neoload.json",
-              "description": "Schema for neoload.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for neoload.json"
             }
           }
         },
@@ -4348,8 +4342,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/renovate.json",
-              "description": "Schema for renovate.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for renovate.json"
             }
           }
         },
@@ -4701,8 +4694,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/semgrep.json",
-              "description": "Schema for semgrep.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for semgrep.json"
             }
           }
         },
@@ -5008,8 +5000,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/taskfile.json",
-              "description": "Schema for taskfile.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for taskfile.json"
             }
           }
         },
@@ -5053,8 +5044,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/theme-v1.json",
-              "description": "Schema for theme-v1.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for theme-v1.json"
             }
           }
         },
@@ -5847,13 +5837,11 @@
           "versions": {
             "2.2": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/xunit-2.2.json",
-              "description": "Schema for xunit-2.2.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for xunit-2.2.json"
             },
             "2.3": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/xunit-2.3.json",
-              "description": "Schema for xunit-2.3.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for xunit-2.3.json"
             }
           }
         },
@@ -5861,8 +5849,7 @@
           "versions": {
             "1.0.0": {
               "schemauri": "https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/xunit.runner.schema.json",
-              "description": "Schema for xunit.runner.schema.json",
-              "format": "JSONSchema/Unknown"
+              "description": "Schema for xunit.runner.schema.json"
             }
           }
         },

--- a/core/model.md
+++ b/core/model.md
@@ -727,6 +727,9 @@ Note that this feature has similar results to setting the Resource attribute's
   that it MUST NOT exceed 57 characters (not 63).
 - MUST be unique across all Resources (plural and singular names) within the
   scope of its owning Group type.
+- When `hasdocument` is `true`, the derived `<RESOURCE>`, `<RESOURCE>base64`,
+  and `<RESOURCE>url` Version attribute names MUST NOT collide with
+  specification-defined Version attribute names.
 
 ### `groups.<STRING>.resources.<STRING>.description`
 - Type: String.

--- a/core/samples/README.md
+++ b/core/samples/README.md
@@ -34,15 +34,16 @@ the documents stored needs to be a first class concept in the model. So, in
 this case the "document" maps to the xRegistry "group" and the document
 "format" maps to the xRegistry "resource".
 
-In this model each document does not need to have a unique id for each format,
+In this model each document does not need to have a unique id for each rendition,
 rather in this scenario the document id (and often "name") will be the same for
-all formats. Thus the XID for a single document and format would look something
-like: `docs/form-1040/formats/pdf` and `docs/form-1040/formats/ms-word`.
-Each format of the documents can then be versioned as needed.
+all renditions. Thus the XID for a single document and rendition would look
+something like: `docs/form-1040/renditions/pdf` and
+`docs/form-1040/renditions/ms-word`. Each rendition of the documents can then
+be versioned as needed.
 
 Model:
 - Group: `docs` / `doc`
-  - Resources: `formats` / `format`
+  - Resources: `renditions` / `rendition`
 
 Files:
 - Model: [formatted-doc-store-model.json](formatted-doc-store-model.json)

--- a/core/samples/formatted-doc-store-data.json
+++ b/core/samples/formatted-doc-store-data.json
@@ -2,34 +2,34 @@
   "name": "Document Store Sample",
   "docs": {
     "newContract": {
-      "formats": {
+      "renditions": {
         "pdf": {
           "contenttype": "application/pdf",
-          "format": "This is form 1040 in pdf - not really pdf though"
+          "rendition": "This is form 1040 in pdf - not really pdf though"
         },
         "ms-word": {
           "versions": {
             "v1": {
               "contenttype": "application/ms-word",
-              "formatbase64": "YW4gb2xkIG1zLXdvcmQgZG9jCg=="
+              "renditionbase64": "YW4gb2xkIG1zLXdvcmQgZG9jCg=="
             },
             "v2": {
               "contenttype": "application/ms-word",
-              "formatbase64": "c29tZSBtcy13b3JkIGRvYwo="
+              "renditionbase64": "c29tZSBtcy13b3JkIGRvYwo="
             }
           }
         }
       }
     },
     "amendContract": {
-      "formats": {
+      "renditions": {
         "text": {
             "contenttype": "text/plain",
-            "format": "Please amend Joe's contract such that..."
+            "rendition": "Please amend Joe's contract such that..."
         },
         "html": {
             "contenttype": "text/html",
-            "format": "<html><body>Please amend Joe's contract such that...</body></html>"
+            "rendition": "<html><body>Please amend Joe's contract such that...</body></html>"
         }
       }
     }

--- a/core/samples/formatted-doc-store-model.json
+++ b/core/samples/formatted-doc-store-model.json
@@ -4,8 +4,8 @@
       "singular": "doc",
 
       "resources": {
-        "formats": {
-          "singular": "format"
+        "renditions": {
+          "singular": "rendition"
         }
       }
     }

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -594,8 +594,10 @@ with the declared version.
 A URI, like the Message Registry's
 [`dataschemauri`](../message/spec.md#dataschemauri), that points to a Protobuf
 Schema document MUST reference a Protobuf `message` declaration contained in the
-schema document using a URI fragment suffix `[:]{message-name}`. The ':'
-character is used as a separator when the URI already contains a fragment.
+schema document. If the URI does not contain a fragment, the message name MUST
+be appended as a URI fragment using `#{message-name}`. If the URI already
+contains a fragment, the message name MUST be appended to the fragment using
+`:{message-name}`.
 
 Examples:
 


### PR DESCRIPTION
## Summary

- move endpoint deployment and address data into `protocoloptions`, including Kafka `bootstrap.servers`
- use the defined AMQP option names and Protobuf format identifier
- clarify `#` versus `:` Protobuf message fragment separators
- remove inert resource defaults and unidentified SchemaStore formats
- prevent derived document attributes from colliding with Version attributes and rename the colliding sample resource

Fixes #536

## PR relationship

This PR is based directly on `main`. Draft PR #565 separately fixes strict conformance failures in some of the same generated/sample files. Merge or rebase #565 first, then resolve the small overlapping hunks here; the concerns remain intentionally separated for review.

The legacy Contoso CRM sample migration/removal is handled by #565 and is not duplicated here.

## Validation

- 52 Python tests passed
- `py -3 tools/verify.py core`
- `py -3 tools/verify.py cloudevents`
- `py -3 tools/verify.py schema`
- all 14 sample JSON documents parse
- explicit endpoint, format, fragment, generator, and removal assertions pass