### PR TITLE
Add generated JSON Structure schemas

### DIFF
--- a/cloudevents/schemas/document-schema.struct.json
+++ b/cloudevents/schemas/document-schema.struct.json
@@ -1,0 +1,1506 @@
+{
+  "$schema": "https://json-structure.org/meta/extended/v0/#",
+  "$id": "https://xregistry.io/xreg/xregistryspecs/cloudevents-v1/schemas/document-schema.struct.json",
+  "$uses": [
+    "JSONStructureAlternateNames"
+  ],
+  "name": "CloudEventsRegistryDocument",
+  "type": "object",
+  "properties": {
+    "messagegroups": {
+      "type": "map",
+      "values": {
+        "type": {
+          "$ref": "#/definitions/Messagegroups/Messagegroup"
+        }
+      }
+    },
+    "endpoints": {
+      "type": "map",
+      "values": {
+        "type": {
+          "$ref": "#/definitions/Endpoints/Endpoint"
+        }
+      }
+    },
+    "schemagroups": {
+      "type": "map",
+      "values": {
+        "type": {
+          "$ref": "#/definitions/Schemagroups/Schemagroup"
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Messagegroups": {
+      "MessageProtocoloptionsApplicationPropertiesValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The application property type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Application property value"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Application property required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsMessageAnnotationsValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The message annotation type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Annotation value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Annotation required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsDeliveryAnnotationsValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The annotation type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Annotation value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Annotation required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsFooterValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "AMQP footer type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Footer value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Footer required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "messageid": {
+            "type": "string",
+            "description": "ID of the message object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "basemessageuri": {
+            "type": "uri",
+            "description": "Reference to a base definition for this definition. Relative references are XIDs within the same registry. Absolute URIs reference message definitions in external registries. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups. The predefined envelope format is 'CloudEvents/1.0'"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+          },
+          "dataschemaformat": {
+            "type": "string",
+            "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
+          },
+          "dataschema": {
+            "type": "any",
+            "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
+          },
+          "dataschemauri": {
+            "type": "uri",
+            "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
+          },
+          "dataschemaxid": {
+            "type": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
+          "datacontenttype": {
+            "type": "string",
+            "description": "The content type for the message payload"
+          },
+          "envelopemetadata": {
+            "type": "object",
+            "properties": {
+              "specversion": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents spec version (fixed to '1.0')",
+                    "enum": [
+                      "1.0"
+                    ]
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents specversion is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents specversion https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#specversion"
+              },
+              "id": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents id value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents id is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents id https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id"
+              },
+              "type": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents type value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents type is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents type https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type"
+              },
+              "source": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents source value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents source is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents source https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source-1"
+              },
+              "subject": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents subject value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents subject required"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents subject https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject"
+              },
+              "time": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "timestamp"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The timestamp value constraint."
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents time https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time"
+              },
+              "dataschema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The URI value constraint"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents dataschema https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema. The URI of the schema for the event payload. Absence indicates no known schema. This attribute corresponds to the 'dataschemauri' attribute in the message definition and MUST be the same as the 'dataschemauri' attribute of the definition if present."
+              },
+              "datacontenttype": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The content type value constraint"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents datacontenttype https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#datacontenttype."
+              }
+            },
+            "additionalProperties": false,
+            "description": "CloudEvents attribute declarations, adding constraints to the CloudEvents envelope not yet covered by the CloudEvents spec https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md"
+          },
+          "envelopeoptions": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "description": "Whether CloudEvents 'binary' or 'structured' mode will be used",
+                "enum": [
+                  "binary",
+                  "structured"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+              }
+            },
+            "additionalProperties": true,
+            "description": "Envelope metadata constraints"
+          },
+          "protocoloptions": {
+            "type": "object",
+            "properties": {
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "messageId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.message-id type constraint. The type values refer to the AMQP type model` and the defined message-id types",
+                        "enum": [
+                          "ulong",
+                          "uuid",
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.message-id value constraint. "
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.message-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.message-id",
+                    "altnames": {
+                      "json": "message-id"
+                    }
+                  },
+                  "userId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.user-id value type",
+                        "enum": [
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.user-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.user-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.user-id",
+                    "altnames": {
+                      "json": "user-id"
+                    }
+                  },
+                  "to": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.to value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.to value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.to required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.to"
+                  },
+                  "subject": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.subject value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.subject value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.subject required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.subject"
+                  },
+                  "replyTo": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.reply-to required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.reply-to",
+                    "altnames": {
+                      "json": "reply-to"
+                    }
+                  },
+                  "correlationId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value type",
+                        "enum": [
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP correlation-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.correlation-id",
+                    "altnames": {
+                      "json": "correlation-id"
+                    }
+                  },
+                  "contentType": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.content-type value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.content-type value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.content-type required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.content-type",
+                    "altnames": {
+                      "json": "content-type"
+                    }
+                  },
+                  "contentEncoding": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.content-encoding value type",
+                        "enum": [
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.content-encoding value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.content-encoding required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.content-encoding",
+                    "altnames": {
+                      "json": "content-encoding"
+                    }
+                  },
+                  "absoluteExpiryTime": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.absolute-expiry-time value type",
+                        "enum": [
+                          "timestamp"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.absolute-expiry-time value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.absolute-expiry-time required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.absolute-expiry-time",
+                    "altnames": {
+                      "json": "absolute-expiry-time"
+                    }
+                  },
+                  "creationTime": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.creation-time value type",
+                        "enum": [
+                          "timestamp"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.creation-time value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.creation-time required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.creation-time",
+                    "altnames": {
+                      "json": "creation-time"
+                    }
+                  },
+                  "groupId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.group-id value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.group-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.group-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.group-id",
+                    "altnames": {
+                      "json": "group-id"
+                    }
+                  },
+                  "groupSequence": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value type",
+                        "enum": [
+                          "integer"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP group-sequence required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP group-sequence",
+                    "altnames": {
+                      "json": "group-sequence"
+                    }
+                  },
+                  "replyToGroupId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to-group-id value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to-group-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.reply-to-group-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.reply-to-group-id",
+                    "altnames": {
+                      "json": "reply-to-group-id"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "description": "AMQP properties section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties"
+              },
+              "applicationProperties": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsApplicationPropertiesValue"
+                  }
+                },
+                "description": "AMQP application-properties section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties",
+                "altnames": {
+                  "json": "application-properties"
+                }
+              },
+              "messageAnnotations": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsMessageAnnotationsValue"
+                  }
+                },
+                "description": "AMQP message-annotations section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-message-annotations",
+                "altnames": {
+                  "json": "message-annotations"
+                }
+              },
+              "deliveryAnnotations": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsDeliveryAnnotationsValue"
+                  }
+                },
+                "description": "AMQP delivery-annotations section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-delivery-annotations",
+                "altnames": {
+                  "json": "delivery-annotations"
+                }
+              },
+              "header": {
+                "type": "object",
+                "properties": {
+                  "durable": {
+                    "type": "boolean",
+                    "description": "AMQP durable flag"
+                  },
+                  "priority": {
+                    "type": "integer",
+                    "description": "AMQP priority"
+                  },
+                  "ttl": {
+                    "type": "integer",
+                    "description": "AMQP time-to-live (milliseconds)"
+                  },
+                  "firstAcquirer": {
+                    "type": "boolean",
+                    "description": "AMQP first-acquirer flag",
+                    "altnames": {
+                      "json": "first-acquirer"
+                    }
+                  },
+                  "deliveryCount": {
+                    "type": "integer",
+                    "description": "AMQP delivery-count",
+                    "altnames": {
+                      "json": "delivery-count"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "description": "AMQP header section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header"
+              },
+              "footer": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsFooterValue"
+                  }
+                },
+                "description": "AMQP footer section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-footer"
+              }
+            },
+            "additionalProperties": false,
+            "description": "AMQP message metadata constraints"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Messagegroup": {
+        "type": "object",
+        "properties": {
+          "messagegroupid": {
+            "type": "string",
+            "description": "ID of the messagegroup object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted. The predefined envelope format is CloudEvents/1.0"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted. Predefined protocol formats are 'AMQP/1.0', 'MQTT/3.1.1', 'MQTT/5.0', 'KAFKA', 'HTTP', and 'NATS'"
+          },
+          "messages": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Messagegroups/Message"
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "Schemagroups": {
+      "SchemaVersion": {
+        "type": "object",
+        "properties": {
+          "versionid": {
+            "type": "string",
+            "description": "ID of the schema version"
+          },
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "format": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "any"
+          },
+          "schemabase64": {
+            "type": "binary"
+          },
+          "schemaurl": {
+            "type": "uri"
+          }
+        },
+        "additionalProperties": true,
+        "required": [
+          "format"
+        ]
+      },
+      "Schema": {
+        "type": "object",
+        "properties": {
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "schema": {
+            "type": "any",
+            "description": "Embedded schema document"
+          },
+          "schemabase64": {
+            "type": "binary",
+            "description": "Base64-encoded schema document"
+          },
+          "schemaurl": {
+            "type": "uri",
+            "description": "URL of the schema document"
+          },
+          "versionsurl": {
+            "type": "uri"
+          },
+          "versionscount": {
+            "type": "uint32"
+          },
+          "versions": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Schemagroups/SchemaVersion"
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Schemagroup": {
+        "type": "object",
+        "properties": {
+          "schemagroupid": {
+            "type": "string",
+            "description": "ID of the schemagroup object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "format": {
+            "type": "string"
+          },
+          "schemas": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Schemagroups/Schema"
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "Endpoints": {
+      "EndpointProtocoloptionsEndpointsItem": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "uri",
+            "description": "AMQP Addressing URI"
+          }
+        },
+        "additionalProperties": true
+      },
+      "EndpointProtocoloptionsAuthorizationItem": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+          },
+          "mechanism": {
+            "type": "string",
+            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
+          },
+          "resourceuri": {
+            "type": "uri",
+            "description": "The resource uri for which authorization shall be granted (if applicable)"
+          },
+          "authorityuri": {
+            "type": "uri",
+            "description": "The authority uri where authorization shall be requested (if applicable)"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Endpoint": {
+        "type": "object",
+        "properties": {
+          "endpointid": {
+            "type": "string",
+            "description": "ID of the endpoint object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "usage": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "subscriber",
+                "consumer",
+                "producer"
+              ]
+            },
+            "description": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous.",
+            "enum": [
+              "subscriber",
+              "consumer",
+              "producer"
+            ]
+          },
+          "channel": {
+            "type": "string",
+            "description": "The name of the channel"
+          },
+          "deprecated": {
+            "type": "object",
+            "properties": {
+              "effective": {
+                "type": "datetime",
+                "description": "tbd"
+              },
+              "removal": {
+                "type": "datetime",
+                "description": "tbd"
+              },
+              "alternative": {
+                "type": "uri",
+                "description": "tbd"
+              },
+              "docs": {
+                "type": "uri",
+                "description": "tbd"
+              }
+            },
+            "additionalProperties": true,
+            "description": "Indicates whether the endpoint is deprecated"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Envelope metadata format identifier. If set, all definitions MUST use this format value"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value"
+          },
+          "messagegroups": {
+            "type": "array",
+            "items": {
+              "type": "uri"
+            },
+            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries."
+          },
+          "envelopeoptions": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "binary",
+                  "structured"
+                ]
+              },
+              "format": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true,
+            "description": "Envelope metadata constraints"
+          },
+          "protocoloptions": {
+            "type": "object",
+            "properties": {
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": {
+                    "$ref": "#/definitions/Endpoints/EndpointProtocoloptionsEndpointsItem"
+                  }
+                },
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific"
+              },
+              "authorization": {
+                "type": "array",
+                "items": {
+                  "type": {
+                    "$ref": "#/definitions/Endpoints/EndpointProtocoloptionsAuthorizationItem"
+                  }
+                },
+                "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration"
+              },
+              "deployed": {
+                "type": "boolean",
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
+              },
+              "node": {
+                "type": "string",
+                "description": "The AMQP node name. Commonly the name of a queue or a topic. Corresponds to the 'address' in source or target of the attach frame."
+              },
+              "durable": {
+                "type": "boolean",
+                "description": "Whether the AMQP node identified by 'node' is durable rather than transient. This is a property of the node, not of the link terminus and not of the message header field of the same name. Terminus durability is expressed by 'terminus-durability'"
+              },
+              "linkProperties": {
+                "type": "map",
+                "values": {
+                  "type": "string"
+                },
+                "description": "An optional map of AMQP link properties to use with the endpoint",
+                "altnames": {
+                  "json": "link-properties"
+                }
+              },
+              "connectionProperties": {
+                "type": "map",
+                "values": {
+                  "type": "string"
+                },
+                "description": "An optional map of AMQP connection properties to use with the endpoint",
+                "altnames": {
+                  "json": "connection-properties"
+                }
+              },
+              "distributionMode": {
+                "type": "string",
+                "description": "The AMQP source distribution mode. 'move' means a transferred message is removed from the node and is therefore seen by only one receiver. 'copy' means the message remains at the node after transfer and may also be transferred to other receivers. This does not describe message locking",
+                "enum": [
+                  "move",
+                  "copy"
+                ],
+                "altnames": {
+                  "json": "distribution-mode"
+                }
+              },
+              "connectionCapabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The AMQP capabilities to use with the endpoint",
+                "altnames": {
+                  "json": "connection-capabilities"
+                }
+              },
+              "nodeCapabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The AMQP node capabilities to use with the endpoint",
+                "altnames": {
+                  "json": "node-capabilities"
+                }
+              },
+              "sourceFilters": {
+                "type": "map",
+                "values": {
+                  "type": "any"
+                },
+                "description": "AMQP source filters used for subscription/receive setup",
+                "altnames": {
+                  "json": "source-filters"
+                }
+              },
+              "dynamic": {
+                "type": "boolean",
+                "description": "Whether a dynamic source or target is requested"
+              },
+              "terminusDurability": {
+                "type": "string",
+                "description": "Durability mode for the applicable source/target terminus",
+                "enum": [
+                  "none",
+                  "configuration",
+                  "unsettled-state"
+                ],
+                "altnames": {
+                  "json": "terminus-durability"
+                }
+              },
+              "expiryPolicy": {
+                "type": "string",
+                "description": "Expiry policy for the applicable source/target terminus",
+                "enum": [
+                  "link-detach",
+                  "session-end",
+                  "connection-close",
+                  "never"
+                ],
+                "altnames": {
+                  "json": "expiry-policy"
+                }
+              },
+              "timeout": {
+                "type": "uint32",
+                "description": "Timeout in seconds for the applicable expiry policy"
+              },
+              "senderSettleMode": {
+                "type": "string",
+                "description": "AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the client for a producer endpoint, the remote node for a consumer endpoint",
+                "enum": [
+                  "unsettled",
+                  "settled",
+                  "mixed"
+                ],
+                "altnames": {
+                  "json": "sender-settle-mode"
+                }
+              },
+              "receiverSettleMode": {
+                "type": "string",
+                "description": "AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a producer endpoint, the client for a consumer endpoint",
+                "enum": [
+                  "first",
+                  "second"
+                ],
+                "altnames": {
+                  "json": "receiver-settle-mode"
+                }
+              }
+            },
+            "additionalProperties": true,
+            "description": "Configuration information for this endpoint"
+          },
+          "messages": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Messagegroups/Message"
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/endpoint/schemas/document-schema.struct.json
+++ b/endpoint/schemas/document-schema.struct.json
@@ -1,0 +1,1296 @@
+{
+  "$schema": "https://json-structure.org/meta/extended/v0/#",
+  "$id": "https://xregistry.io/xreg/xregistryspecs/endpoint-v1/schemas/document-schema.struct.json",
+  "$uses": [
+    "JSONStructureAlternateNames"
+  ],
+  "name": "EndpointRegistryDocument",
+  "type": "object",
+  "properties": {
+    "messagegroups": {
+      "type": "map",
+      "values": {
+        "type": {
+          "$ref": "#/definitions/Messagegroups/Messagegroup"
+        }
+      }
+    },
+    "endpoints": {
+      "type": "map",
+      "values": {
+        "type": {
+          "$ref": "#/definitions/Endpoints/Endpoint"
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Messagegroups": {
+      "MessageProtocoloptionsApplicationPropertiesValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The application property type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Application property value"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Application property required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsMessageAnnotationsValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The message annotation type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Annotation value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Annotation required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsDeliveryAnnotationsValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The annotation type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Annotation value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Annotation required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsFooterValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "AMQP footer type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Footer value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Footer required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "messageid": {
+            "type": "string",
+            "description": "ID of the message object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "basemessageuri": {
+            "type": "uri",
+            "description": "Reference to a base definition for this definition. Relative references are XIDs within the same registry. Absolute URIs reference message definitions in external registries. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups. The predefined envelope format is 'CloudEvents/1.0'"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+          },
+          "dataschemaformat": {
+            "type": "string",
+            "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
+          },
+          "dataschema": {
+            "type": "any",
+            "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
+          },
+          "dataschemauri": {
+            "type": "uri",
+            "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
+          },
+          "dataschemaxid": {
+            "type": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
+          "datacontenttype": {
+            "type": "string",
+            "description": "The content type for the message payload"
+          },
+          "envelopemetadata": {
+            "type": "object",
+            "properties": {
+              "specversion": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents spec version (fixed to '1.0')",
+                    "enum": [
+                      "1.0"
+                    ]
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents specversion is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents specversion https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#specversion"
+              },
+              "id": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents id value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents id is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents id https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id"
+              },
+              "type": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents type value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents type is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents type https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type"
+              },
+              "source": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents source value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents source is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents source https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source-1"
+              },
+              "subject": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents subject value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents subject required"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents subject https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject"
+              },
+              "time": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "timestamp"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The timestamp value constraint."
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents time https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time"
+              },
+              "dataschema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The URI value constraint"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents dataschema https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema. The URI of the schema for the event payload. Absence indicates no known schema. This attribute corresponds to the 'dataschemauri' attribute in the message definition and MUST be the same as the 'dataschemauri' attribute of the definition if present."
+              },
+              "datacontenttype": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The content type value constraint"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents datacontenttype https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#datacontenttype."
+              }
+            },
+            "additionalProperties": false,
+            "description": "CloudEvents attribute declarations, adding constraints to the CloudEvents envelope not yet covered by the CloudEvents spec https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md"
+          },
+          "envelopeoptions": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "description": "Whether CloudEvents 'binary' or 'structured' mode will be used",
+                "enum": [
+                  "binary",
+                  "structured"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+              }
+            },
+            "additionalProperties": true,
+            "description": "Envelope metadata constraints"
+          },
+          "protocoloptions": {
+            "type": "object",
+            "properties": {
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "messageId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.message-id type constraint. The type values refer to the AMQP type model` and the defined message-id types",
+                        "enum": [
+                          "ulong",
+                          "uuid",
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.message-id value constraint. "
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.message-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.message-id",
+                    "altnames": {
+                      "json": "message-id"
+                    }
+                  },
+                  "userId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.user-id value type",
+                        "enum": [
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.user-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.user-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.user-id",
+                    "altnames": {
+                      "json": "user-id"
+                    }
+                  },
+                  "to": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.to value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.to value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.to required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.to"
+                  },
+                  "subject": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.subject value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.subject value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.subject required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.subject"
+                  },
+                  "replyTo": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.reply-to required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.reply-to",
+                    "altnames": {
+                      "json": "reply-to"
+                    }
+                  },
+                  "correlationId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value type",
+                        "enum": [
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP correlation-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.correlation-id",
+                    "altnames": {
+                      "json": "correlation-id"
+                    }
+                  },
+                  "contentType": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.content-type value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.content-type value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.content-type required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.content-type",
+                    "altnames": {
+                      "json": "content-type"
+                    }
+                  },
+                  "contentEncoding": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.content-encoding value type",
+                        "enum": [
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.content-encoding value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.content-encoding required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.content-encoding",
+                    "altnames": {
+                      "json": "content-encoding"
+                    }
+                  },
+                  "absoluteExpiryTime": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.absolute-expiry-time value type",
+                        "enum": [
+                          "timestamp"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.absolute-expiry-time value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.absolute-expiry-time required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.absolute-expiry-time",
+                    "altnames": {
+                      "json": "absolute-expiry-time"
+                    }
+                  },
+                  "creationTime": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.creation-time value type",
+                        "enum": [
+                          "timestamp"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.creation-time value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.creation-time required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.creation-time",
+                    "altnames": {
+                      "json": "creation-time"
+                    }
+                  },
+                  "groupId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.group-id value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.group-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.group-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.group-id",
+                    "altnames": {
+                      "json": "group-id"
+                    }
+                  },
+                  "groupSequence": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value type",
+                        "enum": [
+                          "integer"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP group-sequence required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP group-sequence",
+                    "altnames": {
+                      "json": "group-sequence"
+                    }
+                  },
+                  "replyToGroupId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to-group-id value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to-group-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.reply-to-group-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.reply-to-group-id",
+                    "altnames": {
+                      "json": "reply-to-group-id"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "description": "AMQP properties section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties"
+              },
+              "applicationProperties": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsApplicationPropertiesValue"
+                  }
+                },
+                "description": "AMQP application-properties section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties",
+                "altnames": {
+                  "json": "application-properties"
+                }
+              },
+              "messageAnnotations": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsMessageAnnotationsValue"
+                  }
+                },
+                "description": "AMQP message-annotations section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-message-annotations",
+                "altnames": {
+                  "json": "message-annotations"
+                }
+              },
+              "deliveryAnnotations": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsDeliveryAnnotationsValue"
+                  }
+                },
+                "description": "AMQP delivery-annotations section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-delivery-annotations",
+                "altnames": {
+                  "json": "delivery-annotations"
+                }
+              },
+              "header": {
+                "type": "object",
+                "properties": {
+                  "durable": {
+                    "type": "boolean",
+                    "description": "AMQP durable flag"
+                  },
+                  "priority": {
+                    "type": "integer",
+                    "description": "AMQP priority"
+                  },
+                  "ttl": {
+                    "type": "integer",
+                    "description": "AMQP time-to-live (milliseconds)"
+                  },
+                  "firstAcquirer": {
+                    "type": "boolean",
+                    "description": "AMQP first-acquirer flag",
+                    "altnames": {
+                      "json": "first-acquirer"
+                    }
+                  },
+                  "deliveryCount": {
+                    "type": "integer",
+                    "description": "AMQP delivery-count",
+                    "altnames": {
+                      "json": "delivery-count"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "description": "AMQP header section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header"
+              },
+              "footer": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsFooterValue"
+                  }
+                },
+                "description": "AMQP footer section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-footer"
+              }
+            },
+            "additionalProperties": false,
+            "description": "AMQP message metadata constraints"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Messagegroup": {
+        "type": "object",
+        "properties": {
+          "messagegroupid": {
+            "type": "string",
+            "description": "ID of the messagegroup object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted. The predefined envelope format is CloudEvents/1.0"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted. Predefined protocol formats are 'AMQP/1.0', 'MQTT/3.1.1', 'MQTT/5.0', 'KAFKA', 'HTTP', and 'NATS'"
+          },
+          "messages": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Messagegroups/Message"
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "Endpoints": {
+      "EndpointProtocoloptionsEndpointsItem": {
+        "type": "object",
+        "properties": {
+          "uri": {
+            "type": "uri",
+            "description": "AMQP Addressing URI"
+          }
+        },
+        "additionalProperties": true
+      },
+      "EndpointProtocoloptionsAuthorizationItem": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "The authentication/authorization type. OAuth2, Plain, APIKey, X509Cert, and SASL are well-defined"
+          },
+          "mechanism": {
+            "type": "string",
+            "description": "The SASL mechanism name when authorization.type is SASL (for example PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, or EXTERNAL)"
+          },
+          "resourceuri": {
+            "type": "uri",
+            "description": "The resource uri for which authorization shall be granted (if applicable)"
+          },
+          "authorityuri": {
+            "type": "uri",
+            "description": "The authority uri where authorization shall be requested (if applicable)"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Endpoint": {
+        "type": "object",
+        "properties": {
+          "endpointid": {
+            "type": "string",
+            "description": "ID of the endpoint object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "usage": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "subscriber",
+                "consumer",
+                "producer"
+              ]
+            },
+            "description": "Client's expected usage of this endpoint. Single-role declarations are preferred. Mixed declarations are guidance-oriented metadata and should be used only when role semantics are unambiguous.",
+            "enum": [
+              "subscriber",
+              "consumer",
+              "producer"
+            ]
+          },
+          "channel": {
+            "type": "string",
+            "description": "The name of the channel"
+          },
+          "deprecated": {
+            "type": "object",
+            "properties": {
+              "effective": {
+                "type": "datetime",
+                "description": "tbd"
+              },
+              "removal": {
+                "type": "datetime",
+                "description": "tbd"
+              },
+              "alternative": {
+                "type": "uri",
+                "description": "tbd"
+              },
+              "docs": {
+                "type": "uri",
+                "description": "tbd"
+              }
+            },
+            "additionalProperties": true,
+            "description": "Indicates whether the endpoint is deprecated"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Envelope metadata format identifier. If set, all definitions MUST use this format value"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Endpoint protocol identifier. If set, all definitions MUST use this protocol value"
+          },
+          "messagegroups": {
+            "type": "array",
+            "items": {
+              "type": "uri"
+            },
+            "description": "The message groups that are supported by this endpoint. Relative references are XIDs within the same registry. Absolute URIs reference message groups in external registries."
+          },
+          "envelopeoptions": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "binary",
+                  "structured"
+                ]
+              },
+              "format": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true,
+            "description": "Envelope metadata constraints"
+          },
+          "protocoloptions": {
+            "type": "object",
+            "properties": {
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": {
+                    "$ref": "#/definitions/Endpoints/EndpointProtocoloptionsEndpointsItem"
+                  }
+                },
+                "description": "The network addresses that are for communication with the endpoint. The endpoints are ordered by preference, with the first endpoint being the preferred endpoint. Some protocol implementations might not support multiple endpoints, in which case all but the first endpoint might be ignored. Whether the URI just identifies a network host or links directly to a resource managed by the network host is protocol specific"
+              },
+              "authorization": {
+                "type": "array",
+                "items": {
+                  "type": {
+                    "$ref": "#/definitions/Endpoints/EndpointProtocoloptionsAuthorizationItem"
+                  }
+                },
+                "description": "Authorization options. These are hints for the adapter for interacting with the authorization endpoint. This is not a credentials configuration"
+              },
+              "deployed": {
+                "type": "boolean",
+                "description": "If `true`, the endpoint metadata represents a public endpoint that is expected to be available for communication"
+              },
+              "node": {
+                "type": "string",
+                "description": "The AMQP node name. Commonly the name of a queue or a topic. Corresponds to the 'address' in source or target of the attach frame."
+              },
+              "durable": {
+                "type": "boolean",
+                "description": "Whether the AMQP node identified by 'node' is durable rather than transient. This is a property of the node, not of the link terminus and not of the message header field of the same name. Terminus durability is expressed by 'terminus-durability'"
+              },
+              "linkProperties": {
+                "type": "map",
+                "values": {
+                  "type": "string"
+                },
+                "description": "An optional map of AMQP link properties to use with the endpoint",
+                "altnames": {
+                  "json": "link-properties"
+                }
+              },
+              "connectionProperties": {
+                "type": "map",
+                "values": {
+                  "type": "string"
+                },
+                "description": "An optional map of AMQP connection properties to use with the endpoint",
+                "altnames": {
+                  "json": "connection-properties"
+                }
+              },
+              "distributionMode": {
+                "type": "string",
+                "description": "The AMQP source distribution mode. 'move' means a transferred message is removed from the node and is therefore seen by only one receiver. 'copy' means the message remains at the node after transfer and may also be transferred to other receivers. This does not describe message locking",
+                "enum": [
+                  "move",
+                  "copy"
+                ],
+                "altnames": {
+                  "json": "distribution-mode"
+                }
+              },
+              "connectionCapabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The AMQP capabilities to use with the endpoint",
+                "altnames": {
+                  "json": "connection-capabilities"
+                }
+              },
+              "nodeCapabilities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "The AMQP node capabilities to use with the endpoint",
+                "altnames": {
+                  "json": "node-capabilities"
+                }
+              },
+              "sourceFilters": {
+                "type": "map",
+                "values": {
+                  "type": "any"
+                },
+                "description": "AMQP source filters used for subscription/receive setup",
+                "altnames": {
+                  "json": "source-filters"
+                }
+              },
+              "dynamic": {
+                "type": "boolean",
+                "description": "Whether a dynamic source or target is requested"
+              },
+              "terminusDurability": {
+                "type": "string",
+                "description": "Durability mode for the applicable source/target terminus",
+                "enum": [
+                  "none",
+                  "configuration",
+                  "unsettled-state"
+                ],
+                "altnames": {
+                  "json": "terminus-durability"
+                }
+              },
+              "expiryPolicy": {
+                "type": "string",
+                "description": "Expiry policy for the applicable source/target terminus",
+                "enum": [
+                  "link-detach",
+                  "session-end",
+                  "connection-close",
+                  "never"
+                ],
+                "altnames": {
+                  "json": "expiry-policy"
+                }
+              },
+              "timeout": {
+                "type": "uint32",
+                "description": "Timeout in seconds for the applicable expiry policy"
+              },
+              "senderSettleMode": {
+                "type": "string",
+                "description": "AMQP sender settle mode requested for the link. It constrains the party that sends transfers over the link: the client for a producer endpoint, the remote node for a consumer endpoint",
+                "enum": [
+                  "unsettled",
+                  "settled",
+                  "mixed"
+                ],
+                "altnames": {
+                  "json": "sender-settle-mode"
+                }
+              },
+              "receiverSettleMode": {
+                "type": "string",
+                "description": "AMQP receiver settle mode requested for the link. It constrains the party that receives transfers over the link: the remote node for a producer endpoint, the client for a consumer endpoint",
+                "enum": [
+                  "first",
+                  "second"
+                ],
+                "altnames": {
+                  "json": "receiver-settle-mode"
+                }
+              }
+            },
+            "additionalProperties": true,
+            "description": "Configuration information for this endpoint"
+          },
+          "messages": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Messagegroups/Message"
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/message/schemas/document-schema.struct.json
+++ b/message/schemas/document-schema.struct.json
@@ -1,0 +1,968 @@
+{
+  "$schema": "https://json-structure.org/meta/extended/v0/#",
+  "$id": "https://xregistry.io/xreg/xregistryspecs/message-v1/schemas/document-schema.struct.json",
+  "$uses": [
+    "JSONStructureAlternateNames"
+  ],
+  "name": "MessageRegistryDocument",
+  "type": "object",
+  "properties": {
+    "messagegroups": {
+      "type": "map",
+      "values": {
+        "type": {
+          "$ref": "#/definitions/Messagegroups/Messagegroup"
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Messagegroups": {
+      "MessageProtocoloptionsApplicationPropertiesValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The application property type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Application property value"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Application property required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsMessageAnnotationsValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The message annotation type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Annotation value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Annotation required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsDeliveryAnnotationsValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "The annotation type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Annotation value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Annotation required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MessageProtocoloptionsFooterValue": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "AMQP footer type",
+            "enum": [
+              "string",
+              "uritemplate",
+              "integer",
+              "number",
+              "boolean"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "description": "Footer value constraint"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Footer required"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Message": {
+        "type": "object",
+        "properties": {
+          "messageid": {
+            "type": "string",
+            "description": "ID of the message object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "basemessageuri": {
+            "type": "uri",
+            "description": "Reference to a base definition for this definition. Relative references are XIDs within the same registry. Absolute URIs reference message definitions in external registries. The base definition is overridden by this definition. If not present, this definition does not override any base definition"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Message envelope format identifier. This attribute MUST be the same as the 'envelope' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups. The predefined envelope format is 'CloudEvents/1.0'"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Protocol identifier. This attribute MUST be the same as the 'protocol' attribute of the definition group, but is not automatically inherited because definitions may be cross-referenced across groups"
+          },
+          "dataschemaformat": {
+            "type": "string",
+            "description": "The schema format applicable to the message payload, equivalent to the 'format' attribute of the schema registry"
+          },
+          "dataschema": {
+            "type": "any",
+            "description": "The inline schema for the message payload, equivalent to the 'schema' attribute of the schema registry"
+          },
+          "dataschemauri": {
+            "type": "uri",
+            "description": "The URI of the schema for the message payload, equivalent to the 'schemauri' attribute of the schema registry"
+          },
+          "dataschemaxid": {
+            "type": "uri",
+            "description": "Contains the xid of the xRegistry schema Resource entity associated with the dataschemauri referenced schema document. Note that this means the entity MUST be located within the same Registry."
+          },
+          "datacontenttype": {
+            "type": "string",
+            "description": "The content type for the message payload"
+          },
+          "envelopemetadata": {
+            "type": "object",
+            "properties": {
+              "specversion": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents spec version (fixed to '1.0')",
+                    "enum": [
+                      "1.0"
+                    ]
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents specversion is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents specversion https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#specversion"
+              },
+              "id": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents id value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents id is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents id https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#id"
+              },
+              "type": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents type value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents type is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents type https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type"
+              },
+              "source": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents source value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents source is always required",
+                    "enum": [
+                      true
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents source https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#source-1"
+              },
+              "subject": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "uritemplate",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "CloudEvents subject value constraint"
+                  },
+                  "required": {
+                    "type": "boolean",
+                    "description": "CloudEvents subject required"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents subject https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#subject"
+              },
+              "time": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "timestamp"
+                    ]
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The timestamp value constraint."
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents time https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#time"
+              },
+              "dataschema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The URI value constraint"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents dataschema https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#dataschema. The URI of the schema for the event payload. Absence indicates no known schema. This attribute corresponds to the 'dataschemauri' attribute in the message definition and MUST be the same as the 'dataschemauri' attribute of the definition if present."
+              },
+              "datacontenttype": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The content type value constraint"
+                  },
+                  "required": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false,
+                "description": "CloudEvents datacontenttype https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#datacontenttype."
+              }
+            },
+            "additionalProperties": false,
+            "description": "CloudEvents attribute declarations, adding constraints to the CloudEvents envelope not yet covered by the CloudEvents spec https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md"
+          },
+          "envelopeoptions": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "description": "Whether CloudEvents 'binary' or 'structured' mode will be used",
+                "enum": [
+                  "binary",
+                  "structured"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "description": "The media type format used to serialize the CloudEvent in the case of mode=structured"
+              }
+            },
+            "additionalProperties": true,
+            "description": "Envelope metadata constraints"
+          },
+          "protocoloptions": {
+            "type": "object",
+            "properties": {
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "messageId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.message-id type constraint. The type values refer to the AMQP type model` and the defined message-id types",
+                        "enum": [
+                          "ulong",
+                          "uuid",
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.message-id value constraint. "
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.message-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.message-id",
+                    "altnames": {
+                      "json": "message-id"
+                    }
+                  },
+                  "userId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.user-id value type",
+                        "enum": [
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.user-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.user-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.user-id",
+                    "altnames": {
+                      "json": "user-id"
+                    }
+                  },
+                  "to": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.to value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.to value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.to required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.to"
+                  },
+                  "subject": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.subject value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.subject value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.subject required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.subject"
+                  },
+                  "replyTo": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.reply-to required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.reply-to",
+                    "altnames": {
+                      "json": "reply-to"
+                    }
+                  },
+                  "correlationId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value type",
+                        "enum": [
+                          "binary",
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP correlation-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP correlation-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.correlation-id",
+                    "altnames": {
+                      "json": "correlation-id"
+                    }
+                  },
+                  "contentType": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.content-type value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.content-type value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.content-type required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.content-type",
+                    "altnames": {
+                      "json": "content-type"
+                    }
+                  },
+                  "contentEncoding": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.content-encoding value type",
+                        "enum": [
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.content-encoding value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.content-encoding required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.content-encoding",
+                    "altnames": {
+                      "json": "content-encoding"
+                    }
+                  },
+                  "absoluteExpiryTime": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.absolute-expiry-time value type",
+                        "enum": [
+                          "timestamp"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.absolute-expiry-time value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.absolute-expiry-time required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.absolute-expiry-time",
+                    "altnames": {
+                      "json": "absolute-expiry-time"
+                    }
+                  },
+                  "creationTime": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.creation-time value type",
+                        "enum": [
+                          "timestamp"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.creation-time value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.creation-time required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.creation-time",
+                    "altnames": {
+                      "json": "creation-time"
+                    }
+                  },
+                  "groupId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.group-id value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.group-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.group-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.group-id",
+                    "altnames": {
+                      "json": "group-id"
+                    }
+                  },
+                  "groupSequence": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value type",
+                        "enum": [
+                          "integer"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP group-sequence value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP group-sequence required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP group-sequence",
+                    "altnames": {
+                      "json": "group-sequence"
+                    }
+                  },
+                  "replyToGroupId": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to-group-id value type",
+                        "enum": [
+                          "string",
+                          "uritemplate"
+                        ]
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "AMQP properties.reply-to-group-id value constraint"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "AMQP properties.reply-to-group-id required"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "AMQP properties.reply-to-group-id",
+                    "altnames": {
+                      "json": "reply-to-group-id"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "description": "AMQP properties section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties"
+              },
+              "applicationProperties": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsApplicationPropertiesValue"
+                  }
+                },
+                "description": "AMQP application-properties section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties",
+                "altnames": {
+                  "json": "application-properties"
+                }
+              },
+              "messageAnnotations": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsMessageAnnotationsValue"
+                  }
+                },
+                "description": "AMQP message-annotations section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-message-annotations",
+                "altnames": {
+                  "json": "message-annotations"
+                }
+              },
+              "deliveryAnnotations": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsDeliveryAnnotationsValue"
+                  }
+                },
+                "description": "AMQP delivery-annotations section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-delivery-annotations",
+                "altnames": {
+                  "json": "delivery-annotations"
+                }
+              },
+              "header": {
+                "type": "object",
+                "properties": {
+                  "durable": {
+                    "type": "boolean",
+                    "description": "AMQP durable flag"
+                  },
+                  "priority": {
+                    "type": "integer",
+                    "description": "AMQP priority"
+                  },
+                  "ttl": {
+                    "type": "integer",
+                    "description": "AMQP time-to-live (milliseconds)"
+                  },
+                  "firstAcquirer": {
+                    "type": "boolean",
+                    "description": "AMQP first-acquirer flag",
+                    "altnames": {
+                      "json": "first-acquirer"
+                    }
+                  },
+                  "deliveryCount": {
+                    "type": "integer",
+                    "description": "AMQP delivery-count",
+                    "altnames": {
+                      "json": "delivery-count"
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "description": "AMQP header section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header"
+              },
+              "footer": {
+                "type": "map",
+                "values": {
+                  "type": {
+                    "$ref": "#/definitions/Messagegroups/MessageProtocoloptionsFooterValue"
+                  }
+                },
+                "description": "AMQP footer section https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-footer"
+              }
+            },
+            "additionalProperties": false,
+            "description": "AMQP message metadata constraints"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Messagegroup": {
+        "type": "object",
+        "properties": {
+          "messagegroupid": {
+            "type": "string",
+            "description": "ID of the messagegroup object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "envelope": {
+            "type": "string",
+            "description": "Envelope format identifier that defines the common metadata information for the message. All definitions in this group share this envelope format. Mixed-envelope-format groups are not permitted. The predefined envelope format is CloudEvents/1.0"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Protocol identifier that defines the transport message protocol. All definitions in this group share this protocol type. Mixed-protocol groups are not permitted. Predefined protocol formats are 'AMQP/1.0', 'MQTT/3.1.1', 'MQTT/5.0', 'KAFKA', 'HTTP', and 'NATS'"
+          },
+          "messages": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Messagegroups/Message"
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/schema/schemas/document-schema.struct.json
+++ b/schema/schemas/document-schema.struct.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "https://json-structure.org/meta/extended/v0/#",
+  "$id": "https://xregistry.io/xreg/xregistryspecs/schema-v1/schemas/document-schema.struct.json",
+  "$uses": [
+    "JSONStructureAlternateNames"
+  ],
+  "name": "SchemaRegistryDocument",
+  "type": "object",
+  "properties": {
+    "schemagroups": {
+      "type": "map",
+      "values": {
+        "type": {
+          "$ref": "#/definitions/Schemagroups/Schemagroup"
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Schemagroups": {
+      "SchemaVersion": {
+        "type": "object",
+        "properties": {
+          "versionid": {
+            "type": "string",
+            "description": "ID of the schema version"
+          },
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "format": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "any"
+          },
+          "schemabase64": {
+            "type": "binary"
+          },
+          "schemaurl": {
+            "type": "uri"
+          }
+        },
+        "additionalProperties": true,
+        "required": [
+          "format"
+        ]
+      },
+      "Schema": {
+        "type": "object",
+        "properties": {
+          "schemaid": {
+            "type": "string",
+            "description": "ID of the schema object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "schema": {
+            "type": "any",
+            "description": "Embedded schema document"
+          },
+          "schemabase64": {
+            "type": "binary",
+            "description": "Base64-encoded schema document"
+          },
+          "schemaurl": {
+            "type": "uri",
+            "description": "URL of the schema document"
+          },
+          "versionsurl": {
+            "type": "uri"
+          },
+          "versionscount": {
+            "type": "uint32"
+          },
+          "versions": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Schemagroups/SchemaVersion"
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Schemagroup": {
+        "type": "object",
+        "properties": {
+          "schemagroupid": {
+            "type": "string",
+            "description": "ID of the schemagroup object"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the object"
+          },
+          "epoch": {
+            "type": "integer",
+            "description": "Epoch of the object"
+          },
+          "self": {
+            "type": "uri",
+            "description": "URL of the object"
+          },
+          "xid": {
+            "type": "uri",
+            "description": "XID of the object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the object"
+          },
+          "documentation": {
+            "type": "uri",
+            "description": "Documentation URL"
+          },
+          "labels": {
+            "type": "map",
+            "values": {
+              "type": "string"
+            }
+          },
+          "createdat": {
+            "type": "datetime",
+            "description": "Creation time"
+          },
+          "modifiedat": {
+            "type": "datetime",
+            "description": "Modification time"
+          },
+          "format": {
+            "type": "string"
+          },
+          "schemas": {
+            "type": "map",
+            "values": {
+              "type": {
+                "$ref": "#/definitions/Schemagroups/Schema"
+              }
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -616,14 +616,6 @@ Schema is `JsonStructure`. When the `format` attribute is set to `JsonStructure`
 the `schema` attribute of the schema Resource is a JSON object representing a JSON
 Structure schema document [JSTRUCT-CORE].
 
-A JSON Structure schema document MUST contain the REQUIRED top-level
-`$schema` keyword defined by [JSTRUCT-CORE]. Its value MUST be an absolute URI
-corresponding to the `$id` of the JSON Structure meta-schema to which the
-document conforms. The `$schema` keyword identifies the JSON Structure version
-and meta-schema; it does not import definitions into the document. The value is
-part of the schema document and is distinct from the xRegistry `format`
-attribute.
-
 The version identifier follows the pattern `JsonStructure/{version}`, where
 `{version}` is the version of the JSON Structure Core specification that is
 used to define the schema.

--- a/schema/spec.md
+++ b/schema/spec.md
@@ -616,6 +616,14 @@ Schema is `JsonStructure`. When the `format` attribute is set to `JsonStructure`
 the `schema` attribute of the schema Resource is a JSON object representing a JSON
 Structure schema document [JSTRUCT-CORE].
 
+A JSON Structure schema document MUST contain the REQUIRED top-level
+`$schema` keyword defined by [JSTRUCT-CORE]. Its value MUST be an absolute URI
+corresponding to the `$id` of the JSON Structure meta-schema to which the
+document conforms. The `$schema` keyword identifies the JSON Structure version
+and meta-schema; it does not import definitions into the document. The value is
+part of the schema document and is distinct from the xRegistry `format`
+attribute.
+
 The version identifier follows the pattern `JsonStructure/{version}`, where
 `{version}` is the version of the JSON Structure Core specification that is
 used to define the schema.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -98,15 +98,19 @@ website:
 makeschema: loadpython
 	@echo "Rebuilding the schemas..."
 	@python tools/schema-generator.py --type json-schema --schema-id https://xregistry.io/xreg/xregistryspecs/schema-v1/schemas/document-schema.json --output schema/schemas/document-schema.json schema/model.json
+	@python tools/schema-generator.py --type json-structure --schema-id https://xregistry.io/xreg/xregistryspecs/schema-v1/schemas/document-schema.struct.json --schema-name SchemaRegistryDocument --output schema/schemas/document-schema.struct.json schema/model.json
 	@python tools/schema-generator.py --type avro-schema --output schema/schemas/document-schema.avsc schema/model.json
 	@python tools/schema-generator.py --type openapi --output schema/schemas/openapi.json schema/model.json
 	@python tools/schema-generator.py --type json-schema --schema-id https://xregistry.io/xreg/xregistryspecs/message-v1/schemas/document-schema.json --output message/schemas/document-schema.json message/model.json
+	@python tools/schema-generator.py --type json-structure --schema-id https://xregistry.io/xreg/xregistryspecs/message-v1/schemas/document-schema.struct.json --schema-name MessageRegistryDocument --output message/schemas/document-schema.struct.json message/model.json
 	@python tools/schema-generator.py --type avro-schema --output message/schemas/document-schema.avsc message/model.json
 	@python tools/schema-generator.py --type openapi --output message/schemas/openapi.json message/model.json
 	@python tools/schema-generator.py --type json-schema --schema-id https://xregistry.io/xreg/xregistryspecs/endpoint-v1/schemas/document-schema.json --output endpoint/schemas/document-schema.json endpoint/model.json
+	@python tools/schema-generator.py --type json-structure --schema-id https://xregistry.io/xreg/xregistryspecs/endpoint-v1/schemas/document-schema.struct.json --schema-name EndpointRegistryDocument --output endpoint/schemas/document-schema.struct.json endpoint/model.json
 	@python tools/schema-generator.py --type avro-schema --output endpoint/schemas/document-schema.avsc endpoint/model.json
 	@python tools/schema-generator.py --type openapi --output endpoint/schemas/openapi.json endpoint/model.json
 	@python tools/schema-generator.py --type json-schema --schema-id https://xregistry.io/xreg/xregistryspecs/cloudevents-v1/schemas/document-schema.json --output cloudevents/schemas/document-schema.json endpoint/model.json message/model.json schema/model.json
+	@python tools/schema-generator.py --type json-structure --schema-id https://xregistry.io/xreg/xregistryspecs/cloudevents-v1/schemas/document-schema.struct.json --schema-name CloudEventsRegistryDocument --output cloudevents/schemas/document-schema.struct.json endpoint/model.json message/model.json schema/model.json
 	@python tools/schema-generator.py --type avro-schema --output cloudevents/schemas/document-schema.avsc endpoint/model.json message/model.json schema/model.json
 	@python tools/schema-generator.py --type openapi --output cloudevents/schemas/openapi.json endpoint/model.json message/model.json schema/model.json
 

--- a/tools/schema-generator.py
+++ b/tools/schema-generator.py
@@ -84,6 +84,22 @@ json_type_mapping = {
     "var": {"type": "object"}
 }
 
+json_structure_type_mapping = {
+    "string": "string",
+    "uri": "uri",
+    "url": "uri",
+    "xid": "uri",
+    "datetime": "datetime",
+    "integer": "integer",
+    "uinteger": "uint32",
+    "boolean": "boolean",
+    "uritemplate": "string",
+    "binary": "binary",
+    "timestamp": "datetime",
+    "any": "any",
+    "var": "any"
+}
+
 json_common_attributes = {
     "name": {"type": "string", "description": "Name of the object"},
     "epoch": {"type": "integer", "description": "Epoch time of the object creation"},
@@ -712,6 +728,262 @@ def generate_json_schema(model_definition, for_openapi=False, schema_id='') -> d
 
 
 
+def generate_json_structure(model_definition, schema_id='', schema_name='') -> dict:
+    """Generate a native JSON Structure schema for an xRegistry document."""
+    definitions = {}
+
+    def identifier(wire_name):
+        words = [word for word in re.split(r'[^A-Za-z0-9]+', wire_name) if word]
+        logical_name = words[0] + ''.join(
+            word[:1].upper() + word[1:] for word in words[1:]
+        ) if words else "value"
+        if logical_name[0].isdigit():
+            logical_name = "value" + logical_name
+        return logical_name
+
+    def type_identifier(wire_name):
+        logical_name = identifier(wire_name)
+        return logical_name[:1].upper() + logical_name[1:]
+
+    def reference(namespace, type_name):
+        return {"type": {"$ref": f"#/definitions/{namespace}/{type_name}"}}
+
+    def add_definition(namespace, suggested_name, schema):
+        namespace_definitions = definitions.setdefault(namespace, {})
+        type_name = type_identifier(suggested_name)
+        existing = namespace_definitions.get(type_name)
+        if existing is not None and existing != schema:
+            raise ValueError(
+                f"Conflicting JSON Structure definition: {namespace}/{type_name}"
+            )
+        if existing is None:
+            namespace_definitions[type_name] = schema
+        return type_name
+
+    def apply_annotations(schema, definition):
+        if definition.get("description"):
+            schema["description"] = definition["description"]
+        if definition.get("enum") and definition.get("strict", True):
+            schema["enum"] = copy.deepcopy(definition["enum"])
+
+    def value_schema(definition, namespace, suggested_name, require_reference=False):
+        value_type = definition["type"]
+        if value_type == "object":
+            schema = object_schema(
+                definition.get("attributes", {}), namespace, suggested_name
+            )
+            apply_annotations(schema, definition)
+            if require_reference:
+                type_name = add_definition(namespace, suggested_name, schema)
+                return reference(namespace, type_name)
+            return schema
+        if value_type == "map":
+            item = definition.get("item", {"type": "any"})
+            schema = {
+                "type": "map",
+                "values": value_schema(item, namespace, suggested_name + "Value", True)
+            }
+            apply_annotations(schema, definition)
+            return schema
+        if value_type == "array":
+            item = definition.get("item", {"type": "any"})
+            schema = {
+                "type": "array",
+                "items": value_schema(item, namespace, suggested_name + "Item", True)
+            }
+            if definition.get("enum"):
+                schema["items"]["enum"] = copy.deepcopy(definition["enum"])
+            apply_annotations(schema, definition)
+            return schema
+        if value_type not in json_structure_type_mapping:
+            raise ValueError(f"Unsupported JSON Structure type: {value_type}")
+        schema = {"type": json_structure_type_mapping[value_type]}
+        apply_annotations(schema, definition)
+        return schema
+
+    def collect_attributes(attributes):
+        collected = dict(attributes)
+        for definition in attributes.values():
+            for condition in definition.get("ifvalues", {}).values():
+                for sibling_name, sibling_definition in condition.get(
+                    "siblingattributes", {}
+                ).items():
+                    collected.setdefault(sibling_name, sibling_definition)
+        return collected
+
+    def object_schema(attributes, namespace, owner_name):
+        properties = {}
+        required = []
+        used_names = {}
+        additional_properties = False
+        for wire_name, definition in collect_attributes(attributes).items():
+            if wire_name == "*":
+                additional_properties = definition["type"] == "any"
+                continue
+            logical_name = identifier(wire_name)
+            if logical_name in used_names and used_names[logical_name] != wire_name:
+                raise ValueError(
+                    f"JSON Structure name collision: '{wire_name}' and "
+                    f"'{used_names[logical_name]}' both map to '{logical_name}'"
+                )
+            used_names[logical_name] = wire_name
+            property_schema = value_schema(
+                definition, namespace, owner_name + type_identifier(logical_name)
+            )
+            if logical_name != wire_name:
+                property_schema["altnames"] = {"json": wire_name}
+            properties[logical_name] = property_schema
+            if definition.get("required") is True and "default" not in definition:
+                required.append(logical_name)
+        schema = {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": additional_properties
+        }
+        if required:
+            schema["required"] = required
+        return schema
+
+    common_attributes = {
+        "name": {"type": "string", "description": "Name of the object"},
+        "epoch": {"type": "integer", "description": "Epoch of the object"},
+        "self": {"type": "url", "description": "URL of the object"},
+        "xid": {"type": "xid", "description": "XID of the object"},
+        "description": {"type": "string", "description": "Description of the object"},
+        "documentation": {"type": "url", "description": "Documentation URL"},
+        "labels": {"type": "map", "item": {"type": "string"}},
+        "createdat": {"type": "timestamp", "description": "Creation time"},
+        "modifiedat": {"type": "timestamp", "description": "Modification time"}
+    }
+    root_properties = {}
+    group_metadata = {}
+    groups = model_definition.get("groups", {})
+
+    for group_key, group in groups.items():
+        group_plural = group.get("plural", group_key)
+        namespace = type_identifier(group_plural)
+        resource_collections = {}
+        for resource_key, unresolved_resource in group.get("resources", {}).items():
+            resource = resolve_resource(group, unresolved_resource)
+            resource_plural = resource.get("plural", resource_key)
+            resource_singular = resource["singular"]
+            resource_type_name = type_identifier(resource_singular)
+            identity_attributes = {
+                resource_singular + "id": {
+                    "type": "string",
+                    "description": f"ID of the {resource_singular} object"
+                },
+                **common_attributes
+            }
+            resource_attributes = dict(identity_attributes)
+            if resource.get("maxversions", -1) == 1:
+                resource_attributes.update(resource.get("attributes", {}))
+            resource_schema = object_schema(
+                resource_attributes, namespace, resource_type_name
+            )
+            if resource.get("hasdocument", True):
+                resource_schema["properties"].update({
+                    resource_singular: {
+                        "type": "any",
+                        "description": f"Embedded {resource_singular} document"
+                    },
+                    resource_singular + "base64": {
+                        "type": "binary",
+                        "description": f"Base64-encoded {resource_singular} document"
+                    },
+                    resource_singular + "url": {
+                        "type": "uri",
+                        "description": f"URL of the {resource_singular} document"
+                    }
+                })
+            if resource.get("maxversions", -1) != 1:
+                version_type_name = resource_type_name + "Version"
+                version_schema = object_schema(
+                    {
+                        "versionid": {
+                            "type": "string",
+                            "description": f"ID of the {resource_singular} version"
+                        },
+                        **identity_attributes,
+                        **resource.get("attributes", {})
+                    },
+                    namespace,
+                    version_type_name
+                )
+                if resource.get("hasdocument", True):
+                    version_schema["properties"].update({
+                        resource_singular: {"type": "any"},
+                        resource_singular + "base64": {"type": "binary"},
+                        resource_singular + "url": {"type": "uri"}
+                    })
+                add_definition(namespace, version_type_name, version_schema)
+                resource_schema["properties"].update({
+                    "versionsurl": {"type": "uri"},
+                    "versionscount": {"type": "uint32"},
+                    "versions": {
+                        "type": "map",
+                        "values": reference(namespace, version_type_name)
+                    }
+                })
+            add_definition(namespace, resource_type_name, resource_schema)
+            resource_collections[resource_plural] = {
+                "type": "map",
+                "values": reference(namespace, resource_type_name)
+            }
+        group_metadata[group_plural] = {
+            "group": group,
+            "namespace": namespace,
+            "resource_collections": resource_collections
+        }
+
+    for group_plural, metadata in group_metadata.items():
+        group = metadata["group"]
+        namespace = metadata["namespace"]
+        group_singular = group["singular"]
+        group_type_name = type_identifier(group_singular)
+        group_schema = object_schema(
+            {
+                group_singular + "id": {
+                    "type": "string",
+                    "description": f"ID of the {group_singular} object"
+                },
+                **common_attributes,
+                **group.get("attributes", {})
+            },
+            namespace,
+            group_type_name
+        )
+        group_schema["properties"].update(metadata["resource_collections"])
+        for resource_xid in group.get("ximportresources", []):
+            source_group_plural, source_resource_plural = resource_xid.split("/")[1:]
+            source_metadata = group_metadata[source_group_plural]
+            source_resource = resolve_resource(
+                groups[source_group_plural],
+                groups[source_group_plural]["resources"][source_resource_plural]
+            )
+            source_resource_type = type_identifier(source_resource["singular"])
+            group_schema["properties"][source_resource_plural] = {
+                "type": "map",
+                "values": reference(source_metadata["namespace"], source_resource_type)
+            }
+        add_definition(namespace, group_type_name, group_schema)
+        root_properties[group_plural] = {
+            "type": "map",
+            "values": reference(namespace, group_type_name)
+        }
+
+    return {
+        "$schema": "https://json-structure.org/meta/extended/v0/#",
+        "$id": schema_id or "https://xregistry.io/schemas/xregistry.struct.json",
+        "$uses": ["JSONStructureAlternateNames"],
+        "name": type_identifier(schema_name or "xRegistryDocument"),
+        "type": "object",
+        "properties": root_properties,
+        "additionalProperties": False,
+        "definitions": definitions
+    }
+
+
 def generate_avro_schema(model_definition) -> dict:
     """
     Generates an Avro schema based on the given model definition.
@@ -1155,9 +1427,10 @@ def resolve_imports(basedir, node):
 
 def main():
     parser = argparse.ArgumentParser(description='Generate JSON schema from model definition')
-    parser.add_argument('--type', type=str, help='type of document to generate', choices=['json-schema', 'avro-schema', 'openapi'], default='json-schema')
+    parser.add_argument('--type', type=str, help='type of document to generate', choices=['json-schema', 'json-structure', 'avro-schema', 'openapi'], default='json-schema')
     parser.add_argument('--output', type=str, help='Path for output file', default='', required=False)
     parser.add_argument('--schema-id', type=str, help='URI for the $id field in the schema', default='', required=False)
+    parser.add_argument('--schema-name', type=str, help='Root type name for JSON Structure output', default='', required=False)
     parser.add_argument('input_files', type=str, help='Path to input files', nargs='+')
 
     args = parser.parse_args()
@@ -1183,6 +1456,17 @@ def main():
                 json.dump(json_schema, of, indent=2)
         else:
             print(json.dumps(json_schema, indent=2))
+    elif (args.type == 'json-structure'):
+        json_structure = generate_json_structure(
+            model_definition,
+            schema_id=args.schema_id,
+            schema_name=args.schema_name
+        )
+        if args.output:
+            with open(args.output, 'w', encoding='utf-8') as of:
+                json.dump(json_structure, of, indent=2)
+        else:
+            print(json.dumps(json_structure, indent=2))
     elif (args.type == 'avro-schema'):
         avro_schema = generate_avro_schema(model_definition)
         if args.output:

--- a/tools/test_schema_generator.py
+++ b/tools/test_schema_generator.py
@@ -3,6 +3,7 @@ Tests for schema-generator.py to validate JSON Schema and Avro output conformanc
 """
 import json
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -55,6 +56,86 @@ class TestSchemaGenerator:
 
             with open(tmp_path, 'r') as f:
                 return json.load(f)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def assert_json_structure(self, schema_data: dict):
+        """Validate the structural invariants of generated JSON Structure."""
+        assert schema_data['$schema'] == 'https://json-structure.org/meta/extended/v0/#'
+        assert schema_data['$uses'] == ['JSONStructureAlternateNames']
+        assert schema_data['type'] == 'object'
+        assert schema_data['additionalProperties'] is False
+
+        identifier_pattern = re.compile(r'^[A-Za-z][A-Za-z0-9]*$')
+
+        def resolve_reference(reference):
+            assert reference.startswith('#/definitions/')
+            target = schema_data
+            for segment in reference[2:].split('/'):
+                target = target[segment]
+            return target
+
+        def visit(node):
+            if isinstance(node, dict):
+                if '$ref' in node:
+                    resolve_reference(node['$ref'])
+                for collection_name in ('properties', 'definitions'):
+                    for name in node.get(collection_name, {}):
+                        assert identifier_pattern.fullmatch(name), name
+                for value in node.values():
+                    visit(value)
+            elif isinstance(node, list):
+                for value in node:
+                    visit(value)
+
+        visit(schema_data)
+
+    def test_schema_model_json_structure(self, schema_model, tools_dir):
+        """Test native JSON Structure shape for a registry model."""
+        schema_data = self.generate_schema(schema_model, 'json-structure', tools_dir)
+
+        self.assert_json_structure(schema_data)
+        assert schema_data['properties']['schemagroups']['type'] == 'map'
+        schema_version = schema_data['definitions']['Schemagroups']['SchemaVersion']
+        assert schema_version['properties']['format']['type'] == 'string'
+
+    def test_cloudevents_multi_model_json_structure(
+        self, endpoint_model, message_model, schema_model, tools_dir
+    ):
+        """Test namespaced JSON Structure composition for all extension models."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            result = subprocess.run(
+                [
+                    'python', 'schema-generator.py', '--type', 'json-structure',
+                    str(endpoint_model), str(message_model), str(schema_model),
+                    '--output', tmp_path
+                ],
+                cwd=str(tools_dir),
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            assert result.returncode == 0, result.stderr
+            with open(tmp_path, 'r', encoding='utf-8') as schema_file:
+                schema_data = json.load(schema_file)
+            self.assert_json_structure(schema_data)
+            assert set(schema_data['properties']) == {
+                'endpoints', 'messagegroups', 'schemagroups'
+            }
+            assert set(schema_data['definitions']) == {
+                'Endpoints', 'Messagegroups', 'Schemagroups'
+            }
+            message = schema_data['definitions']['Messagegroups']['Message']
+            protocol_properties = message['properties']['protocoloptions'][
+                'properties'
+            ]['properties']['properties']
+            assert protocol_properties['messageId']['altnames'] == {
+                'json': 'message-id'
+            }
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)


### PR DESCRIPTION
## Summary

- add native JSON Structure output to `tools/schema-generator.py`
- generate JSON Structure schemas for the Schema, Message, Endpoint, and combined CloudEvents registries
- preserve JSON wire property names through `JSONStructureAlternateNames`
- add deterministic generation commands and structural regression tests

## Generated artifacts

- `schema/schemas/document-schema.struct.json`
- `message/schemas/document-schema.struct.json`
- `endpoint/schemas/document-schema.struct.json`
- `cloudevents/schemas/document-schema.struct.json`

## Validation

- `jstruct check --verbose` against all four generated schemas
- deterministic regeneration verified by SHA-256 comparison
- `py -3 -m pytest tools` (54 passed)
- `py -3 tools/verify.py` for `schema`, `message`, `endpoint`, and `cloudevents`

Fixes #543

DO NOT MERGE